### PR TITLE
Accept CRLF in SMT check-sat output

### DIFF
--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -7,6 +7,11 @@ open Lean Meta Blaster.Optimize Blaster.Options
 
 namespace Blaster.Smt
 
+/-- Normalize solver output line endings: strip any `\r` so that downstream
+    code only sees Unix-style `\n` terminators, regardless of platform. -/
+private def normalizeLine (s : String) : String :=
+  s.replace "\r" ""
+
 /-- Minimal version of z3 we support -/
 private def minZ3Version : String := "4.15.2"
 
@@ -142,26 +147,29 @@ def checkCancelTk? : TranslateEnvT Unit := do
       throwInterruptException
 
 /-- Retrieve model output from `h` when a counterexample is generated.
-    NOTE: A model output starts with "(" and ends with ")\n"
+    NOTE: A model output starts with "(" and ends with ")\n".
+    Line endings are normalized to handle both Unix (LF) and Windows (CRLF).
 -/
 partial def getOutputModel (h : IO.FS.Handle) (proof := false) : TranslateEnvT String := do
   let rec loop (acc : String) : TranslateEnvT String := do
     checkCancelTk?
-    let line ← h.getLine
-    if ((line == ")\n" || line == ")\r\n") && !proof) || ((line == "\n" || line == "\r\n") && proof) then
+    let line := normalizeLine (← h.getLine)
+    if (line == ")\n" && !proof) || (line == "\n" && proof) then
       return acc
     else loop (acc ++ line)
   loop ""
 
 /-- Retrieve proof output for an `unsat` result.
     NOTE: A proof output starts with "(proof" and ends with ")\n\n".
+    Line endings are normalized to handle both Unix (LF) and Windows (CRLF).
 -/
 def getOutputProof := λ h => getOutputModel h true
 
 /-- Retrieve error msg from 'h'.
     NOTE: An error msg starts with "(error" and ends with ")\n".
+    Line endings are normalized to handle both Unix (LF) and Windows (CRLF).
 -/
-partial def getErrorMsg (h : IO.FS.Handle) : IO String := h.getLine
+partial def getErrorMsg (h : IO.FS.Handle) : IO String := normalizeLine <$> h.getLine
 
 /-- Retrieve an `eval` output from `h` after execution `(eval t)`
     NOTE: An eval output may either correspond to a scalar value
@@ -170,7 +178,7 @@ partial def getErrorMsg (h : IO.FS.Handle) : IO String := h.getLine
     should tally to stop reading from `h`.
 -/
 partial def getOutputEval (h : IO.FS.Handle) : IO String := do
-  let line ← h.getLine
+  let line := normalizeLine (← h.getLine)
   if line.get! 0 != '(' then return line
   getIndValue line (tallyParenthesis line 0)
 
@@ -184,7 +192,7 @@ partial def getOutputEval (h : IO.FS.Handle) : IO String := do
   getIndValue (acc : String) (tally : Int) : IO String := do
     if tally == 0 then return acc
     else
-      let line ← h.getLine
+      let line := normalizeLine (← h.getLine)
       getIndValue (acc ++ line) (tallyParenthesis line tally)
 
 /-- Push smt command `c` in the translation environment only when sOpts.dumpSmtLib is set -/
@@ -210,9 +218,9 @@ partial def trySubmitCommand! (c : SmtCommand) (checkSuccess := true) : Translat
   c.emit
   let h ← getProcStdOut
   if !checkSuccess then return ()
-  let out ← h.getLine
+  let out := normalizeLine (← h.getLine)
   match out with
-  | "success\n" | "success\r\n" => return ()
+  | "success\n" => return ()
   | err => throwEnvError s!"Unexpected smt error: {err} for {c}"
 
 /-- Same as trySubmitCommand! but with flag `checkSuccess` set to `false`.
@@ -527,10 +535,10 @@ partial def getSatResult (p : IO.Process.Child ⟨.piped, .piped, .piped⟩) : T
    waitForResult (res : Task (Except IO.Error String)) : TranslateEnvT Result := do
      checkCancelTk?
      if ← IO.hasFinished res then
-       match ← IO.ofExcept res.get with
-       | "sat\n" | "sat\r\n"    => return (.Falsified (← getModel))
-       | "unsat\n" | "unsat\r\n"    => return .Valid
-       | "unknown\n" | "unknown\r\n" => return .Undetermined -- unknown is also return when timeout is set to stdin
+       match normalizeLine (← IO.ofExcept res.get) with
+       | "sat\n"     => return (.Falsified (← getModel))
+       | "unsat\n"   => return .Valid
+       | "unknown\n" => return .Undetermined -- unknown is also return when timeout is set to stdin
        | err => throwEnvError s!"checkSat: Unexpected check-sat result: {err}"
      else
        let sleepTimeMs := (20 : UInt32)


### PR DESCRIPTION
## Description

This pull request improves the robustness of SMT command handling in `Blaster/Smt/Env.lean` by ensuring correct processing of line endings from external processes. The main changes ensure that both Unix (`\n`) and Windows (`\r\n`) line endings are properly handled when reading responses from the SMT solver.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Related Issue

- Closes #106 

## Changes Made

- Add support to end of line to \r\n

## Testing

Testing done on my machines, no regression on MacOS and Linux, works on my Windows

### Test Coverage

- [ ] Added new tests for new functionality
- [ ] Updated existing tests
- [x] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder

## Documentation

- [ ] README updated (if applicable)
- [ ] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes using `make check_all`
- [ ] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number

## Additional Notes

No additional tests proposed as this is machine dependent. 