### PR TITLE
Converting True/False Smt predicate assertion into definition

### DIFF
--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -289,28 +289,24 @@ def fvarIdToSmtTerm (v : FVarId) : TranslateEnvT SmtTerm :=
   return smtSimpleVarId (← fvarIdToSmtSymbol v)
 
 /-- Given `s` and smt symbol `t` and smt sort and optional `assertFlag` boolean value, perform the following:
-     - declare smt predicate `(declare-fun s ((t)) Bool)`
      - When `assertFlag = some b`:
-        - assert smt formula `(assert (forall ((@x t)) (= b (s @x))))`
+        - define smt predicate `(define-fun s ((@x t)) Bool b)`
+     - Otherwise:
+        - declare smt predicate `(declare-fun s ((t)) Bool)`
    Assume that `s` is defined as `@is{xxx}`
 -/
 def definePredQualifier (s : SmtSymbol) (t : SortExpr) (assertFlag : Option Bool) : TranslateEnvT Unit := do
- declareFun s #[t] boolSort
  match assertFlag with
  | some b =>
-   let xsym := mkReservedSymbol "@x"
-   let xId := smtSimpleVarId xsym
-   let boolSmt := if b then trueSmt else falseSmt
-   let appSmt := mkSimpleSmtAppN s #[xId]
-   let forallBody := eqSmt boolSmt appSmt
-   let patterns := some #[mkPattern #[appSmt]]
-   assertTerm (mkForallTerm none #[(xsym, t)] forallBody patterns)
- | none => return ()
+      let xsym := mkReservedSymbol "@x"
+      let boolSmt := if b then trueSmt else falseSmt
+      defineFun s #[(xsym, t)] boolSort boolSmt
+ | none => declareFun s #[t] boolSort
 
 
 /-- Perform the following actions:
      - Declare smt universal sort `(declare-sort @@Type 0)`
-     - Declare smt predicate `(declare-fun @isType ((@@Type)) Bool)` with `true` assertion
+     - Define smt predicate `(define-fun @isType ((@x @@Type)) Bool true)`
     Assume `isTypeSym := @isType`
 -/
 def defineTypeSort (isTypeSym : SmtSymbol) : TranslateEnvT Unit := do
@@ -320,7 +316,7 @@ def defineTypeSort (isTypeSym : SmtSymbol) : TranslateEnvT Unit := do
 
 /-- Perform the following actions:
      - Declare Empty sort in Smt Lib
-     - Declare smt predicate `(declare-fun @isEmpty ((Empty)) Bool)` with `false` assertion
+     - Define smt predicate `(define-fun @isEmpty ((@x Empty)) Bool false)`
     Assume `isEmptySym := @isEmpty`
 -/
 def defineEmptySort (isEmptySym : SmtSymbol) : TranslateEnvT Unit := do
@@ -329,7 +325,7 @@ def defineEmptySort (isEmptySym : SmtSymbol) : TranslateEnvT Unit := do
 
 /-- Perform the following actions:
      - Declare PEmpty sort in Smt Lib
-     - Declare smt predicate `(declare-fun @isPEmpty ((PEmpty)) Bool)` with `false` assertion
+     - Define smt predicate `(define-fun @isPEmpty ((@x PEmpty)) Bool false)`
     Assume `isPEmptySym := @isPEmpty`
 -/
 def definePEmptySort (isPEmptySym : SmtSymbol) : TranslateEnvT Unit := do
@@ -339,7 +335,7 @@ def definePEmptySort (isPEmptySym : SmtSymbol) : TranslateEnvT Unit := do
 
 /-- Perform the following actions:
      - Define Prop sort in Smt Lib, which is an alias to Bool Smt Sort
-     - Declare smt predicate `(declare-fun @isProp ((Prop)) Bool)` with `true` assertion
+     - Define smt predicate `(define-fun @isProp ((@x Prop)) Bool true)`
     Assume `isPropSym := @isProp`
 -/
 def definePropSort (isPropSym : SmtSymbol) : TranslateEnvT Unit := do

--- a/Blaster/Smt/Translate/Application.lean
+++ b/Blaster/Smt/Translate/Application.lean
@@ -1084,7 +1084,8 @@ def translateLambda
 
  where
    retrieveLocalFVars (b : Expr) : TranslateEnvT (Array Expr) := do
-     let fvars ← getFVarsInExpr b
+     -- Need to ensure that fvars are unique
+     let (fvars, _) ← updateGenericArgs b #[] Std.HashSet.emptyWithCapacity
      let mut lvars := #[]
      for h : i in [:fvars.size] do
        let p := fvars[i]

--- a/Tests/FixedIssues/Issue24.lean
+++ b/Tests/FixedIssues/Issue24.lean
@@ -10,8 +10,7 @@ namespace Tests.Issue24
 
 
 axiom hash : String → String
-axiom hash_collision_prop1 : ∀ (s1 s2 : String), hash s1 = hash s2 → s1 = s2
-axiom hash_collision_prop2 : ∀ (s1 s2 : String), s1 = s2 → hash s1 = hash s2
+axiom hash_collision_prop : ∀ (s1 s2 : String), hash s1 = hash s2 → s1 = s2
 axiom hash_size : ∀ (s : String), (hash s).length = 256
 
 -- check if we have a counterexample of length 256

--- a/Tests/FixedIssues/Issue25.lean
+++ b/Tests/FixedIssues/Issue25.lean
@@ -9,8 +9,7 @@ namespace Tests.Issue25
 --             during optimization phase.
 
 axiom hash : α → String
-axiom hash_collision_prop1 : ∀ (s1 s2 : α), hash s1 = hash s2 → s1 = s2
-axiom hash_collision_prop2 : ∀ (s1 s2 : α), s1 = s2 → hash s1 = hash s2
+axiom hash_collision_prop : ∀ (s1 s2 : α), hash s1 = hash s2 → s1 = s2
 axiom hash_size : ∀ (s : α), (hash s).length = 256
 
 -- check if we have a counterexample of length 256

--- a/Tests/FixedIssues/Issue26.lean
+++ b/Tests/FixedIssues/Issue26.lean
@@ -41,7 +41,7 @@ theorem validProof {α : Type}[BEq α](v : α)(p : Path)(ls : List α)
 theorem getElem?_zipWith {f : α → β → γ} {i : Nat} :
     (List.zipWith f as bs)[i]? = match as[i]?, bs[i]? with
       | some a, some b => some (f a b) | _, _ => none := by
-  induction as generalizing bs i <;> blaster
+  induction as generalizing bs i <;> blaster (random-seed: 2)
 
 -- remove solver option once induction proof is supported
 #blaster (timeout: 5) (solve-result: 2) [getElem?_zipWith]


### PR DESCRIPTION
Converting True/False Smt predicate assertion into definition

## Description

This PR addresses  the following:
- [x] Each always true/false predicate qualifier are now represented as defined function to facilitate proof convergence. E.g.,

The following Smt predicate declaration for `Int` 
```
(declare-fun @isInt ((Int)) Bool)
(assert (forall ((x Int)) (= true (@isInt x)))
```
is now represented as 
```
(define-fun @isInt ((x Int)) Bool true)
```
- [x] Ensure that generated parameters for global lambdas (i.e., lambda encapsulating closures) are unique.
- [x] Discard meta data when resolving type abbreviation during translation

## Checklist
- [x] All theorems valid for each formalization in CI
- [x] All the specified lean file are properly considered when compiling and verifying the formalization
- [x] Self review of the code has been done.
- [x] Reviewer has been requested.
- [ ] Reviewer has performed the following tasks
     - [ ] Ensure that all the test cases are still valid
     - [ ] Ensure that each specified lean file is properly considered in the tool chain.