### PR TITLE
Bug fix: Properly handling sort universe at smt level

### DIFF
--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -34,56 +34,37 @@ def blasterTacticImp : Tactic := fun stx =>
    -- Parse options in any order
    let opts := stx[1].getArgs
    let sOpts ← parseSolveOptions opts default
-   let (goal, nbQuantifiers) ← revertHypotheses (← getMainGoal)
+   let goal ← revertHypotheses (← getMainGoal)
    let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
    let ((result, optExpr), _) ←
      withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0 }) $ do
        IO.setNumHeartbeats 0
-       Translate.main (← goal.getType >>= instantiateMVars') (logUndetermined := false) |>.run env
+       Translate.main (← goal.getType) (logUndetermined := false) |>.run env
    match result with
    | .Valid => goal.admit -- TODO: replace with proof reconstruction
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression
         let newGoal ← goal.replaceTargetDefEq optExpr
-        -- reintroduce reverted quantifiers
-        let currQuantifiers ← getFirstNbQuantifiers optExpr
-        let (_, newGoal') ← newGoal.introNP (max currQuantifiers nbQuantifiers)
-        replaceMainGoal [newGoal']
+        replaceMainGoal [newGoal]
 
   where
-    getFirstNbQuantifiers (e : Expr) : MetaM Nat := do
-      forallTelescope e fun fvars _ => do
-        let mut nb := 0
-        for v in fvars do
-          if !(← isProp (← v.fvarId!.getType)) then
-            nb := nb + 1
-        return nb
 
     @[always_inline, inline]
-    instantiateMVars' (e : Expr) : TacticM Expr :=
-     if e.hasMVar then instantiateMVars e else return e
-
-    @[always_inline, inline]
-    revertHypotheses (goal : MVarId) : TacticM (MVarId × Nat) :=
+    revertHypotheses (goal : MVarId) : TacticM MVarId :=
       goal.withContext $ do
         -- Get all hypotheses from the local context
         let lctx ← getLCtx
         let mut hyps := #[]
-        let mut nbQuantifiers := 0
         for decl in lctx do
           if decl.isImplementationDetail then continue
-          let declType ← instantiateMVars' decl.type
-          if !(← isProp declType) then
-            nbQuantifiers := nbQuantifiers + 1
-          hyps := hyps.push decl.fvarId
+          if ← isProp decl.type then
+            hyps := hyps.push decl.fvarId
         -- revert hyp from context
-        let goal' ←
-          hyps.foldrM
+        hyps.foldrM
           (fun h g => do
              let (_, g) ← g.revert #[h]
              return g) goal
-        return (goal', nbQuantifiers)
 
 
 end Blaster.Tactic

--- a/Blaster/Optimize/Expr.lean
+++ b/Blaster/Optimize/Expr.lean
@@ -71,6 +71,11 @@ def fVarInExpr (v : FVarId) (e : Expr) : Bool :=
  else false
 
 
+/-- Return `true` only when the given expression is a `.sort u` such that `u ≠ .zero`. -/
+def isTypeUniverse : Expr → Bool
+| Expr.sort u => u != .zero
+| _ => false
+
 /-- If the `e` is a sequence of lambda `fun x₁ => fun x₂ => ... fun xₙ => b`,
     return `b`. Otherwise return `e`.
 -/

--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -309,13 +309,13 @@ def definePredQualifier (s : SmtSymbol) (t : SortExpr) (assertFlag : Option Bool
 
 
 /-- Perform the following actions:
-     - Declare smt universal sort `(declare-sort @@Type 0)`
-     - Declare smt predicate `(declare-fun @isType ((@@Type)) Bool)` with `true` assertion
+     - Declare smt universal sort `(declare-sort typeSym 0)`
+     - Declare smt predicate `(declare-fun decl.instName ((decl.instSort)) Bool)` with `true` assertion
     Assume `isTypeSym := @isType`
 -/
-def defineTypeSort (isTypeSym : SmtSymbol) : TranslateEnvT Unit := do
-  declareSort typeSymbol 0
-  definePredQualifier isTypeSym typeSort (some true)
+def defineTypeSort (typeSym: SmtSymbol) (decl: IndTypeDeclaration) : TranslateEnvT Unit := do
+  declareSort typeSym 0
+  definePredQualifier decl.instName decl.instSort (some true)
 
 
 /-- Perform the following actions:

--- a/Blaster/Smt/Term.lean
+++ b/Blaster/Smt/Term.lean
@@ -37,10 +37,6 @@ def emptySymbol : SmtSymbol := mkReservedSymbol "Empty"
 /-! Smt PEmpty symbol. -/
 def pemptySymbol : SmtSymbol := mkReservedSymbol "PEmpty"
 
-/-! Smt universal type symbol. -/
-def typeSymbol : SmtSymbol := mkReservedSymbol "@@Type"
-
-
 /-! ## Builtin Smt sorts. -/
 
 /-! Smt Int Sort. -/
@@ -85,14 +81,7 @@ def emptySort : SortExpr := .SymbolSort emptySymbol
 -/
 def pemptySort : SortExpr := .SymbolSort pemptySymbol
 
-/-! Smt @@Type Sort used to denote universal sort
-    NOTE: This sort is declared during translation whenever required.
-    (see function `defineTypeSort`).
--/
-def typeSort : SortExpr := .SymbolSort typeSymbol
-
 -- TODO: add other sort once supported, e.g., BitVec, Unicode (for char), Seq, etc
-
 
 /-! ## Builtin Smt symbols. -/
 

--- a/Blaster/Smt/Translate/Quantifier.lean
+++ b/Blaster/Smt/Translate/Quantifier.lean
@@ -68,7 +68,7 @@ def nameToSmtSymbol (n : Name) : SmtSymbol :=
      - return smt symbol `"@" ++ v.getUserName ++ v.name` when `unique` is set to `true`
      - return smt symbol `"@" ++ v.getUserName` otherwise.
 -/
-def sortNameToSmtSymbol (v : FVarId) (unique := true) : TranslateEnvT SmtSymbol := do
+def typeParamNameToSmtSymbol (v : FVarId) (unique := true) : TranslateEnvT SmtSymbol := do
   if unique
   then return mkNormalSymbol s!"@{← v.getUserName}{v.name}"
   else return mkNormalSymbol s!"@{← v.getUserName}"
@@ -147,34 +147,24 @@ def declareArrowTypeSort (nbArity : Nat) : TranslateEnvT SmtSymbol := do
       declareSort s nbArity
       return s
 
-/-- Define smt universal sort @@Type and its corresponding predicate qualified
-    whenever flag `typeUniverse` is not set.
-    Do nothing otherwise.
-    Assume `isTypeSym := @isType`
--/
-def declareTypeSort (isTypeSym : SmtSymbol) : TranslateEnvT Unit := do
- unless ((← get).smtEnv.options.typeUniverse) do
-  defineTypeSort isTypeSym
-  modify (fun env => { env with smtEnv.options.typeUniverse := true })
-
 /-- Update sort cache with `v`. -/
 def updateSortCache (v : FVarId) (s : SmtSymbol) : TranslateEnvT Unit := do
-  modify (fun env => { env with smtEnv.sortCache := env.smtEnv.sortCache.insert v s})
+  modify (fun env => { env with smtEnv.typeParamCache := env.smtEnv.typeParamCache.insert v s})
 
 
-/-- Return `vstrₙ` when entry `v := vstrₙ` exists in `sortCache`,
+/-- Return `vstrₙ` when entry `v := vstrₙ` exists in `typeParamCache`,
     otherwise, perform the following:
       - `vstr := "@" ++ v.getUserName ++ v.name`.
       - add `define-sort "vstr" () @@Type` to the Smt context
-      - add entry `v := vstr` to `sortCache`
+      - add entry `v := vstr` to `typeParamCache`
       - return vstr
 -/
-def defineSortAndCache (v : FVarId) : TranslateEnvT SmtSymbol := do
+def defineTypeParamAndCache (v : FVarId) (decl : IndTypeDeclaration): TranslateEnvT SmtSymbol := do
   let env ← get
-  match env.smtEnv.sortCache.get? v with
+  match env.smtEnv.typeParamCache.get? v with
   | none =>
-      let s ← sortNameToSmtSymbol v
-      defineSort s none typeSort
+      let s ← typeParamNameToSmtSymbol v
+      defineSort s none decl.instSort
       updateSortCache v s
       return s
   | some s => return s
@@ -231,7 +221,7 @@ private partial def updateTopLevelVars (step : Nat) (vars : TopLevelVars) (s : S
 
 /-- Perform the following:
       - add `v` to `quantifierFvars` cache
-      - add `v` to `topLevelVars` only when topLevel is set to `true` and `¬ isType (← inferTypeEnv (mkFVar v))`.
+      - add `v` to `topLevelVars` only when topLevel is set to `true` and `¬ isTypeUniverse (← inferTypeEnv (mkFVar v))`.
 -/
 def updateQuantifiedFVarsCache (v : FVarId) (topLevel : Bool) : TranslateEnvT Unit := do
   let s ← fvarIdToSmtSymbol v
@@ -241,7 +231,7 @@ def updateQuantifiedFVarsCache (v : FVarId) (topLevel : Bool) : TranslateEnvT Un
   modify
     (fun env =>
       let updatedVars := env.smtEnv.quantifiedFVars.insert v topLevel
-      if topLevel && !t.isType
+      if topLevel && !(isTypeUniverse t)
       then
         { env with
               smtEnv.quantifiedFVars := updatedVars,
@@ -488,7 +478,7 @@ def createPredQualifierApp (smtSym : SmtSymbol) (t : Expr) : TranslateEnvT SmtTe
          - return `{@is{instName}, st, applyInstName}`
       - Otherwise:
          - let n ← mkFreshId
-         - instName ← (Fun ++ n) (i.e., generate a unique name for function instance)
+         - let instName := Fun ++ n (i.e., generate a unique name for function instance)
          - add entry `t := {@is{instName}, st, applyInstName := some @apply{n}}` to `indTypeInstCache`
          - declare smt predicate `(declare-fun @is{instName} ((instSort)) Bool)`
          - declare apply function `(declare-fun @apply{n} (st sα₁ ... sαₙ₋₁) sαₙ)`
@@ -603,31 +593,46 @@ def generateFunInstDecl (t : Expr) (st : SortExpr) : TranslateEnvT Unit :=
   discard $ generateFunInstDeclAux t st
 
 
-/-- Given `t := Expr.sort _` perform the following actions only when
-    no entry for `t` exists in `indTypeInstCache`:
-     - When `t := Expr.sort .zero`
-        - add entry `t := {@isProp, propSort} to `indTypeInstCache`
-        - define smt sort `(define-sort Prop () Bool)`
-        - declare smt function `(declare-fun @isProp ((Prop)) Bool)` with `true` assertion
-
-     - When `isType t`
-         - add entry `t := {@isType, typeSort} to `indTypeInstCache`
-         - Define smt univseral sort @@Type when flag `typeUniverse is not set
-           (see function `declareTypeSort`)
+/-- Given `t := Expr.sort _` perform the following actions:
+     - When `t := decl ∈ IndTypeDeclaration`
+         - return `decl`
+     - Otherwise:
+         - When `t := Expr.sort .zero`
+            - let decl := {@isProp, propSort, none}
+            - add entry `t := decl to `indTypeInstCache`
+            - define smt sort `(define-sort Prop () Bool)`
+            - declare smt predicate `(declare-fun @isProp ((Prop)) Bool)` with `true` assertion
+            - return `decl`
+         - Otherwise
+            - let n ← mkFreshId
+            - let typeName := "@Type{n}"
+            - let typeSort := .SymbolSort typeName
+            - let decl := {@isType{n}, typeSort, none}
+            - add entry `t := decl to `indTypeInstCache`
+            - declare smt sort `(declare-sort typeName 0)`
+            - declare smt predicate `(declare-fun @isType{n} ((typeSort)) Bool)` with `true` assertion
+            - return `decl`
 
     An error is triggered when t is not the expected sort type.
 -/
-def generateSortInstDecl (t : Expr) : TranslateEnvT Unit := do
+def generateSortInstDecl (t : Expr) : TranslateEnvT IndTypeDeclaration := do
  let Expr.sort u := t | throwEnvError "generateSortInstDecl: sort type expected but got {reprStr t}"
- unless ((← get).smtEnv.indTypeInstCache.get? t).isSome do
-   match u with
-   | .zero =>
-        let decl ← updateIndInstCacheAux t propSymbol propSort (isReservedSymbol := true)
-        definePropSort decl.instName
-   | _ =>
-       if !t.isType then throwEnvError "generateSortInstDecl: sort type expected but got {reprStr t}"
-       let decl ← updateIndInstCacheAux t (mkReservedSymbol "Type") typeSort (isReservedSymbol := true)
-       declareTypeSort decl.instName
+  match (← get).smtEnv.indTypeInstCache.get? t with
+   | some decl => return decl
+   | none =>
+      match u with
+      | .zero =>
+          let decl ← updateIndInstCacheAux t propSymbol propSort (isReservedSymbol := true)
+          definePropSort decl.instName
+          return decl
+      | _ =>
+        let n ← mkFreshId
+        let typeName := mkReservedSymbol s!"@Type{n}"
+        let instName := mkReservedSymbol s!"Type{n}"
+        let typeSort := .SymbolSort typeName
+        let decl ← updateIndInstCacheAux t instName typeSort (isReservedSymbol := true)
+        defineTypeSort typeName decl
+        return decl
 
 /-- TODO: UPDATE SPEC -/
 def getRecRuleFor (recVal : RecursorVal) (c : Name) : TranslateEnvT RecursorRule :=
@@ -801,8 +806,8 @@ def translateInductiveType
             -- resolve type abbreviation (useful when handling instance parameters)
             -- TODO: IMP need to apply optimizer on argument to instance parameters
             let argType' ← removeTypeAbbrev decl.type
-            if argType'.isType then
-              polyParams := polyParams.push (← sortNameToSmtSymbol v false)
+            if isTypeUniverse argType' then
+              polyParams := polyParams.push (← typeParamNameToSmtSymbol v false)
             else throwEnvError "Inductive datatype with instance parameters not supported: {reprStr indVal.name}"
         return polyParams
    if params.isEmpty then return none else return (some params)
@@ -1127,26 +1132,25 @@ partial def translateTypeAux
 
    | Expr.fvar v =>
       let t ← inferTypeEnv e
-      if !t.isType then throwEnvError "translateType: sort type expected but got {reprStr t}"
-      -- Need to call defineSortAndCache to handle case when sort is defined a top level
-      -- `defineSortAndCache` is called only when flags `inTypeDefinition` and `genericParamFun`
+      if !(isTypeUniverse t) then throwEnvError "translateType: sort type expected but got {reprStr t}"
+      -- Need to call defineTypeParamAndCache to handle case when sort is defined a top level
+      -- `defineTypeParamAndCache` is called only when flags `inTypeDefinition` and `genericParamFun`
       -- are set to `false`
       -- NOTE: `inTypeDefinition` is set to `true` only when translating inductive datatype`,
       -- while `genericParamFun` is set to `true` when generating predicate qualifiers.
       if !topts.inTypeDefinition && !topts.genericParamFun then
-        generateSortInstDecl t
-        let smtSym ← defineSortAndCache v
+        let smtSym ← defineTypeParamAndCache v (← generateSortInstDecl t)
         return .SymbolSort smtSym
       else if topts.genericParamFun then
-        generateSortInstDecl t
-        return typeSort
+        let decl ← generateSortInstDecl t
+        return decl.instSort
       else -- case when inTypeDefinition is set to true
         -- check if sort has been defined at top level (see note in `translateArrowType`)
-        match (← get).smtEnv.sortCache.get? v with
+        match (← get).smtEnv.typeParamCache.get? v with
         | some s => -- case when sort defined at top level
            return .SymbolSort s
         | _ => -- case when sort is a param of an inductive data type.
-          return .SymbolSort (← sortNameToSmtSymbol v false)
+          return .SymbolSort (← typeParamNameToSmtSymbol v false)
 
    | Expr.forallE .. =>
        let st ← translateArrowType t topts
@@ -1159,8 +1163,8 @@ partial def translateTypeAux
        return st
 
    | Expr.sort .zero =>
-        generateSortInstDecl e
-        return boolSort -- prop sort represented as bool at smt level
+        let decl ← generateSortInstDecl e
+        return decl.instSort
 
    | Expr.sort .. =>
        throwEnvError "translateType: unexpected sort type {reprStr e}"
@@ -1211,7 +1215,7 @@ def initialQuantifierEnv (topLevel : Bool) : QuantifierEnv :=
 /-- Translate a quantifier `(n : t)` by performing the following actions:
      - Add `n` to the quantified fvars cache.
      - When isType t, e.g., (α : Type or α : Sort u)
-       - Call `defineSortAndCache n` to declare an Smt sort and return quantified array `qts` unchanged
+       - Call `defineTypeParamAndCache n` to declare an Smt sort and return quantified array `qts` unchanged
      - When ¬ isType t:
         - translate n to an Smt symbol `s`
         - translate t to a Smt type `st`
@@ -1233,9 +1237,8 @@ def translateQuantifier
  -- update quantified fvars cache
  updateQuantifiedFVarsCache v (← get).topLevel
  -- define sort if t is a sort type
- if t.isType then
-   generateSortInstDecl t
-   discard $ defineSortAndCache v
+ if isTypeUniverse t then
+   discard $ defineTypeParamAndCache v (← generateSortInstDecl t)
  else
    -- No more required to resolve type at this stage.
    let smtType ← translateTypeAux termTranslator t
@@ -1310,7 +1313,7 @@ def translateFreeVar
    -- top level declaration case
    updateQuantifiedFVarsCache v true
    let t ← inferTypeEnv f
-   if t.isType then throwEnvError "translateFreeVar: sort type not expected but got {reprStr t}"
+   if isTypeUniverse t then throwEnvError "translateFreeVar: sort type not expected but got {reprStr t}"
    let t' ← removeTypeAbbrev t
    let smtType ← translateTypeAux termTranslator t'
    let smtSym ← fvarIdToSmtSymbol v

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -28,4 +28,5 @@ import Tests.FixedIssues.Issue27
 import Tests.FixedIssues.Issue28
 import Tests.FixedIssues.Issue29
 import Tests.FixedIssues.Issue30
+import Tests.FixedIssues.Issue31
 

--- a/Tests/FixedIssues/Issue25.lean
+++ b/Tests/FixedIssues/Issue25.lean
@@ -5,20 +5,23 @@ open Lean Meta
 namespace Tests.Issue25
 
 -- Issue: translateType: unexpected sort type Lean.Expr.sort (Lean.Level.param `u_1)
--- Diagnosis : We need to normalize `sort (.params ..)` and `sort (.mvar ..)` to  `sort (.succ level.zero)`
---             during optimization phase.
+-- Diagnosis : We need to normalize `sort (.mvar m)` to `sort l`
+--             during optimization phase. It is expected that `m` must be assigned to `l`
+--             in the Lean4 environment. Otherwise we error.
+--             We also need to generate a distinct type universe at the smt level for each
+--             unique `·sort ..` expression.
 
 axiom hash : α → String
-axiom hash_collision_prop1 : ∀ (s1 s2 : α), hash s1 = hash s2 → s1 = s2
-axiom hash_collision_prop2 : ∀ (s1 s2 : α), s1 = s2 → hash s1 = hash s2
-axiom hash_size : ∀ (s : α), (hash s).length = 256
+axiom hash_collision_prop1 : ∀ (α : Type) (s1 s2 : α), hash s1 = hash s2 → s1 = s2
+axiom hash_collision_prop2 : ∀ (α : Type) (s1 s2 : α), s1 = s2 → hash s1 = hash s2
+axiom hash_size : ∀ (α : Type) (s : α), (hash s).length = 256
 
 -- check if we have a counterexample of length 256
 #blaster (gen-cex: 0) (solve-result: 1) [∀ (α : Type) (s : α), (hash s).length < 256]
 
 -- validate axiom
 #blaster (only-optimize: 1) [∀ (α : Type) (s : α), (hash s).length = 256]
--- Need to handle instantiation of polymorphic function
+-- Need to handle instantiation of polymorphic function as we need to instantiate the axioms
 -- #blaster [∀ (s : String), (hash s).length = 256]
 
 -- check if we are not wrongly applying axiom on another function

--- a/Tests/FixedIssues/Issue27.lean
+++ b/Tests/FixedIssues/Issue27.lean
@@ -6,6 +6,8 @@ namespace Tests.Issue27
 
 -- Issue:  (kernel) application type mismatch ...
 -- Diagnosis: Before calling blaster we also need to revert quantifiers so as to properly normalize their types.
+--            Note that is is now no more necessary as we are implicitly instantiating any
+--            universe level meta variables.
 
 set_option warn.sorry false
 -- NOTE: remove induction when supporting implicit induction

--- a/Tests/FixedIssues/Issue31.lean
+++ b/Tests/FixedIssues/Issue31.lean
@@ -1,0 +1,74 @@
+import Lean
+import Blaster
+
+open Lean Meta
+namespace Tests.Issue31
+
+-- Issue: Unexpected Valid
+-- Diagnosis: We need to create a unique type universe at the SMT level for each sort.
+
+set_option warn.sorry false
+-- Valid expected
+theorem sort_unification_thm1 :
+  (∀ (β : Type) (x : β) (f : β → Nat), f x > 10) →
+  (∀ (α : Type) (x : α) (f : α → Nat), f x > 10) := by
+  intro h1 α x f
+  apply h1 α x f
+
+#blaster [sort_unification_thm1]
+
+-- Counterexample expected as β has Type u while α has Type 1
+theorem sort_unification_thm2 :
+  (∀ (x : β) (f : β → Nat), f x > 10) →
+  (∀ (α : Type) (x : α) (f : α → Nat), f x > 10) := by sorry
+   -- intro h1 α x f
+   -- apply h1 α x f can't apply h1
+
+#blaster (gen-cex: 0) (solve-result: 1) [sort_unification_thm2]
+
+-- Valid expected
+theorem sort_unification_thm3 :
+  (∀ (β : Type u) (x : β) (f : β → Nat), f x > 10) →
+  (∀ (α : Type u) (x : α) (f : α → Nat), f x > 10) := by
+   intro h1 α x f
+   apply h1 α x f
+
+#blaster [sort_unification_thm3]
+
+-- Counterexample expected as β has Type u + 1 while α has Type v + 1
+theorem sort_unification_thm4 :
+  (∀ (β : Type u) (x : β) (f : β → Nat), f x > 10) →
+  (∀ (α : Type v) (x : α) (f : α → Nat), f x > 10) := by sorry
+   -- intro h1 α x f
+   -- apply h1 α x f can't apply h1
+
+#blaster (gen-cex: 0) (solve-result: 1) [sort_unification_thm4]
+
+-- Valid expected
+theorem sort_unification_thm5 :
+  (∀ (β : Type u) (x : β) (f : β → Nat), f x > 10) →
+  (∀ (α : Type u) (x : α) (f : α → Nat), f x > 10) := by
+   intro h1 α x f
+   apply h1 α x f
+
+#blaster [sort_unification_thm5]
+
+-- Valid expected
+theorem sort_unification_thm6 :
+  (∀ (α : Type u) (β : Type v) (x : α) (f : α → β) (g : β → Nat), g (f x) > 10) →
+  (∀ (A : Type u) (B : Type v) (x : A) (m : A → B) (n : B → Nat), n (m x) > 10) := by
+  intro h1 α β x f g
+  apply h1 α β x f g
+
+#blaster [sort_unification_thm6]
+
+-- Counterexample expected as β has Type v + 1 while B has Type v + 2
+theorem sort_unification_thm7 :
+  (∀ (α : Type u) (β : Type v) (x : α) (f : α → β) (g : β → Nat), g (f x) > 10) →
+  (∀ (A : Type u) (B : Type (v + 1)) (x : A) (m : A → B) (n : B → Nat), n (m x) > 10) := by sorry
+  -- intro h1 α β x f g
+  -- apply h1 α β x f g -- can't apply h1
+
+#blaster (gen-cex: 0) (solve-result: 1) [sort_unification_thm7]
+
+end Tests.Issue31

--- a/Tests/Smt/SmtPredQualifier.lean
+++ b/Tests/Smt/SmtPredQualifier.lean
@@ -101,11 +101,14 @@ instance [BEq a] [BEq b] : BEq (Either a b) where
       | Either.Right b1, Either.Right b2 => b1 == b2
       | _, _ => false
 
-#blaster
-  [ (∀ (α : Type) (a b : α), [BEq α] → a == b → a = b) →
-      (∀ (α : Type) (β : Type) (x y : Either α β), [BEq α] → [BEq β] → x == y → x = y)
-  ]
 
+theorem Either.eq_of_beq (h : ∀ (α : Type) (a b : α), [BEq α] → a == b → a = b) :
+        (∀ (α : Type) (β : Type) (x y : Either α β), [BEq α] → [BEq β] → x == y → x = y) := by
+        intro α β x y h2 h3
+        simp [BEq.beq]
+        split <;> simp <;> apply h
+
+#blaster [Either.eq_of_beq]
 
 /-! # Test cases to ensure that counterexample are properly detected -/
 


### PR DESCRIPTION
# Bug fixing Smt translation of sort universe

## Description

This PR addresses issue #43 and perform the following modifications:
- Optimization:
  - [x] We now explicitly normalize meta variables via `normMVar`. This function expects that each `mvar` must be assigned in the Lean4 environment when `optimizeExpr` is invoked. Otherwise an error is triggered
  - [x] `normFVar` has been simplified to directly optimize any assigned value (if any). Indeed, any `mvar` in the assigned value will now be handled by `normMVar`.
  - [x]  `normLevel` has been updated to only normalize any universe level meta variable present in a given Level. 
- Smt Translation 
  - [x] A type universe instance is generated at the smt level for each unique sort instance considered as a type universe. Hence,
    - Flag `typeUniverse` has been removed from the Translation environment
    - `sortCache` has been renamed to `typeParamCache` to avoid any confusion
    - Map `indTypeInstCache` is used to cache type universe instances that have already been defined at the smt level instance.
    - `defineTypeSort` is now generic
    - Term `typeSymbol` and `typeSort` have been removed
    - `sortNamtToSmtSymbol` has been renamed to `typeParamNameToSmtSymbol` to avoid any confusion
    - `declareTypeSort` has been removed
    - `definedSortAndCache` has been renamed to `defineTypeParamAndCache` to avoid any confusion and now also accepts an `IndTypeDeclaration` instance as argument.
    - `generateSortInstDecl` has been updated to declare a unique type universe instance at the smt level for each unique sort instance considered as type universe.
- Blaster tactic
  - [x] Quantifiers are no more reverted before translate.main is invoked (we are only reverting hypotheses). Indeed, we are now explicitly handling `mvar` instantiation at the preprocessing phase.

- Test suite:
  - [x] `Issue31.lean` has been added to show that we are not wrongly unifying sorts with different universes at the smt level.
  - [x] `Issue25.lean` has been updated to avoid wrong sort unification
  - [x] Diagnosis in `Issue27.lean` has been updated to reflect current implementation

Closes #32 
## Checklist
- [x] All theorems valid for each formalization in CI
- [x] All the specified lean file are properly considered when compiling and verifying the formalization
- [x] Self review of the code has been done.
- [x] Reviewer has been requested.
- [ ] Reviewer has performed the following tasks
     - [ ] Ensure that all the test cases are still valid
     - [ ] Ensure that each specified lean file is properly considered in the tool chain.