### PR TITLE
Bug fixing predicate qualifier translation for single recursive datatype

### DIFF
--- a/Blaster/Smt/Translate/Quantifier.lean
+++ b/Blaster/Smt/Translate/Quantifier.lean
@@ -896,8 +896,8 @@ where
        for d in decls do generatePredicates d.1 l d.2 args (mutualRec := true)
      else
        -- define predicate qualifier for single inductive datatype
-       let decl ← generateIndInstDecl t args none typeTranslator (declarePredicate := false)
-       generatePredicates indName l decl args
+       let decl ← generateIndInstDecl t args none typeTranslator (declarePredicate := indVal.isRec)
+       generatePredicates indName l decl args (mutualRec := indVal.isRec)
 
   generatePredicates
     (indName : Name) (us : List Level) (decl : IndTypeDeclaration)
@@ -937,7 +937,10 @@ where
 
   getPredicateQualifierName (t : Expr) (currDecl : IndTypeDeclaration) : TranslateEnvT SmtSymbol := do
     match (← getPredicateDeclaration t) with
-    | some decl => return decl.instName
+    | some decl =>
+        if currDecl.instName == decl.instName
+        then return appendSymbol decl.instName "LRec"
+        else return decl.instName
     | none =>
         if t.isForall then -- function ctor parameter
           withInstantiatedImplicitArgs t fun t' => do

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -29,3 +29,5 @@ import Tests.FixedIssues.Issue28
 import Tests.FixedIssues.Issue29
 import Tests.FixedIssues.Issue30
 
+import Tests.FixedIssues.Issue32
+

--- a/Tests/FixedIssues/Issue32.lean
+++ b/Tests/FixedIssues/Issue32.lean
@@ -1,0 +1,23 @@
+import Lean
+import Blaster
+
+namespace Tests.Issue32
+
+-- Issue: Unexpected smt error: (.. unknown constant @isTests.Issue32.Term._uniq.2392 ((@Tests.Issue30.Term (@List @@Type))) ")
+-- Diagnosis : Predicate qualifier for single recursive datatype must still use limited call so as to properly
+--             declare the recursive qualifier function.
+
+abbrev IdentName := String
+
+inductive Term (α : Type u) where
+ | Ident (s : IdentName)
+ | Seq (x : List α)
+ | App (nm : IdentName) (args : List (Term α))
+ | Annotated (t : Term α) (annot : List (String))
+
+#blaster [ (∀ (β : Type) (x : Term (List β)) (f : Term (List β) → Nat), f x > 10) →
+           (∀ (α : Type) (x y : Term (List α)) (f : Term (List α) → Nat), f x + f y > 20)
+         ]
+
+
+end Tests.Issue32


### PR DESCRIPTION
# Bug fixing predicate qualifier generation for single recursive datatype

## Description

This PR covers issue #56  and performs the following modifications:

- Smt Translation:
  - [x] Adjust predicate qualifier generation to still consider limited call for single recursive datatype
- Test suite:
  - [x] Add Issue32.lean to ensure that the reported bug is no more triggered

## Closing tickets
Closes #56

## Checklist
- [x] All theorems valid for each formalization in CI
- [x] All the specified lean file are properly considered when compiling and verifying the formalization
- [x] Self review of the code has been done.
- [x] Reviewer has been requested.
- [x] Reviewer has performed the following tasks
     - [x] Ensure that all the test cases are still valid
     - [x] Ensure that each specified lean file is properly considered in the tool chain.