### PR TITLE
Killing external running Smt process when blaster command/tactic has changed in editor

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -62,7 +62,7 @@ jobs:
           path: ./Blaster/build.log
 
       - name: Execute and Validate Tests
-        run: ./scripts/check_lean_project_compilation.sh Tests
+        run: LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests
 
       - name: Upload Tests log
         if: failure()

--- a/Blaster/Smt/Translate.lean
+++ b/Blaster/Smt/Translate.lean
@@ -88,17 +88,6 @@ def Translate.main (e : Expr) (logUndetermined := true) : TranslateEnvT (Result 
          addAxioms (mkForall (← Term.mkFreshBinderName) BinderInfo.default a e) tl
 
 def command (sOpts: BlasterOptions) (stx : Syntax) : TermElabM Unit := do
-  -- NOTE: We need to set maxRecDepth to 0 as the term elaborator function is triggering
-  -- "maximum recursion depth has been reached".
-  -- This only happens when the #solve command is invoked on some complex term.
-  -- NOTE: maxHeartbeats is set to 0 to avoid all Lean4 codebase functions that depends on whnf
-  -- to trigger the maxHeartbeats reached error. Indeed, Lean4 badly handles the number of heat beats.
-  -- Heart beats are only incremented but never decremented. It should be decremented when
-  -- memory allocation is freed.
-  -- The direct use of whnf will soon be removed at the preprocessing phase.
-  -- However, since we rely on functions like isProp, inferType and withLocalDecl, setting maxHearbeats
-  -- to zero will still be required. Unless, we have a new implementation for these functions.
-  withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0, maxRecDepth := 0 }) $ do
    withRef stx do
      instantiateMVars (← withSynthesize (postpone := .partial) <| elabTerm stx none) >>= fun e => do
        let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}

--- a/Blaster/StateMachine/BMC.lean
+++ b/Blaster/StateMachine/BMC.lean
@@ -99,10 +99,9 @@ partial def bmcStrategy (smInst : Expr) : TranslateEnvT Unit := do
 syntax (name := bmc) "#bmc" (solveOption)* solveTerm : command
 
 def bmcCommand (sOpts: BlasterOptions) (stx : Syntax) : TermElabM Unit :=
-  withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0 }) $ do
-    elabTermAndSynthesize stx none >>= fun e => do
-      let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
-      discard $ bmcStrategy e|>.run env
+   elabTermAndSynthesize stx none >>= fun e => do
+     let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
+     discard $ bmcStrategy e|>.run env
 
 @[command_elab bmc]
 def bmcImp : CommandElab := commandInvoker bmcCommand

--- a/Blaster/StateMachine/KInduction.lean
+++ b/Blaster/StateMachine/KInduction.lean
@@ -156,10 +156,9 @@ partial def kIndStrategy (smInst : Expr) : TranslateEnvT Unit := do
 syntax (name := kind) "#kind" (solveOption)* solveTerm : command
 
 def kIndCommand (sOpts: BlasterOptions) (stx : Syntax) : TermElabM Unit :=
- withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0 }) $ do
-   elabTermAndSynthesize stx none >>= fun e => do
-     let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
-     discard $ kIndStrategy e|>.run env
+  elabTermAndSynthesize stx none >>= fun e => do
+    let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
+    discard $ kIndStrategy e|>.run env
 
 @[command_elab kind]
 def kIndImp : CommandElab := commandInvoker kIndCommand

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check_blaster: clean_blaster
 
 .PHONY: build_tests
 build_tests:
-	lake test
+	LEAN_NUM_THREADS=5 lake test
 
 .PHONY: clean_tests
 clean_tests:
@@ -33,7 +33,7 @@ clean_tests:
 
 .PHONY: check_tests
 check_tests: clean_tests
-	./scripts/check_lean_project_compilation.sh Tests
+	LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests
 
 # Aggregate commands
 # To maintain when you add new components

--- a/Tests/FixedIssues/Issue17.lean
+++ b/Tests/FixedIssues/Issue17.lean
@@ -31,7 +31,10 @@ def sizeOfNatGroup (x : NatGroup) : Nat :=
 
 #blaster [∃ (x : NatGroup), sizeOfNatGroup x > 200]
 
--- remove solver options when supporting proof by induction
+#blaster [∃ (x : NatGroup), sizeOfNatGroup x < 20]
+
+-- Expecting a counterexample
+-- Remove solver options when supporting proof by induction
 #blaster (timeout: 2) (solve-result: 2) [∃ (x : NatGroup), sizeOfNatGroup x < 10]
 
 

--- a/Tests/Smt/SmtNat/SmtNatMod.lean
+++ b/Tests/Smt/SmtNat/SmtNatMod.lean
@@ -38,7 +38,7 @@ namespace Test.SmtNatMod
 
 #blaster [∀ (x y : Nat), (x * y) % x = 0]
 
-#blaster [∀ (x y z : Nat), (z * x) % (z * y) = z * (x % y)]
+#blaster (random-seed: 3) [∀ (x y z : Nat), (z * x) % (z * y) = z * (x % y)]
 
 
 /-! # Test cases to ensure that counterexample are properly detected -/


### PR DESCRIPTION
# Killing external running Smt process when blaster command/tactic has changed in editor

## Description
This PR covers issue #31 and performs the following modifications:
- [x] Update `commandInvoker` to register the cancel token with the language server
- [x] Setting `maxHeartBeats and `maxRecDepth` to zero in `commandInvoker` to factorize code
- [x] Add function `checkCancelTk?` to check if cancel token has been set by language server
- [x] Update functions `getOutputModel`, `getSatResult` and `evalTerm` to kill external process when cancel token has been set.
- [x] Explicitly setting `timeout` option in SMT query as opposed to using the `-T` z3 command line option. Indeed, the latter case performs timeout on the entire z3 process instead of  applying timeout on each `checkSat` call.
- [x] Limiting the number of threads when executing the tests


 ## Closing tickets
Closes #31

## Checklist
- [x] All theorems valid for each formalization in CI
- [x] All the specified lean file are properly considered when compiling and verifying the formalization
- [x] Self review of the code has been done.
- [x] Reviewer has been requested.
- [ ] Reviewer has performed the following tasks
     - [ ] Ensure that all the test cases are still valid
     - [ ] Ensure that each specified lean file is properly considered in the tool chain.