### PR TITLE
feat: proof reconstruction for rewrite rules (proofStack)

### DIFF
--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -37,10 +37,13 @@ def toElabForm (e : Expr) : MetaM Expr := do
       mkSub (← toElabForm a) (← toElabForm b)
   | Expr.app (Expr.app (Expr.const ``Nat.mul _) a) b =>
       mkMul (← toElabForm a) (← toElabForm b)
-  -- Future-proofing: Nat.div currently elaborates directly (not via HDiv.hDiv),
+  -- Future-proofing: Nat.div /Nat.mod currently elaborates directly
+  --                  (not via HDiv.hDiv / HMod.hMod),
   -- but we normalize it here in case that changes, consistent with add/sub/mul.
   | Expr.app (Expr.app (Expr.const ``Nat.div _) a) b =>
       mkAppM ``HDiv.hDiv #[← toElabForm a, ← toElabForm b]
+  | Expr.app (Expr.app (Expr.const ``Nat.mod _) a) b =>
+      mkAppM ``HMod.hMod #[← toElabForm a, ← toElabForm b]
   | Expr.app f a =>
       return mkApp (← toElabForm f) (← toElabForm a)
   | _ => return e

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -27,7 +27,7 @@ Example: `blaster (timeout: 10) (verbose: 1)`
 -/
 syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 
-/-- Convert core Nat operators to their HAdd/HSub/HMul elaborated form
+/-- Convert core Nat/Int operators to their HAdd/HSub/HMul/Neg elaborated form
     so that proof term LHS patterns structurally match goal expressions. -/
 def toElabForm (e : Expr) : MetaM Expr := do
   match e with
@@ -37,6 +37,14 @@ def toElabForm (e : Expr) : MetaM Expr := do
       mkSub (← toElabForm a) (← toElabForm b)
   | Expr.app (Expr.app (Expr.const ``Nat.mul _) a) b =>
       mkMul (← toElabForm a) (← toElabForm b)
+  | Expr.app (Expr.app (Expr.const ``Int.add _) a) b =>
+      mkAdd (← toElabForm a) (← toElabForm b)
+  | Expr.app (Expr.app (Expr.const ``Int.sub _) a) b =>
+      mkSub (← toElabForm a) (← toElabForm b)
+  | Expr.app (Expr.app (Expr.const ``Int.mul _) a) b =>
+      mkMul (← toElabForm a) (← toElabForm b)
+  | Expr.app (Expr.const ``Int.neg _) a =>
+      mkAppM ``Neg.neg #[← toElabForm a]
   -- Future-proofing: Nat.div /Nat.mod currently elaborates directly
   --                  (not via HDiv.hDiv / HMod.hMod),
   -- but we normalize it here in case that changes, consistent with add/sub/mul.

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -45,6 +45,8 @@ def toElabForm (e : Expr) : MetaM Expr := do
       mkMul (← toElabForm a) (← toElabForm b)
   | Expr.app (Expr.const ``Int.neg _) a =>
       mkAppM ``Neg.neg #[← toElabForm a]
+  | Expr.app (Expr.const ``Int.ofNat _) (a@(Expr.lit (Literal.natVal _))) =>
+      mkAppOptM ``OfNat.ofNat #[mkConst ``Int, a, none]
   -- Future-proofing: Nat.div /Nat.mod currently elaborates directly
   --                  (not via HDiv.hDiv / HMod.hMod),
   -- but we normalize it here in case that changes, consistent with add/sub/mul.

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -27,6 +27,40 @@ Example: `blaster (timeout: 10) (verbose: 1)`
 -/
 syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 
+/-- Apply recorded proof stack rewrites to a goal.
+    Each rewrite step is attempted; steps that don't match are skipped.
+-/
+def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) : MetaM MVarId := do
+  /- trace[Optimize.expr] "proofStack size: {steps.size}" -/
+  let mut g := goal
+  g ← rewriteFixpoint g steps
+  for step in steps do
+    match step with
+    | .rewrite heq symm once =>
+      if once then
+        try
+          let r ← g.rewrite (← g.getType) heq symm
+          g ← g.replaceTargetEq r.eNew r.eqProof
+        catch _ => pure ()
+  g ← rewriteFixpoint g steps
+  /- trace[Optimize.expr] "final goal after proofStack: {← g.getType}" -/
+  return g
+where
+  rewriteFixpoint (g : MVarId) (steps : Array Blaster.Optimize.ProofStep) : MetaM MVarId := do
+    let mut g := g
+    let mut changed := true
+    while changed do
+      changed := false
+      for step in steps do
+        match step with
+        | .rewrite heq symm once =>
+          if !once then
+            try
+              let r ← g.rewrite (← g.getType) heq symm
+              g ← g.replaceTargetEq r.eNew r.eqProof
+              changed := true
+            catch _ => pure ()
+    return g
 
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
@@ -36,12 +70,18 @@ def blasterTacticImp : Tactic := fun stx =>
    let sOpts ← parseSolveOptions opts default
    let (goal, nbQuantifiers) ← revertHypotheses (← getMainGoal)
    let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
-   let ((result, optExpr), _) ←
+   let ((result, optExpr), finalEnv) ←
      withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0 }) $ do
        IO.setNumHeartbeats 0
        Translate.main (← goal.getType >>= instantiateMVars') (logUndetermined := false) |>.run env
    match result with
-   | .Valid => goal.admit -- TODO: replace with proof reconstruction
+   | .Valid =>
+        -- intro all binders so rewrite can find patterns
+        let numBinders ← forallTelescope (← goal.getType) fun fvars _ => pure fvars.size
+        let (_, g) ← goal.introNP numBinders
+        let g ← applyProofStack g finalEnv.optEnv.proofStack
+        try g.refl
+        catch _ => g.admit
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -47,6 +47,9 @@ def toElabForm (e : Expr) : MetaM Expr := do
       mkAppM ``Neg.neg #[← toElabForm a]
   | Expr.app (Expr.const ``Int.ofNat _) (a@(Expr.lit (Literal.natVal _))) =>
       mkAppOptM ``OfNat.ofNat #[mkConst ``Int, a, none]
+  | Expr.app (Expr.const ``Int.negSucc _) (Expr.lit (Literal.natVal n)) =>
+      -- `Int.negSucc n` denotes `-(n+1)`.
+      mkAppM ``Neg.neg #[← mkAppOptM ``OfNat.ofNat #[mkConst ``Int, mkNatLit (n + 1), none]]
   -- Future-proofing: Nat.div /Nat.mod currently elaborates directly
   --                  (not via HDiv.hDiv / HMod.hMod),
   -- but we normalize it here in case that changes, consistent with add/sub/mul.

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -77,6 +77,29 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
   /- trace[Optimize.expr] "final goal after proofStack: {← g.getType}" -/
   return g
 
+/-- Given a proof `h : ∀ x₁ ... xₙ, P x₁...xₙ = Q x₁...xₙ`, produce a proof of
+    `(∀ x₁ ... xₙ, P x₁...xₙ) = (∀ x₁ ... xₙ, Q x₁...xₙ)`.
+    When `lhs` and `rhs` are not both foralls, returns `h` unchanged. -/
+partial def liftForallEq (lhs rhs h : Expr) : MetaM Expr := do
+  match lhs, rhs with
+  | Expr.forallE n α lhsBody bi, Expr.forallE _ _ rhsBody _ =>
+    let forward ← withLocalDecl `hp .default lhs fun hp =>
+      withLocalDecl n bi α fun x => do
+        let innerEq ← liftForallEq (lhsBody.instantiate1 x) (rhsBody.instantiate1 x) (mkApp h x)
+        let body ← mkAppM ``cast #[innerEq, mkApp hp x]
+        let lam ← mkLambdaFVars #[x] body
+        mkLambdaFVars #[hp] lam
+    let backward ← withLocalDecl `hq .default rhs fun hq =>
+      withLocalDecl n bi α fun x => do
+        let innerEq ← liftForallEq (lhsBody.instantiate1 x) (rhsBody.instantiate1 x) (mkApp h x)
+        let symmEq ← mkAppM ``Eq.symm #[innerEq]
+        let body ← mkAppM ``cast #[symmEq, mkApp hq x]
+        let lam ← mkLambdaFVars #[x] body
+        mkLambdaFVars #[hq] lam
+    let iff ← mkAppM ``Iff.intro #[forward, backward]
+    mkAppM ``propext #[iff]
+  | _, _ => return h
+
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
   withMainContext $ do
@@ -90,15 +113,45 @@ def blasterTacticImp : Tactic := fun stx =>
        IO.setNumHeartbeats 0
        Translate.main (← goal.getType) (logUndetermined := false) |>.run env
    match result with
-  | .Valid =>
-        -- intro all binders so rewrite can find patterns
-        let numBinders ← forallTelescope (← goal.getType) fun fvars _ => pure fvars.size
-        let (goalFVarIds, g) ← goal.introNP numBinders
-        let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
-                            finalEnv.optEnv.optBinders goalFVarIds
-        let g ← applyProofStack g proofStack
-        try g.refl
-        catch _ => g.admit
+   | .Valid =>
+        let goalType ← goal.getType
+        -- Try propositional equality path: (∀ xs, body₁) = (∀ xs, body₂)
+        let usedPropEqPath ← try
+          match goalType.eq? with
+          | some (_, lhs, rhs) =>
+            if ← isProp lhs then
+              let numBinders ← forallTelescope lhs fun fvars _ => pure fvars.size
+              if numBinders > 0 then
+                -- Build pointwise equality goal: ∀ xs, body₁(xs) = body₂(xs)
+                let innerGoalType ← forallTelescope lhs fun inputFvars inputBody => do
+                  let optBody ← forallBoundedTelescope rhs (some numBinders) fun optFvars optBody =>
+                    pure (optBody.replaceFVars optFvars inputFvars)
+                  let eq ← mkEq inputBody optBody
+                  mkForallFVars inputFvars eq
+                let innerMVar ← mkFreshExprMVar innerGoalType
+                let (goalFVarIds, ig) ← innerMVar.mvarId!.introNP numBinders
+                let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
+                                    finalEnv.optEnv.optBinders goalFVarIds
+                let ig ← applyProofStack ig proofStack
+                try ig.refl
+                catch _ => ig.admit
+                -- Lift: (∀ xs, body₁ = body₂) → (∀ xs, body₁) = (∀ xs, body₂)
+                let liftedProof ← liftForallEq lhs rhs innerMVar
+                goal.assign liftedProof
+                pure true
+              else pure false
+            else pure false
+          | none => pure false
+        catch _ => pure false
+        unless usedPropEqPath do
+          -- intro all binders, rewrite, refl
+          let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
+          let (goalFVarIds, g) ← goal.introNP numBinders
+          let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
+                              finalEnv.optEnv.optBinders goalFVarIds
+          let g ← applyProofStack g proofStack
+          try g.refl
+          catch _ => g.admit
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -77,9 +77,6 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
   let steps : Array Blaster.Optimize.ProofStep ← goal.withContext <| steps.mapM fun
     | .rewrite proof symm => return .rewrite (← toElabForm proof) symm
     | .exact proof => return .exact proof
-  /- trace[Optimize.expr] "proofStack size: {steps.size}" -/
-  /- trace[Optimize.expr] "proofStack: -/
-  /-   {reprStr $ Array.map (λ | .rewrite proof _ => proof | .exact proof => proof) steps}" -/
   let mut g := goal
   let mut changed := true
   while changed do
@@ -94,10 +91,10 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
         catch _ => pure ()
       | .exact proof =>
         try
-          g.assign proof
-          return g
+          if ← isDefEq (← inferType proof) (← g.getType) then
+            g.assign proof
+            return g
         catch _ => pure ()
-  /- trace[Optimize.expr] "final goal after proofStack: {← g.getType}" -/
   return g
 
 /-- Build a proof of `(∀ x₁…xₙ, P) = (∀ y₁…yₘ, Q)` when m < n (some binders eliminated),
@@ -149,6 +146,20 @@ private def liftForallEq (lhs rhs innerProof : Expr) : MetaM Expr := do
      | Expr.forallE n _ body _ => #[n] ++ getForallBinderNames body
      | _ => #[]
 
+/-- Prove a goal by introducing binders, applying the proof stack, then closing with refl.
+    Returns the proof term so callers can use it directly. -/
+private def proveByProofStack (goalType : Expr) (proofStack : Array Blaster.Optimize.ProofStep)
+    (optBinders : Array FVarId) : MetaM Expr := do
+  let proofMVar ← mkFreshExprMVar goalType
+  let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
+  let (goalFVarIds, g) ← proofMVar.mvarId!.introNP numBinders
+  let proofStack := substProofStackFVars proofStack optBinders goalFVarIds
+  let g ← applyProofStack g proofStack
+  unless ← g.isAssigned do
+    try g.refl
+    catch _ => g.admit
+  return proofMVar
+
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
   withMainContext $ do
@@ -161,6 +172,8 @@ def blasterTacticImp : Tactic := fun stx =>
      withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0 }) $ do
        IO.setNumHeartbeats 0
        Translate.main (← goal.getType) (logUndetermined := false) |>.run env
+   let proofStack := finalEnv.optEnv.proofStack
+   let optBinders := finalEnv.optEnv.optBinders
    match result with
    | .Valid =>
         let goalType ← goal.getType
@@ -168,7 +181,12 @@ def blasterTacticImp : Tactic := fun stx =>
         let usedPropEqPath ← try
           match goalType.eq? with
           | some (_, lhs, rhs) =>
-            if ← isProp lhs then
+            if rhs.isConstOf ``True && (← isProp lhs) then
+              -- Goal is `P = True`: prove P directly, then lift via eq_true
+              let proof ← proveByProofStack lhs proofStack optBinders
+              goal.assign (← mkAppM ``eq_true #[proof])
+              pure true
+            else if ← isProp lhs then
               let numBinders ← forallTelescope lhs fun fvars _ => pure fvars.size
               if numBinders > 0 then
                 -- Build pointwise equality goal: ∀ xs, body₁(xs) = body₂(xs)
@@ -177,34 +195,22 @@ def blasterTacticImp : Tactic := fun stx =>
                     mapOptBodyToInputFVars optBody optFvars inputFvars
                   let eq ← mkEq inputBody optBody
                   mkForallFVars inputFvars eq
-                let innerMVar ← mkFreshExprMVar innerGoalType
-                let (goalFVarIds, ig) ← innerMVar.mvarId!.introNP numBinders
-                let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
-                                    finalEnv.optEnv.optBinders goalFVarIds
-                let ig ← applyProofStack ig proofStack
-                try ig.refl
-                catch _ => ig.admit
+                let innerProof ← proveByProofStack innerGoalType proofStack optBinders
                 -- Lift: (∀ xs, body₁ = body₂) → (∀ xs, body₁) = (∀ xs, body₂)
-                let liftedProof ← liftForallEq lhs rhs innerMVar
+                let liftedProof ← liftForallEq lhs rhs innerProof
                 goal.assign liftedProof
                 pure true
               else pure false
             else pure false
           | none => pure false
-        catch _ => pure false
+        catch _ =>
+          /- trace[Optimize.expr] "propEqPath failed: {e.toMessageData}" -/
+          pure false
         unless usedPropEqPath do
-          -- intro all binders, rewrite, refl
-          let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
-          let (goalFVarIds, g) ← goal.introNP numBinders
-          let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
-                              finalEnv.optEnv.optBinders goalFVarIds
-          let g ← applyProofStack g proofStack
-          unless ← g.isAssigned do
-            try g.refl
-            catch _ => g.admit
+          let proof ← proveByProofStack goalType proofStack optBinders
+          goal.assign proof
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
-        -- Replace the goal with the optimized expression
         let newGoal ← goal.replaceTargetDefEq optExpr
         replaceMainGoal [newGoal]
 

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -51,6 +51,7 @@ def substProofStackFVars (steps : Array Blaster.Optimize.ProofStep)
     let to_ := (goalFVarIds[:n].toArray).map mkFVar
     steps.map fun
       | .rewrite proof symm  => .rewrite (proof.replaceFVars from_ to_) symm
+      | .exact proof => .exact (proof.replaceFVars from_ to_)
 
 /-- Apply recorded proof stack rewrites to a goal.
     Each rewrite step is attempted; steps that don't match are skipped.
@@ -59,9 +60,10 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
   -- normalize proof terms once upfront
   let steps : Array Blaster.Optimize.ProofStep ← goal.withContext <| steps.mapM fun
     | .rewrite proof symm => return .rewrite (← toElabForm proof) symm
+    | .exact proof => return .exact proof
   /- trace[Optimize.expr] "proofStack size: {steps.size}" -/
   /- trace[Optimize.expr] "proofStack: -/
-  /-   {reprStr $ Array.map (λ | .rewrite proof _ => proof) steps}" -/
+  /-   {reprStr $ Array.map (λ | .rewrite proof _ => proof | .exact proof => proof) steps}" -/
   let mut g := goal
   let mut changed := true
   while changed do
@@ -73,6 +75,11 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
           let r ← g.rewrite (← g.getType) heq symm
           g ← g.replaceTargetEq r.eNew r.eqProof
           changed := true
+        catch _ => pure ()
+      | .exact proof =>
+        try
+          g.assign proof
+          return g
         catch _ => pure ()
   /- trace[Optimize.expr] "final goal after proofStack: {← g.getType}" -/
   return g
@@ -150,8 +157,9 @@ def blasterTacticImp : Tactic := fun stx =>
           let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
                               finalEnv.optEnv.optBinders goalFVarIds
           let g ← applyProofStack g proofStack
-          try g.refl
-          catch _ => g.admit
+          unless ← g.isAssigned do
+            try g.refl
+            catch _ => g.admit
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -53,9 +53,25 @@ def substProofStackFVars (steps : Array Blaster.Optimize.ProofStep)
       | .rewrite proof symm  => .rewrite (proof.replaceFVars from_ to_) symm
       | .exact proof => .exact (proof.replaceFVars from_ to_)
 
+/-- Map optimized body fvars to input fvars when binder counts differ.
+    Uses binder names to find the correct correspondence, since the
+    optimizer preserves binder names for surviving forall binders. -/
+def mapOptBodyToInputFVars (optBody : Expr) (optFvars inputFvars : Array Expr) : MetaM Expr := do
+  let mut mapping : Array Expr := #[]
+  for i in [:optFvars.size] do
+    let optName ← optFvars[i]!.fvarId!.getUserName
+    let mut found := false
+    for inputFvar in inputFvars do
+      if (← inputFvar.fvarId!.getUserName) == optName then
+        mapping := mapping.push inputFvar
+        found := true
+        break
+    unless found do
+      mapping := mapping.push optFvars[i]!
+  return optBody.replaceFVars optFvars mapping
+
 /-- Apply recorded proof stack rewrites to a goal.
-    Each rewrite step is attempted; steps that don't match are skipped.
--/
+    Each rewrite step is attempted; steps that don't match are skipped. -/
 def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) : MetaM MVarId := do
   -- normalize proof terms once upfront
   let steps : Array Blaster.Optimize.ProofStep ← goal.withContext <| steps.mapM fun
@@ -84,28 +100,54 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
   /- trace[Optimize.expr] "final goal after proofStack: {← g.getType}" -/
   return g
 
-/-- Given a proof `h : ∀ x₁ ... xₙ, P x₁...xₙ = Q x₁...xₙ`, produce a proof of
-    `(∀ x₁ ... xₙ, P x₁...xₙ) = (∀ x₁ ... xₙ, Q x₁...xₙ)`.
-    When `lhs` and `rhs` are not both foralls, returns `h` unchanged. -/
-partial def liftForallEq (lhs rhs h : Expr) : MetaM Expr := do
-  match lhs, rhs with
-  | Expr.forallE n α lhsBody bi, Expr.forallE _ _ rhsBody _ =>
-    let forward ← withLocalDecl `hp .default lhs fun hp =>
-      withLocalDecl n bi α fun x => do
-        let innerEq ← liftForallEq (lhsBody.instantiate1 x) (rhsBody.instantiate1 x) (mkApp h x)
-        let body ← mkAppM ``cast #[innerEq, mkApp hp x]
-        let lam ← mkLambdaFVars #[x] body
-        mkLambdaFVars #[hp] lam
-    let backward ← withLocalDecl `hq .default rhs fun hq =>
-      withLocalDecl n bi α fun x => do
-        let innerEq ← liftForallEq (lhsBody.instantiate1 x) (rhsBody.instantiate1 x) (mkApp h x)
-        let symmEq ← mkAppM ``Eq.symm #[innerEq]
-        let body ← mkAppM ``cast #[symmEq, mkApp hq x]
-        let lam ← mkLambdaFVars #[x] body
-        mkLambdaFVars #[hq] lam
-    let iff ← mkAppM ``Iff.intro #[forward, backward]
-    mkAppM ``propext #[iff]
-  | _, _ => return h
+/-- Build a proof of `(∀ x₁…xₙ, P) = (∀ y₁…yₘ, Q)` when m < n (some binders eliminated),
+    given `innerProof : ∀ x₁…xₙ, P(x₁…xₙ) = Q(kept(x₁…xₙ))`. -/
+private def liftForallEq (lhs rhs innerProof : Expr) : MetaM Expr := do
+  let rhsNames := getForallBinderNames rhs
+  -- Forward: lhs → rhs
+  let forward ← withLocalDecl `h .default lhs fun h =>
+    forallTelescope lhs fun lhsFvars _ => do
+      let mut lhsArgs : Array Expr := #[]
+      let mut keptFvars : Array Expr := #[]
+      let mut rhsIdx := 0
+      for fvar in lhsFvars do
+        let name ← fvar.fvarId!.getUserName
+        if rhsIdx < rhsNames.size && rhsNames[rhsIdx]! == name then
+          lhsArgs := lhsArgs.push fvar
+          keptFvars := keptFvars.push fvar
+          rhsIdx := rhsIdx + 1
+        else
+          let ty ← inferType fvar
+          let u ← getLevel ty
+          let inst ← synthInstance (mkApp (mkConst ``Inhabited [u]) ty)
+          lhsArgs := lhsArgs.push (mkApp2 (mkConst ``Inhabited.default [u]) ty inst)
+      let eqProof := mkAppN innerProof lhsArgs
+      let hApp := mkAppN h lhsArgs
+      let castExpr ← mkAppM ``cast #[eqProof, hApp]
+      let body ← mkLambdaFVars keptFvars castExpr
+      mkLambdaFVars #[h] body
+  -- Backward: rhs → lhs
+  let backward ← withLocalDecl `h .default rhs fun h =>
+    forallTelescope lhs fun lhsFvars _ => do
+      let mut rhsArgs : Array Expr := #[]
+      for fvar in lhsFvars do
+        let name ← fvar.fvarId!.getUserName
+        if rhsNames.contains name then
+          rhsArgs := rhsArgs.push fvar
+      let hApp := mkAppN h rhsArgs
+      let eqProof := mkAppN innerProof lhsFvars
+      let symmEq ← mkAppM ``Eq.symm #[eqProof]
+      let castExpr ← mkAppM ``cast #[symmEq, hApp]
+      let body ← mkLambdaFVars lhsFvars castExpr
+      mkLambdaFVars #[h] body
+  let iff ← mkAppM ``Iff.intro #[forward, backward]
+  mkAppM ``propext #[iff]
+
+ where
+   /-- Extract binder names from a chain of forall quantifiers. -/
+   getForallBinderNames : Expr → Array Name
+     | Expr.forallE n _ body _ => #[n] ++ getForallBinderNames body
+     | _ => #[]
 
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
@@ -131,8 +173,8 @@ def blasterTacticImp : Tactic := fun stx =>
               if numBinders > 0 then
                 -- Build pointwise equality goal: ∀ xs, body₁(xs) = body₂(xs)
                 let innerGoalType ← forallTelescope lhs fun inputFvars inputBody => do
-                  let optBody ← forallBoundedTelescope rhs (some numBinders) fun optFvars optBody =>
-                    pure (optBody.replaceFVars optFvars inputFvars)
+                  let optBody ← forallTelescope rhs fun optFvars optBody =>
+                    mapOptBodyToInputFVars optBody optFvars inputFvars
                   let eq ← mkEq inputBody optBody
                   mkForallFVars inputFvars eq
                 let innerMVar ← mkFreshExprMVar innerGoalType

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -32,6 +32,8 @@ syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 -/
 def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) : MetaM MVarId := do
   /- trace[Optimize.expr] "proofStack size: {steps.size}" -/
+  /- trace[Optimize.expr] "proofStack: -/
+  /-   {reprStr $ Array.map (λ | .rewrite proof _ _ => proof) steps}" -/
   let mut g := goal
   g ← rewriteFixpoint g steps
   for step in steps do
@@ -62,6 +64,32 @@ where
             catch _ => pure ()
     return g
 
+/-- Normalize an expression by sorting arguments of commutative operators,
+    so that AC-equivalent expressions become structurally equal. -/
+private def acNormalize : Expr → Expr
+  | Expr.app (Expr.app f a) b =>
+      if isCommOp f then
+        let a' := acNormalize a
+        let b' := acNormalize b
+        if b'.lt a' then mkApp2 f b' a' else mkApp2 f a' b'
+      else
+        Expr.app (acNormalize (Expr.app f a)) (acNormalize b)
+  | Expr.app f a => Expr.app (acNormalize f) (acNormalize a)
+  | e => e
+where
+  isCommOp (f : Expr) : Bool :=
+    let head := f.getAppFn
+    head.isConstOf ``Nat.add || head.isConstOf ``Nat.mul ||
+    head.isConstOf ``HAdd.hAdd || head.isConstOf ``HMul.hMul
+
+/-- Check if a goal of the form `LHS = RHS` is AC-equivalent
+    by normalizing both sides and comparing structurally. -/
+private def isACEquiv (g : MVarId) : MetaM Bool := do
+  let some (_, lhs, rhs) := (← g.getType).eq? | return false
+  /- trace[Optimize.expr] "isACEquiv lhs: {repr (acNormalize lhs)}" -/
+  /- trace[Optimize.expr] "isACEquiv rhs: {repr (acNormalize rhs)}" -/
+  return BEq.beq (acNormalize lhs) (acNormalize rhs)
+
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
   withMainContext $ do
@@ -81,7 +109,13 @@ def blasterTacticImp : Tactic := fun stx =>
         let (_, g) ← goal.introNP numBinders
         let g ← applyProofStack g finalEnv.optEnv.proofStack
         try g.refl
-        catch _ => g.admit
+        catch _ =>
+          if ← isACEquiv g then
+            try
+              setGoals [g]
+              evalTactic (← `(tactic| ac_rfl))
+            catch _ => g.admit
+          else g.admit
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -37,6 +37,10 @@ def toElabForm (e : Expr) : MetaM Expr := do
       mkSub (← toElabForm a) (← toElabForm b)
   | Expr.app (Expr.app (Expr.const ``Nat.mul _) a) b =>
       mkMul (← toElabForm a) (← toElabForm b)
+  -- Future-proofing: Nat.div currently elaborates directly (not via HDiv.hDiv),
+  -- but we normalize it here in case that changes, consistent with add/sub/mul.
+  | Expr.app (Expr.app (Expr.const ``Nat.div _) a) b =>
+      mkAppM ``HDiv.hDiv #[← toElabForm a, ← toElabForm b]
   | Expr.app f a =>
       return mkApp (← toElabForm f) (← toElabForm a)
   | _ => return e
@@ -77,7 +81,19 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
   let steps : Array Blaster.Optimize.ProofStep ← goal.withContext <| steps.mapM fun
     | .rewrite proof symm => return .rewrite (← toElabForm proof) symm
     | .exact proof => return .exact proof
+  /- trace[Optimize.expr] "proofStack ({steps.size} steps):" -/
+  /- let mut idx : Nat := 0 -/
+  /- for step in steps do -/
+  /-   match step with -/
+  /-   | .rewrite heq symm => -/
+  /-     let ty ← inferType heq -/
+  /-     trace[Optimize.expr] "  [{idx}] rewrite{if symm then " (symm)" else ""}: {ty}" -/
+  /-   | .exact proof => -/
+  /-     let ty ← inferType proof -/
+  /-     trace[Optimize.expr] "  [{idx}] exact: {ty}" -/
+  /-   idx := idx + 1 -/
   let mut g := goal
+  /- trace[Optimize.expr] "initial goal: {← g.getType}" -/
   let mut changed := true
   while changed do
     changed := false
@@ -88,13 +104,16 @@ def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) :
           let r ← g.rewrite (← g.getType) heq symm
           g ← g.replaceTargetEq r.eNew r.eqProof
           changed := true
+          /- trace[Optimize.expr] "  applied rewrite → {← g.getType}" -/
         catch _ => pure ()
       | .exact proof =>
         try
           if ← isDefEq (← inferType proof) (← g.getType) then
             g.assign proof
+            /- trace[Optimize.expr] "  applied exact, goal closed" -/
             return g
         catch _ => pure ()
+  /- trace[Optimize.expr] "final goal: {← g.getType}" -/
   return g
 
 /-- Build a proof of `(∀ x₁…xₙ, P) = (∀ y₁…yₘ, Q)` when m < n (some binders eliminated),

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -27,68 +27,55 @@ Example: `blaster (timeout: 10) (verbose: 1)`
 -/
 syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 
+/-- Convert core Nat operators to their HAdd/HSub/HMul elaborated form
+    so that proof term LHS patterns structurally match goal expressions. -/
+def toElabForm (e : Expr) : MetaM Expr := do
+  match e with
+  | Expr.app (Expr.app (Expr.const ``Nat.add _) a) b =>
+      mkAdd (← toElabForm a) (← toElabForm b)
+  | Expr.app (Expr.app (Expr.const ``Nat.sub _) a) b =>
+      mkSub (← toElabForm a) (← toElabForm b)
+  | Expr.app (Expr.app (Expr.const ``Nat.mul _) a) b =>
+      mkMul (← toElabForm a) (← toElabForm b)
+  | Expr.app f a =>
+      return mkApp (← toElabForm f) (← toElabForm a)
+  | _ => return e
+
+/-- Replace optimizer-context FVarIds with goal-context FVarIds in proof steps. -/
+def substProofStackFVars (steps : Array Blaster.Optimize.ProofStep)
+    (optBinders goalFVarIds : Array FVarId) : Array Blaster.Optimize.ProofStep :=
+  if optBinders.isEmpty then steps
+  else
+    let n := min optBinders.size goalFVarIds.size
+    let from_ := (optBinders[:n].toArray).map mkFVar
+    let to_ := (goalFVarIds[:n].toArray).map mkFVar
+    steps.map fun
+      | .rewrite proof symm  => .rewrite (proof.replaceFVars from_ to_) symm
+
 /-- Apply recorded proof stack rewrites to a goal.
     Each rewrite step is attempted; steps that don't match are skipped.
 -/
 def applyProofStack (goal : MVarId) (steps : Array Blaster.Optimize.ProofStep) : MetaM MVarId := do
+  -- normalize proof terms once upfront
+  let steps : Array Blaster.Optimize.ProofStep ← goal.withContext <| steps.mapM fun
+    | .rewrite proof symm => return .rewrite (← toElabForm proof) symm
   /- trace[Optimize.expr] "proofStack size: {steps.size}" -/
   /- trace[Optimize.expr] "proofStack: -/
-  /-   {reprStr $ Array.map (λ | .rewrite proof _ _ => proof) steps}" -/
+  /-   {reprStr $ Array.map (λ | .rewrite proof _ => proof) steps}" -/
   let mut g := goal
-  g ← rewriteFixpoint g steps
-  for step in steps do
-    match step with
-    | .rewrite heq symm once =>
-      if once then
+  let mut changed := true
+  while changed do
+    changed := false
+    for step in steps do
+      match step with
+      | .rewrite heq symm =>
         try
           let r ← g.rewrite (← g.getType) heq symm
           g ← g.replaceTargetEq r.eNew r.eqProof
+          changed := true
         catch _ => pure ()
-  g ← rewriteFixpoint g steps
   /- trace[Optimize.expr] "final goal after proofStack: {← g.getType}" -/
   return g
-where
-  rewriteFixpoint (g : MVarId) (steps : Array Blaster.Optimize.ProofStep) : MetaM MVarId := do
-    let mut g := g
-    let mut changed := true
-    while changed do
-      changed := false
-      for step in steps do
-        match step with
-        | .rewrite heq symm once =>
-          if !once then
-            try
-              let r ← g.rewrite (← g.getType) heq symm
-              g ← g.replaceTargetEq r.eNew r.eqProof
-              changed := true
-            catch _ => pure ()
-    return g
-
-/-- Normalize an expression by sorting arguments of commutative operators,
-    so that AC-equivalent expressions become structurally equal. -/
-private def acNormalize : Expr → Expr
-  | Expr.app (Expr.app f a) b =>
-      if isCommOp f then
-        let a' := acNormalize a
-        let b' := acNormalize b
-        if b'.lt a' then mkApp2 f b' a' else mkApp2 f a' b'
-      else
-        Expr.app (acNormalize (Expr.app f a)) (acNormalize b)
-  | Expr.app f a => Expr.app (acNormalize f) (acNormalize a)
-  | e => e
-where
-  isCommOp (f : Expr) : Bool :=
-    let head := f.getAppFn
-    head.isConstOf ``Nat.add || head.isConstOf ``Nat.mul ||
-    head.isConstOf ``HAdd.hAdd || head.isConstOf ``HMul.hMul
-
-/-- Check if a goal of the form `LHS = RHS` is AC-equivalent
-    by normalizing both sides and comparing structurally. -/
-private def isACEquiv (g : MVarId) : MetaM Bool := do
-  let some (_, lhs, rhs) := (← g.getType).eq? | return false
-  /- trace[Optimize.expr] "isACEquiv lhs: {repr (acNormalize lhs)}" -/
-  /- trace[Optimize.expr] "isACEquiv rhs: {repr (acNormalize rhs)}" -/
-  return BEq.beq (acNormalize lhs) (acNormalize rhs)
 
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
@@ -103,19 +90,15 @@ def blasterTacticImp : Tactic := fun stx =>
        IO.setNumHeartbeats 0
        Translate.main (← goal.getType >>= instantiateMVars') (logUndetermined := false) |>.run env
    match result with
-   | .Valid =>
+  | .Valid =>
         -- intro all binders so rewrite can find patterns
         let numBinders ← forallTelescope (← goal.getType) fun fvars _ => pure fvars.size
-        let (_, g) ← goal.introNP numBinders
-        let g ← applyProofStack g finalEnv.optEnv.proofStack
+        let (goalFVarIds, g) ← goal.introNP numBinders
+        let proofStack := substProofStackFVars finalEnv.optEnv.proofStack
+                            finalEnv.optEnv.optBinders goalFVarIds
+        let g ← applyProofStack g proofStack
         try g.refl
-        catch _ =>
-          if ← isACEquiv g then
-            try
-              setGoals [g]
-              evalTactic (← `(tactic| ac_rfl))
-            catch _ => g.admit
-          else g.admit
+        catch _ => g.admit
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -11,6 +11,8 @@ open Lean Elab Command Term Meta Blaster.Options
 
 namespace Blaster.Optimize
 
+theorem nat_succ_eq_one_add (n : Nat) : Nat.succ n = 1 + n := by
+  rw [Nat.succ_eq_add_one, Nat.add_comm]
 
 -- TODO: update formalization with inference rule style notation.
 partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr := do
@@ -54,6 +56,9 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
                -- perform beta reduction and apply optimization
                optimizeExprAux (.InitOptimizeExpr (betaLambda f ras) :: i_stack)
              else
+               -- emit proof step for Nat.succ ==> 1 + n before cache is consulted
+               if f.isConstOf ``Nat.succ && ras.size == 1 then
+                 pushProofStep (.rewrite (mkConst ``nat_succ_eq_one_add))
                -- set inFunApp flag before optimizing `f`
                setInFunApp true
                let i_stack' := .AppWaitForConst ras :: i_stack

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -291,7 +291,8 @@ def cacheOpaqueRecFun : TranslateEnvT Unit := do
 
 /-- Perform the following actions:
       - populate the recFunInstCache with default recursive function definitions.
-      - discard proof steps and optimize binders accumulated during cache initialization
+      - discard proof steps, local proof stack and optimize binders accumulated
+        during cache initialization.
       - optimize expression `e`
 -/
 def Optimize.main (e : Expr) : TranslateEnvT Expr := do
@@ -299,6 +300,7 @@ def Optimize.main (e : Expr) : TranslateEnvT Expr := do
   updateLocalContext (← mkLocalContext)
   cacheOpaqueRecFun
   clearProofStack
+  updateLocalProofStack #[]
   clearOptBinders
   optimizeExpr e
 

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -279,6 +279,8 @@ def Optimize.main (e : Expr) : TranslateEnvT Expr := do
   updateLocalContext (← mkLocalContext)
   -- populate recFunInstCache with recursive function definition.
   cacheOpaqueRecFun
+  -- discard proof steps from cache initialization
+  clearProofStack
   optimizeExpr e
 
 

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -56,9 +56,11 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
                -- perform beta reduction and apply optimization
                optimizeExprAux (.InitOptimizeExpr (betaLambda f ras) :: i_stack)
              else
-               -- emit proof step for Nat.succ ==> 1 + n before cache is consulted
+               -- emit proof steps before cache is consulted
                if f.isConstOf ``Nat.succ && ras.size == 1 then
-                 pushProofStep (.rewrite (mkConst ``nat_succ_eq_one_add))
+                 pushProofStep (.rewrite (mkApp (mkConst ``nat_succ_eq_one_add) ras[0]!))
+               else if f.isConstOf ``Nat.pred && ras.size == 1 then
+                 pushProofStep (.rewrite (mkApp (mkConst ``Nat.pred_eq_sub_one) ras[0]!))
                -- set inFunApp flag before optimizing `f`
                setInFunApp true
                let i_stack' := .AppWaitForConst ras :: i_stack

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -272,16 +272,15 @@ def cacheOpaqueRecFun : TranslateEnvT Unit := do
 
 /-- Perform the following actions:
       - populate the recFunInstCache with default recursive function definitions.
-      - discard proof steps accumulated during cache initialization
+      - discard proof steps and optimize binders accumulated during cache initialization
       - optimize expression `e`
 -/
 def Optimize.main (e : Expr) : TranslateEnvT Expr := do
   -- set start local context
   updateLocalContext (← mkLocalContext)
-  -- populate recFunInstCache with recursive function definition.
   cacheOpaqueRecFun
-  -- discard proof steps from cache initialization
   clearProofStack
+  clearOptBinders
   optimizeExpr e
 
 

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -272,6 +272,7 @@ def cacheOpaqueRecFun : TranslateEnvT Unit := do
 
 /-- Perform the following actions:
       - populate the recFunInstCache with default recursive function definitions.
+      - discard proof steps accumulated during cache initialization
       - optimize expression `e`
 -/
 def Optimize.main (e : Expr) : TranslateEnvT Expr := do

--- a/Blaster/Optimize/Env.lean
+++ b/Blaster/Optimize/Env.lean
@@ -68,6 +68,10 @@ structure OptimizeOptions where
   -/
   inFunApp : Bool := false
 
+  /-- Flag set to `true` when optimizing a recursive function body.
+      Controls whether `pushProofStep` targets `localProofStack` or `proofStack`. -/
+  optimizeRecFunBody : Bool := false
+
   /-- Keep track of the analysis Step reached for bmc and k-induction. -/
   mcDepth : Nat
 
@@ -90,6 +94,12 @@ inductive ProofStep where
   | rewrite (proof : Expr) (symm : Bool := false)
   | exact (proof : Expr)
 deriving Repr
+
+/-- Result of optimizing a recursive function body, storing both the
+    normalized body and the proof steps applied during normalization. -/
+structure RecFunOptResult where
+  optimizedBody : Expr
+  proofStack : Array ProofStep
 
 abbrev HypothesisMap := Std.HashMap Lean.Expr Lean.Expr
 abbrev RewriteCacheMap := Std.HashMap Lean.Expr Lean.Expr
@@ -255,7 +265,7 @@ structure OptimizeEnv where
         - fdef: correspond to the recursive function body.
       TODO: UPDATE SPEC
   -/
-  recFunInstCache : Std.HashMap Lean.Expr Lean.Expr
+  recFunInstCache : Std.HashMap Lean.Expr RecFunOptResult
 
   /-- Cache keeping track of visited recursive function.
       Note that we here keep track of each instantiated polymorphic function.
@@ -303,6 +313,9 @@ structure OptimizeEnv where
 
   /-- Proof steps accumulated during optimization, replayed for proof reconstruction. -/
   proofStack : Array ProofStep := #[]
+
+  /-- Proof steps accumulated during the optimization of the body of recursive functions -/
+  localProofStack : Array ProofStep := #[]
 
   /-- Forall binder FVarIds created during optimization, used to map
       optimizer-context variables to goal-context variables during proof replay. -/
@@ -637,10 +650,49 @@ def isOptimizeRecCall : TranslateEnvT Bool :=
 def isInFunApp : TranslateEnvT Bool :=
   return (← get).optEnv.options.inFunApp
 
-/-- Push a proof step onto the proof stack. -/
+/-- Push a proof step onto the appropriate proof stack.
+    When optimizing a recursive function body, steps go to `localProofStack`;
+    otherwise they go to the global `proofStack`. -/
 @[always_inline, inline]
 def pushProofStep (step : ProofStep) : TranslateEnvT Unit :=
-  modify fun env => { env with optEnv.proofStack := env.optEnv.proofStack.push step }
+  modify fun env =>
+    if env.optEnv.options.optimizeRecFunBody then
+      { env with optEnv.localProofStack := env.optEnv.localProofStack.push step }
+    else
+      { env with optEnv.proofStack := env.optEnv.proofStack.push step }
+
+/-- Set the `optimizeRecFunBody` flag. -/
+@[always_inline, inline]
+def setOptimizeRecFunBody (b : Bool) : TranslateEnvT Unit :=
+  modify fun env => { env with optEnv.options.optimizeRecFunBody := b }
+
+/-- Return `true` if currently optimizing a recursive function body. -/
+@[always_inline, inline]
+def inOptimizeRecFunBody : TranslateEnvT Bool :=
+  return (← get).optEnv.options.optimizeRecFunBody
+
+/-- Replace the local proof stack with `s`. -/
+@[always_inline, inline]
+def updateLocalProofStack (s : Array ProofStep) : TranslateEnvT Unit :=
+  modify fun env => { env with optEnv.localProofStack := s }
+
+/-- Save local proof stack context before optimizing a recursive function body.
+    Returns `some oldStack` when already inside a rec body (mutually recursive case),
+    or `none` when entering the first rec body. -/
+def mkRecFuncStackContext : TranslateEnvT (Option (Array ProofStep)) := do
+  if ← inOptimizeRecFunBody then
+    return some (← get).optEnv.localProofStack
+  else
+    setOptimizeRecFunBody true
+    return none
+
+/-- Restore local proof stack context after optimizing a recursive function body.
+    When `recCtx = some oldStack`, restores the previous local stack (mutually recursive case).
+    When `recCtx = none`, resets the `optimizeRecFunBody` flag. -/
+def restoreRecFunStackContext (recCtx : Option (Array ProofStep)) : TranslateEnvT Unit := do
+  match recCtx with
+  | some oldProofStack => updateLocalProofStack oldProofStack
+  | none => setOptimizeRecFunBody false
 
 /-- Return the current proof stack. -/
 @[always_inline, inline]
@@ -714,7 +766,7 @@ def mkExpr (a : Expr) (cacheResult := true) : TranslateEnvT Expr := do
 /-- Return `true` only when both hypothesisMap and matchInContext are empty and isRefHyp flag is not set -/
 @[always_inline, inline]
 def isGlobalContext : TranslateEnvT Bool := do
-  let ⟨_, ⟨_, _, _, _, _, _, _, _, hypothesisContext, matchInContext, _, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, _, _, _, _, _, _, _, hypothesisContext, matchInContext, _, _, _, _, _, _, _⟩⟩ ← get
   return hypothesisContext.hypothesisMap.size == 0 && matchInContext.size == 0
 
 /-- Perform the following:
@@ -1701,8 +1753,10 @@ where
 /-- Given `f` which is either a function name expression or a fully/partially instantiated polymorphic function (see `getInstApp`),
     and `fbody` corresponding to `f`'s definition, update the recursive instance cache (i.e., `recFunInstCache`),
 -/
-def updateRecFunInst (f : Expr) (fbody : Expr) : TranslateEnvT Unit := do
-  modify (fun env => { env with optEnv.recFunInstCache := env.optEnv.recFunInstCache.insert f fbody })
+def updateRecFunInst (f : Expr) (fbody : Expr) (localProofStack : Array ProofStep) :
+    TranslateEnvT Unit := do
+  modify (fun env => { env with optEnv.recFunInstCache :=
+    env.optEnv.recFunInstCache.insert f { optimizedBody := fbody, proofStack := localProofStack } })
 
 
 /-- Return `fₙ` if `body[mkAnnotation `_solver.recursivecall _'/_recFun α₁ ... αₖ x₁ ... xₙ] := fₙ` is already
@@ -1723,10 +1777,11 @@ def updateRecFunInst (f : Expr) (fbody : Expr) : TranslateEnvT Unit := do
       - an entry exists for each opaque recursive function in `recFunMap` before optimization is performed
         (see function `cacheOpaqueRecFun`).
 -/
-partial def storeRecFunDef (f : Expr) (params : ImplicitParameters) (body : Expr) : TranslateEnvT Expr := do
+partial def storeRecFunDef (f : Expr) (params : ImplicitParameters) (body : Expr)
+    (localProofStack : Array ProofStep) : TranslateEnvT Expr := do
   let body' := body.replace (replacePred (← mkExpr (mkConst internalRecFun)))
   -- update polymorphic instance cache
-  updateRecFunInst f body'
+  updateRecFunInst f body' localProofStack
   match (← get).optEnv.recFunMap.get? body' with
   | some fb => return fb
   | none =>
@@ -1762,12 +1817,13 @@ where
     An error is triggered if no corresponding entry can be found in `recFunMap`.
 -/
 def hasRecFunInst? (instApp : Expr) : TranslateEnvT (Option Expr) := do
-  let ⟨_, ⟨_, _, _, _, _,recFunInstCache,_,recFunMap, _, _, _, _, _, _, _, _⟩⟩ ← get
+  let recFunInstCache := (← get).optEnv.recFunInstCache
+  let recFunMap := (← get).optEnv.recFunMap
   match recFunInstCache.get? instApp with
-  | some fbody =>
+  | some result =>
+     match recFunMap.get? result.optimizedBody with
      -- retrieve function application from recFunMap
-     match recFunMap.get? fbody with
-     | none => throwEnvError "hasRecFunInst: expecting entry for {reprStr fbody} in recFunMap"
+     | none => throwEnvError "hasRecFunInst: expecting entry for {reprStr result.optimizedBody} in recFunMap"
      | res => return res
   | none => return none
 

--- a/Blaster/Optimize/Env.lean
+++ b/Blaster/Optimize/Env.lean
@@ -84,7 +84,7 @@ inductive MatchEntry where
 
 /-- A single proof step recorded during expression optimization. -/
 inductive ProofStep where
-  | rewrite (proof : Expr) (symm : Bool := false) (once : Bool := false)
+  | rewrite (proof : Expr) (symm : Bool := false)
 deriving Repr
 
 abbrev HypothesisMap := Std.HashMap Lean.Expr Lean.Expr
@@ -299,6 +299,10 @@ structure OptimizeEnv where
 
   /-- Proof steps accumulated during optimization, replayed for proof reconstruction. -/
   proofStack : Array ProofStep := #[]
+
+  /-- Forall binder FVarIds created during optimization, used to map
+      optimizer-context variables to goal-context variables during proof replay. -/
+  optBinders : Array FVarId := #[]
 
 instance : Inhabited OptimizeEnv where
   default :=
@@ -634,6 +638,16 @@ def getProofStack : TranslateEnvT (Array ProofStep) :=
 def clearProofStack : TranslateEnvT Unit :=
   modify fun env => { env with optEnv.proofStack := #[] }
 
+/-- Record a forall binder FVarId created during optimization. -/
+@[always_inline, inline]
+def pushOptBinder (id : FVarId) : TranslateEnvT Unit :=
+  modify fun env => { env with optEnv.optBinders := env.optEnv.optBinders.push id }
+
+/-- Clear all recorded binder FVarIds. -/
+@[always_inline, inline]
+def clearOptBinders : TranslateEnvT Unit :=
+  modify fun env => { env with optEnv.optBinders := #[] }
+
 @[always_inline, inline]
 def findGlobalCache (a : Expr) : TranslateEnvT (Option Expr) := do
  return (← get).optEnv.globalRewriteCache.get? a
@@ -686,7 +700,7 @@ def mkExpr (a : Expr) (cacheResult := true) : TranslateEnvT Expr := do
 /-- Return `true` only when both hypothesisMap and matchInContext are empty and isRefHyp flag is not set -/
 @[always_inline, inline]
 def isGlobalContext : TranslateEnvT Bool := do
-  let ⟨_, ⟨_, _, _, _, _, _, _, _, hypothesisContext, matchInContext, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, _, _, _, _, _, _, _, hypothesisContext, matchInContext, _, _, _, _, _, _⟩⟩ ← get
   return hypothesisContext.hypothesisMap.size == 0 && matchInContext.size == 0
 
 /-- Perform the following:
@@ -1735,7 +1749,7 @@ where
     An error is triggered if no corresponding entry can be found in `recFunMap`.
 -/
 def hasRecFunInst? (instApp : Expr) : TranslateEnvT (Option Expr) := do
-  let ⟨_, ⟨_, _, _, _, _,recFunInstCache,_,recFunMap, _, _, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, _, _, _, _,recFunInstCache,_,recFunMap, _, _, _, _, _, _, _, _⟩⟩ ← get
   match recFunInstCache.get? instApp with
   | some fbody =>
      -- retrieve function application from recFunMap

--- a/Blaster/Optimize/Env.lean
+++ b/Blaster/Optimize/Env.lean
@@ -88,6 +88,7 @@ inductive MatchEntry where
 /-- A single proof step recorded during expression optimization. -/
 inductive ProofStep where
   | rewrite (proof : Expr) (symm : Bool := false)
+  | exact (proof : Expr)
 deriving Repr
 
 abbrev HypothesisMap := Std.HashMap Lean.Expr Lean.Expr

--- a/Blaster/Optimize/Env.lean
+++ b/Blaster/Optimize/Env.lean
@@ -113,8 +113,8 @@ structure HypothesisContext where
       Given an implication of the form `h : a → b`, the following entries are introduced in this map:
        - `a := h` ∈ hypothesisMap
        - When `a := e₁ ∧ e₂`
-          - e₁ := Blaster.and_left e₁ e₂ h ∈ hypothesisMap
-          - e₂ := Blaster.and_right e₁ e₂ h ∈ hypothesisMap
+          - e₁ := And.left e₁ e₂ h ∈ hypothesisMap
+          - e₂ := And.right e₁ e₂ h ∈ hypothesisMap
       The Map is populated only when Type(a) = Prop.
       The updated Map is considered only when optimizing `b`, which may also be an implication.
       (see `addHypotheses` function and `optimizeForall` rule).

--- a/Blaster/Optimize/Env.lean
+++ b/Blaster/Optimize/Env.lean
@@ -82,6 +82,11 @@ inductive MatchEntry where
   | NotEqPattern
  deriving Repr
 
+/-- A single proof step recorded during expression optimization. -/
+inductive ProofStep where
+  | rewrite (proof : Expr) (symm : Bool := false) (once : Bool := false)
+deriving Repr
+
 abbrev HypothesisMap := Std.HashMap Lean.Expr Lean.Expr
 abbrev RewriteCacheMap := Std.HashMap Lean.Expr Lean.Expr
 abbrev MatchEntryMap := Std.HashMap Lean.Expr MatchEntry -- with key corresponding to a match pattern
@@ -291,6 +296,9 @@ structure OptimizeEnv where
 
   /-- local declaration context -/
   ctx : LocalDeclContext
+
+  /-- Proof steps accumulated during optimization, replayed for proof reconstruction. -/
+  proofStack : Array ProofStep := #[]
 
 instance : Inhabited OptimizeEnv where
   default :=
@@ -611,6 +619,21 @@ def isOptimizeRecCall : TranslateEnvT Bool :=
 def isInFunApp : TranslateEnvT Bool :=
   return (← get).optEnv.options.inFunApp
 
+/-- Push a proof step onto the proof stack. -/
+@[always_inline, inline]
+def pushProofStep (step : ProofStep) : TranslateEnvT Unit :=
+  modify fun env => { env with optEnv.proofStack := env.optEnv.proofStack.push step }
+
+/-- Return the current proof stack. -/
+@[always_inline, inline]
+def getProofStack : TranslateEnvT (Array ProofStep) :=
+  return (← get).optEnv.proofStack
+
+/-- Clear all proof steps from the proof stack. -/
+@[always_inline, inline]
+def clearProofStack : TranslateEnvT Unit :=
+  modify fun env => { env with optEnv.proofStack := #[] }
+
 @[always_inline, inline]
 def findGlobalCache (a : Expr) : TranslateEnvT (Option Expr) := do
  return (← get).optEnv.globalRewriteCache.get? a
@@ -663,7 +686,7 @@ def mkExpr (a : Expr) (cacheResult := true) : TranslateEnvT Expr := do
 /-- Return `true` only when both hypothesisMap and matchInContext are empty and isRefHyp flag is not set -/
 @[always_inline, inline]
 def isGlobalContext : TranslateEnvT Bool := do
-  let ⟨_, ⟨_, _, _, _, _, _, _, _, hypothesisContext, matchInContext, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, _, _, _, _, _, _, _, hypothesisContext, matchInContext, _, _, _, _, _⟩⟩ ← get
   return hypothesisContext.hypothesisMap.size == 0 && matchInContext.size == 0
 
 /-- Perform the following:
@@ -1712,7 +1735,7 @@ where
     An error is triggered if no corresponding entry can be found in `recFunMap`.
 -/
 def hasRecFunInst? (instApp : Expr) : TranslateEnvT (Option Expr) := do
-  let ⟨_, ⟨_, _, _, _, _,recFunInstCache,_,recFunMap, _, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, _, _, _, _,recFunInstCache,_,recFunMap, _, _, _, _, _, _, _⟩⟩ ← get
   match recFunInstCache.get? instApp with
   | some fbody =>
      -- retrieve function application from recFunMap

--- a/Blaster/Optimize/Hypotheses.lean
+++ b/Blaster/Optimize/Hypotheses.lean
@@ -158,8 +158,8 @@ def leqZeroIntInHyps (e : Expr) : TranslateEnvT Bool := do
      Let hMap := hyps.hypothesisMap
       - When Type(e) = Prop:
          - let hMap' := hMap ∪ [ e := h | ¬ ∃ e := h' ∈ hMap ] ∪
-                               [ e₁ := Blaster.and_left e₁ e₂ h | e := e₁ ∧ e₂, ¬ ∃ e₁ := h' ∈ hMap ] ∪
-                               [ e₂ := Blaster.and_right e₁ e₂ h | e := e₁ ∧ e₂, ¬ ∃ e₂ := h' ∈ hMap ]
+                               [ e₁ := And.left e₁ e₂ h | e := e₁ ∧ e₂, ¬ ∃ e₁ := h' ∈ hMap ] ∪
+                               [ e₂ := And.right e₁ e₂ h | e := e₁ ∧ e₂, ¬ ∃ e₂ := h' ∈ hMap ]
 
          - return (hMap' ≠ hMap, {hypothesisMap := hMap', equalityMap := default})
      Otherwise:
@@ -230,7 +230,7 @@ def leqZeroIntInHyps (e : Expr) : TranslateEnvT Bool := do
           - return `some Blaster.int_not_lt_right_of_eq b a p`
 
       - When `e := ¬ (a < b) ∧ Type(a) = Int ∧ b < a := p ∈ h
-          - return `some Blaster.int_not_lt_of_lt b a p`
+          - return `some Int.lt_asymm b a p`
 
       - When `e := ¬ (a < b) ∧ Type(a) = Nat ∧ a = b := p ∈ h
           - return `some Blaster.nat_not_lt_left_of_eq a b p`
@@ -239,7 +239,7 @@ def leqZeroIntInHyps (e : Expr) : TranslateEnvT Bool := do
           - return `some Blaster.nat_not_lt_right_of_eq b a p`
 
       - When `e := ¬ (a < b) ∧ Type(a) = Nat ∧ b < a := p ∈ h
-          - return `some Blaster.nat_not_lt_of_lt b a p`
+          - return `some Nat.lt_asymm b a p`
 
      - When `e := 0 < a ∧ Type(a) = Nat ∧ ¬ 0 = a := p ∈ h
           - return `some Blaster.nat_zero_lt_of_not_zero_eq a p`
@@ -342,7 +342,7 @@ def inHypMap (e : Expr) (h : HypothesisMap) : TranslateEnvT (Option Expr) := do
             - return `some Blaster.int_not_lt_right_of_eq b a p`
 
         - When `e := ¬ (a < b) ∧ Type(a) = Int ∧ b < a := p ∈ h
-            - return `some Blaster.int_not_lt_of_lt b a p`
+            - return `some Int.lt_asymm b a p`
 
         - When `e := ¬ (a < b) ∧ Type(a) = Nat ∧ a = b := p ∈ h
             - return `some Blaster.nat_not_lt_left_of_eq a b p`
@@ -351,7 +351,7 @@ def inHypMap (e : Expr) (h : HypothesisMap) : TranslateEnvT (Option Expr) := do
             - return `some Blaster.nat_not_lt_right_of_eq b a p`
 
         - When `e := ¬ (a < b) ∧ Type(a) = Nat ∧ b < a := p ∈ h
-            - return `some Blaster.nat_not_lt_of_lt b a p`
+            - return `some Nat.lt_asymm b a p`
 
         - Otherwise:
             - return `none`
@@ -367,7 +367,7 @@ def inHypMap (e : Expr) (h : HypothesisMap) : TranslateEnvT (Option Expr) := do
             then return mkApp3 (← mkNat_not_lt_left_of_eq) op1 op2 p
             else return mkApp3 (← mkNat_not_lt_right_of_eq) op2 op1 p
           else if let some p := h.get? (← mkNatLtExpr op2 op1) then
-            return mkApp3 (← mkNat_not_lt_of_lt) op2 op1 p
+            return mkApp3 (← mkNat_lt_asymm) op2 op1 p
           else return none
 
      | Expr.const ``Int _ =>
@@ -377,7 +377,7 @@ def inHypMap (e : Expr) (h : HypothesisMap) : TranslateEnvT (Option Expr) := do
             then return mkApp3 (← mkInt_not_lt_left_of_eq) op1 op2 p
             else return mkApp3 (← mkInt_not_lt_right_of_eq) op2 op1 p
           else if let some p := h.get? (← mkIntLtExpr op2 op1) then
-            return mkApp3 (← mkInt_not_lt_of_lt) op2 op1 p
+            return mkApp3 (← mkInt_lt_asymm) op2 op1 p
           else return none
      | _ => return none
 

--- a/Blaster/Optimize/Lemmas/LemmasDecide.lean
+++ b/Blaster/Optimize/Lemmas/LemmasDecide.lean
@@ -149,5 +149,22 @@ protected theorem bool_or_decide' (p : Prop) (b : Bool) :
   · rintro (hb | hp); exact Or.inr hb.symm; exact Or.inl hp
   · rintro (hp | hb); exact Or.inr hp; exact Or.inl hb.symm
 
+  /-! ## Lemmas validating the `decide'` simplification rules:
+      - `decide' False ==> false`
+      - `decide' True ==> true`
+      - `decide' (true = p) ==> p`
+      - `decide' (false = p) ==> ! p`
+  -/
+protected theorem decide'_false_simp : Blaster.decide' False = false := by
+  simp [Blaster.decide'_false]
+
+protected theorem decide'_true_simp : Blaster.decide' True = true := by
+  simp [Blaster.decide'_true]
+
+protected theorem decide'_true_eq (p : Bool) : Blaster.decide' (true = p) = p := by
+  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
+
+protected theorem decide'_false_eq (p : Bool) : Blaster.decide' (false = p) = ! p := by
+  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
 
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasDecide.lean
+++ b/Blaster/Optimize/Lemmas/LemmasDecide.lean
@@ -149,12 +149,13 @@ protected theorem bool_or_decide' (p : Prop) (b : Bool) :
   · rintro (hb | hp); exact Or.inr hb.symm; exact Or.inl hp
   · rintro (hp | hb); exact Or.inr hp; exact Or.inl hb.symm
 
-  /-! ## Lemmas validating the `decide'` simplification rules:
-      - `decide' False ==> false`
-      - `decide' True ==> true`
-      - `decide' (true = p) ==> p`
-      - `decide' (false = p) ==> ! p`
-  -/
+/-! ## Lemmas validating the `decide'` simplification rules:
+    - `decide' False ==> false`
+    - `decide' True ==> true`
+    - `decide' (true = p) ==> p`
+    - `decide' (false = p) ==> ! p`
+-/
+
 protected theorem decide'_false_simp : Blaster.decide' False = false := by
   simp [Blaster.decide'_false]
 

--- a/Blaster/Optimize/Lemmas/LemmasDecide.lean
+++ b/Blaster/Optimize/Lemmas/LemmasDecide.lean
@@ -1,4 +1,4 @@
-
+import Blaster.Optimize.Decidable
 
 namespace Blaster
 
@@ -101,6 +101,53 @@ protected theorem or_iff_eq_prop_2 : ∀ (a b : Bool), (a || !b) ↔ (true = a �
 protected theorem or_iff_eq_prop_3 : ∀ (a b : Bool), (!a || b) ↔ (false = a ∨ true = b) := by decide
 
 protected theorem or_iff_eq_prop_4 : ∀ (a b : Bool), !(a && b) ↔ (false = a ∨ false = b) := by decide
+
+
+/-! ## Lemmas validating the `decide'` regrouping on Boolean `&&`/`||:`
+      - `(decide' p && decide' q) ==> decide' (p ∧ q)`
+      - `(decide' p && b) | (b && decide' p) ==> decide' (p ∧ true = b)`
+      - `(decide' p || decide' q) ==> decide' (p ∨ q)`
+      - `(decide' p || b) | (b || decide' p) ==> decide' (p ∨ true = b)`
+-/
+
+protected theorem bool_eq_of_iff (b1 b2 : Bool) (h : b1 = true ↔ b2 = true) : b1 = b2 := by
+  cases b1 <;> cases b2 <;> simp_all
+
+protected theorem decide'_and_decide' (p q : Prop) :
+    (Blaster.decide' p && Blaster.decide' q) = Blaster.decide' (p ∧ q) := by
+  apply Blaster.bool_eq_of_iff; simp only [Bool.and_eq_true, Blaster.decide'_true]
+
+protected theorem decide'_and_bool (p : Prop) (b : Bool) :
+    (Blaster.decide' p && b) = Blaster.decide' (p ∧ (true = b)) := by
+  apply Blaster.bool_eq_of_iff; simp only [Bool.and_eq_true, Blaster.decide'_true]
+  constructor
+  · rintro ⟨hp, hb⟩; exact ⟨hp, hb.symm⟩
+  · rintro ⟨hp, hb⟩; exact ⟨hp, hb.symm⟩
+
+protected theorem bool_and_decide' (p : Prop) (b : Bool) :
+    (b && Blaster.decide' p) = Blaster.decide' (p ∧ (true = b)) := by
+  apply Blaster.bool_eq_of_iff; simp only [Bool.and_eq_true, Blaster.decide'_true]
+  constructor
+  · rintro ⟨hb, hp⟩; exact ⟨hp, hb.symm⟩
+  · rintro ⟨hp, hb⟩; exact ⟨hb.symm, hp⟩
+
+protected theorem decide'_or_decide' (p q : Prop) :
+    (Blaster.decide' p || Blaster.decide' q) = Blaster.decide' (p ∨ q) := by
+  apply Blaster.bool_eq_of_iff; simp only [Bool.or_eq_true, Blaster.decide'_true]
+
+protected theorem decide'_or_bool (p : Prop) (b : Bool) :
+    (Blaster.decide' p || b) = Blaster.decide' (p ∨ (true = b)) := by
+  apply Blaster.bool_eq_of_iff; simp only [Bool.or_eq_true, Blaster.decide'_true]
+  constructor
+  · rintro (hp | hb); exact Or.inl hp; exact Or.inr hb.symm
+  · rintro (hp | hb); exact Or.inl hp; exact Or.inr hb.symm
+
+protected theorem bool_or_decide' (p : Prop) (b : Bool) :
+    (b || Blaster.decide' p) = Blaster.decide' (p ∨ (true = b)) := by
+  apply Blaster.bool_eq_of_iff; simp only [Bool.or_eq_true, Blaster.decide'_true]
+  constructor
+  · rintro (hb | hp); exact Or.inr hb.symm; exact Or.inl hp
+  · rintro (hp | hb); exact Or.inr hp; exact Or.inl hb.symm
 
 
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasDecide.lean
+++ b/Blaster/Optimize/Lemmas/LemmasDecide.lean
@@ -157,15 +157,18 @@ protected theorem bool_or_decide' (p : Prop) (b : Bool) :
 -/
 
 protected theorem decide'_false_simp : Blaster.decide' False = false := by
-  simp [Blaster.decide'_false]
+  simp only [decide'_false, not_false_eq_true]
 
 protected theorem decide'_true_simp : Blaster.decide' True = true := by
-  simp [Blaster.decide'_true]
+  simp only [Blaster.decide'_true]
 
 protected theorem decide'_true_eq (p : Bool) : Blaster.decide' (true = p) = p := by
-  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
+  apply Blaster.bool_eq_of_iff ;
+  rw [Blaster.decide'_true, Bool.true_eq]
 
 protected theorem decide'_false_eq (p : Bool) : Blaster.decide' (false = p) = ! p := by
-  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
+  apply Blaster.bool_eq_of_iff;
+  rw [Blaster.decide'_true, Bool.false_eq];
+  exact Bool.coe_false_iff_true.mpr rfl
 
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasInt.lean
+++ b/Blaster/Optimize/Lemmas/LemmasInt.lean
@@ -37,6 +37,57 @@ protected theorem sub_min_int_of_eq (N1 N2 a b : Int) (h : N1 + a = N2 + b) :
     N1 - min N1 N2 + a = N2 - min N1 N2 + b := by
     by_cases h : N1 ≤ N2 <;> simp [Int.min_def, h] <;> omega
 
+protected theorem int_ediv_gcd_norm (N1 N2 x : Int) :
+    N1 * x / N2 = N1 / ↑(N1.gcd N2) * x / (N2 / ↑(N1.gcd N2)) := by
+  rcases Nat.eq_zero_or_pos (N1.gcd N2) with h0 | hpos
+  · rw [Int.gcd_eq_zero_iff] at h0; obtain ⟨rfl, rfl⟩ := h0; simp
+  · have hg : 0 < (↑(N1.gcd N2) : Int) := by exact_mod_cast hpos
+    have h1 : (↑(N1.gcd N2) : Int) ∣ N1 := Int.gcd_dvd_left N1 N2
+    have h2 : (↑(N1.gcd N2) : Int) ∣ N2 := Int.gcd_dvd_right N1 N2
+    generalize (↑(N1.gcd N2) : Int) = g at hg h1 h2 ⊢
+    have hg0 : g ≠ 0 := by omega
+    obtain ⟨a1, rfl⟩ := h1; obtain ⟨a2, rfl⟩ := h2
+    rw [Int.mul_ediv_cancel_left _ hg0, Int.mul_ediv_cancel_left _ hg0,
+        Int.mul_assoc, Int.mul_ediv_mul_of_pos _ _ hg]
+
+protected theorem int_tdiv_gcd_norm (N1 N2 x : Int) :
+    (N1 * x).tdiv N2 = (N1.tdiv ↑(N1.gcd N2) * x).tdiv (N2.tdiv ↑(N1.gcd N2)) := by
+  rcases Nat.eq_zero_or_pos (N1.gcd N2) with h0 | hpos
+  · rw [Int.gcd_eq_zero_iff] at h0; obtain ⟨rfl, rfl⟩ := h0; simp
+  · have hg : 0 < (↑(N1.gcd N2) : Int) := by exact_mod_cast hpos
+    have h1 : (↑(N1.gcd N2) : Int) ∣ N1 := Int.gcd_dvd_left N1 N2
+    have h2 : (↑(N1.gcd N2) : Int) ∣ N2 := Int.gcd_dvd_right N1 N2
+    generalize (↑(N1.gcd N2) : Int) = g at hg h1 h2 ⊢
+    have hg0 : g ≠ 0 := by omega
+    obtain ⟨a1, rfl⟩ := h1; obtain ⟨a2, rfl⟩ := h2
+    rw [Int.mul_tdiv_cancel_left _ hg0, Int.mul_tdiv_cancel_left _ hg0,
+        Int.mul_assoc, Int.mul_tdiv_mul_of_pos _ _ hg]
+
+protected theorem int_fdiv_gcd_norm (N1 N2 x : Int) :
+    (N1 * x).fdiv N2 = (N1.fdiv ↑(N1.gcd N2) * x).fdiv (N2.fdiv ↑(N1.gcd N2)) := by
+  rcases Nat.eq_zero_or_pos (N1.gcd N2) with h0 | hpos
+  · rw [Int.gcd_eq_zero_iff] at h0; obtain ⟨rfl, rfl⟩ := h0; simp
+  · have hg : 0 < (↑(N1.gcd N2) : Int) := by exact_mod_cast hpos
+    have h1 : (↑(N1.gcd N2) : Int) ∣ N1 := Int.gcd_dvd_left N1 N2
+    have h2 : (↑(N1.gcd N2) : Int) ∣ N2 := Int.gcd_dvd_right N1 N2
+    generalize (↑(N1.gcd N2) : Int) = g at hg h1 h2 ⊢
+    have hg0 : g ≠ 0 := by omega
+    obtain ⟨a1, rfl⟩ := h1; obtain ⟨a2, rfl⟩ := h2
+    rw [Int.mul_fdiv_cancel_left _ hg0, Int.mul_fdiv_cancel_left _ hg0,
+        Int.mul_assoc, Int.mul_fdiv_mul_of_pos _ _ hg]
+
+protected theorem int_emod_mul_zero (N1 N2 x : Int) (h : N1 % N2 = 0) : N1 * x % N2 = 0 := by
+  obtain ⟨k, hk⟩ := Int.dvd_of_emod_eq_zero h
+  exact Int.emod_eq_zero_of_dvd ⟨k * x, by rw [hk, Int.mul_assoc]⟩
+
+protected theorem int_tmod_mul_zero (N1 N2 x : Int) (h : N1 % N2 = 0) : (N1 * x).tmod N2 = 0 := by
+  obtain ⟨k, hk⟩ := Int.dvd_of_emod_eq_zero h
+  exact Int.tmod_eq_zero_of_dvd ⟨k * x, by rw [hk, Int.mul_assoc]⟩
+
+protected theorem int_fmod_mul_zero (N1 N2 x : Int) (h : N1 % N2 = 0) : (N1 * x).fmod N2 = 0 := by
+  obtain ⟨k, hk⟩ := Int.dvd_of_emod_eq_zero h
+  exact Int.fmod_eq_zero_of_dvd ⟨k * x, by rw [hk, Int.mul_assoc]⟩
+
 /-- Return `Blaster.int_not_lt_of_lt` const expression and cache result. -/
 def mkInt_not_lt_of_lt : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_lt_of_lt)
 

--- a/Blaster/Optimize/Lemmas/LemmasInt.lean
+++ b/Blaster/Optimize/Lemmas/LemmasInt.lean
@@ -93,6 +93,68 @@ protected theorem int_ne_zero_of_zero_lt {n : Int} (h : 0 < n) : n ≠ 0 := by o
 protected theorem int_ne_zero_of_lt_zero {n : Int} (h : n < 0) : n ≠ 0 := by omega
 protected theorem int_ne_zero_of_not_zero_eq {n : Int} (h : ¬ (0 = n)) : n ≠ 0 := by omega
 
+/-! ## Lemmas validating the `optimizeLT` simplification and normalization rules on `Int` -/
+
+/-! Lemma to validate simplification rule `e < e ==> False`. -/
+protected theorem int_lt_self_eq_false (a : Int) : (a < a) = False :=
+  propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate constant fold `N1 < N2 ==> True (if N1 "<" N2)`. -/
+protected theorem int_lt_eq_true (a b : Int) (h : decide (a < b) = true) : (a < b) = True :=
+  eq_true (of_decide_eq_true h)
+
+/-! Lemma to validate constant fold `N1 < N2 ==> False (if ¬ (N1 "<" N2))`. -/
+protected theorem int_lt_eq_false (a b : Int) (h : decide (a < b) = false) : (a < b) = False :=
+  eq_false (of_decide_eq_false h)
+
+/-! Lemma to validate normalization rule `0 < -e ==> e < 0`. -/
+protected theorem int_zero_lt_neg_eq_lt_zero (a : Int) : (0 < -a) = (a < 0) := propext (by omega)
+
+/-! Lemma to validate simplification rule `N + e < e ==> False (if N > 0)`. -/
+protected theorem int_add_pos_lt_self_eq_false (a n : Int) (h : decide (0 < n) = true) :
+    (n + a < a) = False := by
+  have : 0 < n := of_decide_eq_true h
+  exact propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `N + e < e ==> True (if N < 0)`. -/
+protected theorem int_add_neg_lt_self_eq_true (a n : Int) (h : decide (n < 0) = true) :
+    (n + a < a) = True := by
+  have : n < 0 := of_decide_eq_true h
+  exact propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `e < N + e ==> True (if N > 0)`. -/
+protected theorem int_lt_add_pos_eq_true (a n : Int) (h : decide (0 < n) = true) :
+    (a < n + a) = True := by
+  have : 0 < n := of_decide_eq_true h
+  exact propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `e < N + e ==> False (if N < 0)`. -/
+protected theorem int_lt_add_neg_eq_false (a n : Int) (h : decide (n < 0) = true) :
+    (a < n + a) = False := by
+  have : n < 0 := of_decide_eq_true h
+  exact propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `N1 + a < N2 ==> a < N2 "-" N1`. -/
+protected theorem int_add_const_lt_eq_lt_sub (a n1 n2 : Int) :
+    (n1 + a < n2) = (a < n2 - n1) := propext (by omega)
+
+/-! Lemma to validate simplification rule `N1 < N2 + a ==> N1 "-" N2 < a`. -/
+protected theorem int_const_lt_add_eq_sub_lt (a n1 n2 : Int) :
+    (n1 < n2 + a) = (n1 - n2 < a) := propext (by omega)
+
+/-! Lemma to validate simplification rule
+    `N1 + a < N2 + b ==> N1 "-" min(N1, N2) + a < N2 "-" min(N1, N2) + b`.
+    `m1` and `m2` are the (already reduced) constants `N1 "-" min(N1, N2)` and
+    `N2 "-" min(N1, N2)`, so the reconstructed goal matches the optimizer output literally. -/
+protected theorem int_add_both_lt (a b n1 n2 m1 m2 : Int)
+    (h1 : n1 - min n1 n2 = m1) (h2 : n2 - min n1 n2 = m2) :
+    (n1 + a < n2 + b) = (m1 + a < m2 + b) := by
+  subst h1 h2; exact propext (by omega)
+
+/-! Lemma to validate normalization rule `a < 1 + b ==> ¬ (b < a)`. -/
+protected theorem int_lt_one_add_eq_not_lt (a b : Int) : (a < 1 + b) = (¬ (b < a)) :=
+  propext (by omega)
+
 def mkInt_lt_asymm : TranslateEnvT Expr := mkExpr (mkConst ``Int.lt_asymm)
 
 def mkInt_not_lt_right_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_lt_right_of_eq)

--- a/Blaster/Optimize/Lemmas/LemmasInt.lean
+++ b/Blaster/Optimize/Lemmas/LemmasInt.lean
@@ -155,6 +155,87 @@ protected theorem int_add_both_lt (a b n1 n2 m1 m2 : Int)
 protected theorem int_lt_one_add_eq_not_lt (a b : Int) : (a < 1 + b) = (¬ (b < a)) :=
   propext (by omega)
 
+/-! ## Lemmas validating the hypothesis-context `optimizeLT` reductions on `Int`.
+    Bridges converting the three stored hypothesis forms (`0 < b`, `0 = b`, `¬ (b < 0)`)
+    into the canonical `0 ≤ b` consumed by the reconstruction lemmas below. -/
+protected theorem int_le_of_zero_lt (b : Int) (h : 0 < b) : 0 ≤ b := Int.le_of_lt h
+
+protected theorem int_le_of_zero_eq (b : Int) (h : 0 = b) : 0 ≤ b := Int.le_of_eq h
+
+protected theorem int_le_of_not_lt_zero (b : Int) (h : ¬ (b < 0)) : 0 ≤ b := Int.not_lt.mp h
+
+/-! Lemma to validate simplification rule `a + b < a ==> False (if 0 ≤ b)`. -/
+protected theorem int_add_lt_self_eq_false_of_nonneg (a b : Int) (h : 0 ≤ b) :
+    (a + b < a) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `b + a < a ==> False (if 0 ≤ b)`. -/
+protected theorem int_add_lt_self_right_eq_false_of_nonneg (a b : Int) (h : 0 ≤ b) :
+    (b + a < a) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `a + b < a ==> True (if b < 0)`. -/
+protected theorem int_add_lt_self_eq_true_of_neg (a b : Int) (h : b < 0) :
+    (a + b < a) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `b + a < a ==> True (if b < 0)`. -/
+protected theorem int_add_lt_self_right_eq_true_of_neg (a b : Int) (h : b < 0) :
+    (b + a < a) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Bridges converting the three stored hypothesis forms (`e < 0`, `0 = e`, `¬ (0 < e)`)
+    into the canonical `e ≤ 0` consumed by the reconstruction lemmas below. -/
+protected theorem int_le_zero_of_lt_zero (e : Int) (h : e < 0) : e ≤ 0 := Int.le_of_lt h
+
+protected theorem int_le_zero_of_zero_eq (e : Int) (h : 0 = e) : e ≤ 0 := Int.le_of_eq h.symm
+
+protected theorem int_le_zero_of_not_zero_lt (e : Int) (h : ¬ (0 < e)) : e ≤ 0 := Int.not_lt.mp h
+
+/-! Lemma to validate simplification rule `a < a + b ==> False (if b ≤ 0)`. -/
+protected theorem int_lt_add_self_eq_false_of_nonpos (a b : Int) (h : b ≤ 0) :
+    (a < a + b) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `a < b + a ==> False (if b ≤ 0)`. -/
+protected theorem int_lt_add_self_right_eq_false_of_nonpos (a b : Int) (h : b ≤ 0) :
+    (a < b + a) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `a < a + b ==> True (if 0 < b)`. -/
+protected theorem int_lt_add_self_eq_true_of_pos (a b : Int) (h : 0 < b) :
+    (a < a + b) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `a < b + a ==> True (if 0 < b)`. -/
+protected theorem int_lt_add_self_right_eq_true_of_pos (a b : Int) (h : 0 < b) :
+    (a < b + a) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemmas to validate simplification rule `0 < x + y ==> True / False` from the signs of
+    `x` and `y` in the hypothesis context. -/
+protected theorem int_zero_lt_add_eq_true_of_nonneg_pos (x y : Int) (hx : 0 ≤ x) (hy : 0 < y) :
+    (0 < x + y) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+protected theorem int_zero_lt_add_eq_true_of_pos_nonneg (x y : Int) (hx : 0 < x) (hy : 0 ≤ y) :
+    (0 < x + y) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+protected theorem int_zero_lt_add_eq_false_of_nonpos_neg (x y : Int) (hx : x ≤ 0) (hy : y < 0) :
+    (0 < x + y) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+protected theorem int_zero_lt_add_eq_false_of_neg_nonpos (x y : Int) (hx : x < 0) (hy : y ≤ 0) :
+    (0 < x + y) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemmas to validate simplification rule `x + y < 0 ==> False / True` from the signs of
+    `x` and `y` in the hypothesis context. -/
+protected theorem int_add_lt_zero_eq_false_of_nonneg_pos (x y : Int) (hx : 0 ≤ x) (hy : 0 < y) :
+    (x + y < 0) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+protected theorem int_add_lt_zero_eq_false_of_pos_nonneg (x y : Int) (hx : 0 < x) (hy : 0 ≤ y) :
+    (x + y < 0) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+protected theorem int_add_lt_zero_eq_true_of_nonpos_neg (x y : Int) (hx : x ≤ 0) (hy : y < 0) :
+    (x + y < 0) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+protected theorem int_add_lt_zero_eq_true_of_neg_nonpos (x y : Int) (hx : x < 0) (hy : y ≤ 0) :
+    (x + y < 0) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `N < e ==> False (if ¬ (N - 1 < e))`. -/
+protected theorem int_lt_false_of_not_pred_lt (n e : Int) (h : ¬ (n - 1 < e)) :
+    (n < e) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
 def mkInt_lt_asymm : TranslateEnvT Expr := mkExpr (mkConst ``Int.lt_asymm)
 
 def mkInt_not_lt_right_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_lt_right_of_eq)

--- a/Blaster/Optimize/Lemmas/LemmasInt.lean
+++ b/Blaster/Optimize/Lemmas/LemmasInt.lean
@@ -8,9 +8,6 @@ namespace Blaster
 
 /-! ## Lemmas validating the normalization and simplifications on `Int` -/
 
-protected theorem int_not_lt_of_lt {a b : Int} (h : a < b) : ¬ b < a := by
-  apply (Int.lt_asymm h)
-
 protected theorem int_not_lt_right_of_eq {a b : Int} (h : a = b) : ¬ b < a := by
   apply (Int.not_lt_of_ge (Int.le_of_eq h))
 
@@ -28,10 +25,6 @@ protected theorem int_not_zero_eq_of_lt_zero {a : Int} (h : a < 0) : ¬ 0 = a :=
 
 protected theorem int_not_zero_eq_of_zero_lt {a : Int} (h : 0 < a) : ¬ 0 = a := by
   unfold Not; intro h1; rw [h1] at h; simp at *
-
-protected theorem zero_lt_neg_of_lt_zero {a : Int} (h : a < 0) : 0 < -a := by simp; assumption
-
-protected theorem lt_zero_of_zero_lt_neg {a : Int} (h : 0 < -a) : a < 0 := by simp at *; assumption
 
 protected theorem sub_min_int_of_eq (N1 N2 a b : Int) (h : N1 + a = N2 + b) :
     N1 - min N1 N2 + a = N2 - min N1 N2 + b := by
@@ -88,34 +81,32 @@ protected theorem int_fmod_mul_zero (N1 N2 x : Int) (h : N1 % N2 = 0) : (N1 * x)
   obtain ⟨k, hk⟩ := Int.dvd_of_emod_eq_zero h
   exact Int.fmod_eq_zero_of_dvd ⟨k * x, by rw [hk, Int.mul_assoc]⟩
 
-/-- Return `Blaster.int_not_lt_of_lt` const expression and cache result. -/
-def mkInt_not_lt_of_lt : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_lt_of_lt)
+/-! Lemma to validate normalization rule `e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Int)`. -/
+protected theorem int_le_eq_not_lt (a b : Int) : (a ≤ b) = (¬ (b < a)) :=
+  propext ⟨fun h hlt => absurd (Int.lt_of_lt_of_le hlt h) (Int.lt_irrefl b), Int.not_lt.mp⟩
 
-/-- Return `Blaster.int_not_lt_right_of_eq` const expression and cache result. -/
+/-! Lemma to validate simplification rule `N1 + -(N2 + n) ==> (N1 "-" N2) + -n`. -/
+protected theorem int_add_neg_add (a b c : Int) : a + -(b + c) = (a - b) + -c := by omega
+
+/-! Helpers turning a strict sign hypothesis into `n ≠ 0`. -/
+protected theorem int_ne_zero_of_zero_lt {n : Int} (h : 0 < n) : n ≠ 0 := by omega
+protected theorem int_ne_zero_of_lt_zero {n : Int} (h : n < 0) : n ≠ 0 := by omega
+protected theorem int_ne_zero_of_not_zero_eq {n : Int} (h : ¬ (0 = n)) : n ≠ 0 := by omega
+
+def mkInt_lt_asymm : TranslateEnvT Expr := mkExpr (mkConst ``Int.lt_asymm)
+
 def mkInt_not_lt_right_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_lt_right_of_eq)
 
-/-- Return `Blaster.int_not_lt_left_of_eq` const expression and cache result. -/
 def mkInt_not_lt_left_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_lt_left_of_eq)
 
-/-- Return `Blaster.int_not_eq_of_lt_left` const expression and cache result. -/
 def mkInt_not_eq_of_lt_left : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_eq_of_lt_left)
 
-/-- Return `Blaster.int_not_eq_of_lt_right` const expression and cache result. -/
 def mkInt_not_eq_of_lt_right : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_eq_of_lt_right)
 
-/-- Return `Blaster.int_not_zero_eq_of_lt_zero` const expression and cache result. -/
 def mkInt_not_zero_eq_of_lt_zero : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_zero_eq_of_lt_zero)
 
-/-- Return `Blaster.int_not_zero_eq_of_zero_lt` const expression and cache result. -/
 def mkInt_not_zero_eq_of_zero_lt : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.int_not_zero_eq_of_zero_lt)
 
-/-- Return `Blaster.zero_lt_neg_of_lt_zero` const expression and cache result. -/
-def mkInt_zero_lt_neg_of_lt_zero : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.zero_lt_neg_of_lt_zero)
-
-/-- Return `Blaster.lt_zero_of_zero_lt_neg` const expression and cache result. -/
-def mkInt_lt_zero_of_zero_lt_neg : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.lt_zero_of_zero_lt_neg)
-
-/-- Return `Blaster.sub_min_int_of_eq` const expression and cache result. -/
 def mkInt_sub_min_int_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.sub_min_int_of_eq)
 
 

--- a/Blaster/Optimize/Lemmas/LemmasNat.lean
+++ b/Blaster/Optimize/Lemmas/LemmasNat.lean
@@ -78,6 +78,73 @@ protected theorem nat_mul_mod_of_mod_eq_zero {a b : Nat} (x : Nat)
   have h' : a % b = 0 := by simp [Nat.beq_eq] at h; exact h
   rw [Nat.mul_mod, h', Nat.zero_mul, Nat.zero_mod]
 
+/-! ## Lemmas validating the `optimizeLT` simplification and normalization rules on `Nat` -/
+
+/-! Lemma to validate simplification rule `e < e ==> False`. -/
+protected theorem nat_lt_self_eq_false (a : Nat) : (a < a) = False :=
+  propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate constant fold `N1 < N2 ==> True (if N1 "<" N2)`. -/
+protected theorem nat_lt_eq_true (a b : Nat) (h : decide (a < b) = true) : (a < b) = True :=
+  eq_true (of_decide_eq_true h)
+
+/-! Lemma to validate constant fold `N1 < N2 ==> False (if ¬ (N1 "<" N2))`. -/
+protected theorem nat_lt_eq_false (a b : Nat) (h : decide (a < b) = false) : (a < b) = False :=
+  eq_false (of_decide_eq_false h)
+
+/-! Lemma to validate simplification rule `e < 1 ==> 0 = e`. -/
+protected theorem nat_lt_one_eq_zero_eq (a : Nat) : (a < 1) = (0 = a) :=
+  propext (by omega)
+
+/-! Lemma to validate simplification rule `a + b < a ==> False`. -/
+protected theorem nat_add_lt_self_eq_false (a b : Nat) : (a + b < a) = False :=
+  propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `b + a < a ==> False`. -/
+protected theorem nat_add_lt_self_right_eq_false (a b : Nat) : (b + a < a) = False :=
+  propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `e < N + e ==> True (if N > 0)`. -/
+protected theorem nat_lt_add_left_eq_true (a n : Nat) (h : Nat.ble 1 n = true) :
+    (a < n + a) = True := by
+  have h1 : 1 ≤ n := Nat.le_of_ble_eq_true h
+  exact propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `N1 + a < N2 ==> False (if N2 ≤ N1)`. -/
+protected theorem nat_add_const_lt_eq_false (a n1 n2 : Nat) (h : Nat.ble n2 n1 = true) :
+    (n1 + a < n2) = False := by
+  have : n2 ≤ n1 := Nat.le_of_ble_eq_true h
+  exact propext ⟨fun h => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `N1 + a < N2 ==> a < N2 "-" N1`. -/
+protected theorem nat_add_const_lt_eq_lt_sub (a n1 n2 : Nat) :
+    (n1 + a < n2) = (a < n2 - n1) := propext (by omega)
+
+/-! Lemma to validate simplification rule `N1 < N2 + a ==> True (if N1 < N2)`. -/
+protected theorem nat_const_lt_add_eq_true (a n1 n2 : Nat) (h : Nat.blt n1 n2 = true) :
+    (n1 < n2 + a) = True := by
+  have h1 : n1 < n2 := cast Nat.blt_eq h
+  exact propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `N1 < N2 + a ==> N1 "-" N2 < a (if N1 ≥ N2)`. -/
+protected theorem nat_const_lt_add_eq_sub_lt (a n1 n2 : Nat) (h : Nat.ble n2 n1 = true) :
+    (n1 < n2 + a) = (n1 - n2 < a) := by
+  have : n2 ≤ n1 := Nat.le_of_ble_eq_true h
+  exact propext (by omega)
+
+/-! Lemma to validate simplification rule
+    `N1 + a < N2 + b ==> N1 "-" min(N1, N2) + a < N2 "-" min(N1, N2) + b`.
+    `m1` and `m2` are the (already reduced) constants `N1 "-" min(N1, N2)` and
+    `N2 "-" min(N1, N2)`, so the reconstructed goal matches the optimizer output literally. -/
+protected theorem nat_add_both_lt (a b n1 n2 m1 m2 : Nat)
+    (h1 : n1 - min n1 n2 = m1) (h2 : n2 - min n1 n2 = m2) :
+    (n1 + a < n2 + b) = (m1 + a < m2 + b) := by
+  subst h1 h2; exact propext (by omega)
+
+/-! Lemma to validate normalization rule `a < 1 + b ==> ¬ (b < a)`. -/
+protected theorem nat_lt_one_add_eq_not_lt (a b : Nat) : (a < 1 + b) = (¬ (b < a)) :=
+  propext (by omega)
+
 def mkNat_lt_asymm : TranslateEnvT Expr := mkExpr (mkConst ``Nat.lt_asymm)
 
 def mkNat_not_lt_right_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_lt_right_of_eq)

--- a/Blaster/Optimize/Lemmas/LemmasNat.lean
+++ b/Blaster/Optimize/Lemmas/LemmasNat.lean
@@ -145,6 +145,28 @@ protected theorem nat_add_both_lt (a b n1 n2 m1 m2 : Nat)
 protected theorem nat_lt_one_add_eq_not_lt (a b : Nat) : (a < 1 + b) = (¬ (b < a)) :=
   propext (by omega)
 
+/-! ## Lemmas validating the hypothesis-context `optimizeLT` reductions on `Nat`. -/
+
+/-! Lemma to validate simplification rule `a < a + b ==> False (if 0 = b)`. -/
+protected theorem nat_lt_add_self_eq_false_of_zero_eq (a b : Nat) (h : 0 = b) :
+    (a < a + b) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `a < b + a ==> False (if 0 = b)`. -/
+protected theorem nat_lt_add_self_right_eq_false_of_zero_eq (a b : Nat) (h : 0 = b) :
+    (a < b + a) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
+/-! Lemma to validate simplification rule `a < a + b ==> True (if 0 < b)`. -/
+protected theorem nat_lt_add_self_eq_true_of_zero_lt (a b : Nat) (h : 0 < b) :
+    (a < a + b) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `a < b + a ==> True (if 0 < b)`. -/
+protected theorem nat_lt_add_self_right_eq_true_of_zero_lt (a b : Nat) (h : 0 < b) :
+    (a < b + a) = True := propext ⟨fun _ => trivial, fun _ => by omega⟩
+
+/-! Lemma to validate simplification rule `N < e ==> False (if ¬ (N - 1 < e))`. -/
+protected theorem nat_lt_false_of_not_pred_lt (n e : Nat) (h : ¬ (n - 1 < e)) :
+    (n < e) = False := propext ⟨fun hlt => by omega, False.elim⟩
+
 def mkNat_lt_asymm : TranslateEnvT Expr := mkExpr (mkConst ``Nat.lt_asymm)
 
 def mkNat_not_lt_right_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_lt_right_of_eq)

--- a/Blaster/Optimize/Lemmas/LemmasNat.lean
+++ b/Blaster/Optimize/Lemmas/LemmasNat.lean
@@ -7,26 +7,6 @@ namespace Blaster
 
 /-! ## Lemmas validating the normalization and simplifications rules on `Nat` -/
 
-/-! Lemma to validate the following simplification rules
-      - `N1 - (N2 + n) ===> (N1 "-" N2) - n`.
-      - (n - N1) - N2 ==> n - (N1 "+" N2).
--/
-protected theorem nat_sub_add_eq_sub_sub : ∀ (x y z : Nat), x - (y + z) = (x - y) - z := by
-  intros x y z
-  apply eq_comm.1
-  apply Nat.sub_sub
-
-
-/-! Lemma to validate simplification rule `(N1 - n) - N2 ==> (N1 "-" N2) - n`. -/
-protected theorem nat_sub_assoc : ∀ (x y z : Nat), (x - y) - z = (x - z) - y := by
-  intros x y z
-  have h2 := Nat.sub_sub x y z
-  have h3 := Nat.sub_sub x z y
-  have h4 := Nat.add_comm y z
-  rw [h2]
-  rw [h3]
-  rw [h4]
-
 /-! Lemma to validate simplification rule `(N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)`. -/
 protected theorem nat_add_sub_assoc : ∀ (x y z : Nat), x ≥ z → (x + y) - z = (x - z) + y := by
  intros x y z h1; simp at *
@@ -34,9 +14,6 @@ protected theorem nat_add_sub_assoc : ∀ (x y z : Nat), x ≥ z → (x + y) - z
  rw [Nat.add_comm x y]
  rw [h2]
  rw [Nat.add_comm (x - z) y]
-
-protected theorem nat_not_lt_of_lt {a b : Nat} (h : a < b) : ¬ b < a := by
-  apply (Nat.lt_asymm h)
 
 protected theorem nat_not_lt_right_of_eq {a b : Nat} (h : a = b) : ¬ b < a := by
   apply (Nat.not_lt_of_le (Nat.le_of_eq h))
@@ -59,28 +36,62 @@ protected theorem sub_min_nat_of_eq (N1 N2 a b : Nat) (h : N1 + a = N2 + b) :
     N1 - Nat.min N1 N2 + a = N2 - Nat.min N1 N2 + b := by
     by_cases h : N1 ≤ N2 <;> simp [Nat.min_def, h] <;> omega
 
-/-- Return `Blaster.nat_not_lt_of_lt` const expression and cache result. -/
-def mkNat_not_lt_of_lt : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_lt_of_lt)
+/-! Lemma to validate simplification rule `e < 0 ==> False (if Type(e) = Nat)`. -/
+protected theorem nat_lt_zero_eq_false (a : Nat) : (a < 0) = False :=
+  propext ⟨fun h => Nat.not_lt_zero a h, fun h => h.elim⟩
 
-/-- Return `Blaster.nat_not_lt_right_of_eq` const expression and cache result. -/
+/-! Lemma to validate normalization rule `e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Nat)`. -/
+protected theorem nat_le_eq_not_lt (a b : Nat) : (a ≤ b) = (¬ (b < a)) :=
+  propext ⟨fun h hlt => Nat.lt_irrefl b (Nat.lt_of_lt_of_le hlt h),
+           Nat.le_of_not_lt⟩
+
+/-! Lemma to validate simplification rule `(N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)`. -/
+protected theorem nat_add_sub_of_ble {c a : Nat} (b : Nat) (h : Nat.ble c a = true) :
+    (a + b) - c = (a - c) + b := by
+  have h : c ≤ a := by simpa [Nat.ble] using h
+  simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using Nat.add_sub_assoc h b
+
+/-! Lemma to validate simplification rule
+    `(N1 * n) / N2 ==> ((N1 / g) * n) / (N2 / g)` (with `g = gcd N1 N2`). -/
+protected theorem nat_mul_div_cancel_gcd {a b g : Nat} (x : Nat)
+    (hg : Nat.ble 1 g = true)
+    (ha : Nat.beq (a % g) 0 = true)
+    (hb : Nat.beq (b % g) 0 = true) :
+    (a * x) / b = ((a / g) * x) / (b / g) := by
+  have hg' : 0 < g := by simp [Nat.ble_eq] at hg; omega
+  have ha' : a % g = 0 := by simp [Nat.beq_eq] at ha; exact ha
+  have hb' : b % g = 0 := by simp [Nat.beq_eq] at hb; exact hb
+  have hag : a = a / g * g := (Nat.div_mul_cancel (Nat.dvd_of_mod_eq_zero ha')).symm
+  have hbg : b = b / g * g := (Nat.div_mul_cancel (Nat.dvd_of_mod_eq_zero hb')).symm
+  have key : a / g * g * x / (b / g * g) = a / g * x / (b / g) := by
+    rw [Nat.mul_assoc, Nat.mul_comm g x, ← Nat.mul_assoc]
+    exact Nat.mul_div_mul_right _ _ hg'
+  rw [← hag, ← hbg] at key
+  exact key
+
+/-! Helper turning `¬ (0 = n)` into `0 < n`. -/
+protected theorem nat_pos_of_ne_zero {n : Nat} (h : ¬ (0 = n)) : 0 < n := by omega
+
+/-! Lemma to validate simplification rule `(a * n) % b ==> 0 (if a % b = 0)`. -/
+protected theorem nat_mul_mod_of_mod_eq_zero {a b : Nat} (x : Nat)
+    (h : Nat.beq (a % b) 0 = true) : (a * x) % b = 0 := by
+  have h' : a % b = 0 := by simp [Nat.beq_eq] at h; exact h
+  rw [Nat.mul_mod, h', Nat.zero_mul, Nat.zero_mod]
+
+def mkNat_lt_asymm : TranslateEnvT Expr := mkExpr (mkConst ``Nat.lt_asymm)
+
 def mkNat_not_lt_right_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_lt_right_of_eq)
 
-/-- Return `Blaster.nat_not_lt_left_of_eq` const expression and cache result. -/
 def mkNat_not_lt_left_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_lt_left_of_eq)
 
-/-- Return `Blaster.nat_not_eq_of_lt_left` const expression and cache result. -/
 def mkNat_not_eq_of_lt_left : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_eq_of_lt_left)
 
-/-- Return `Blaster.nat_not_eq_of_lt_right` const expression and cache result.-/
 def mkNat_not_eq_of_lt_right : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_eq_of_lt_right)
 
-/-- Return `Blaster.nat_not_zero_eq_of_zero_lt` const expression and cache result. -/
 def mkNat_not_zero_eq_of_zero_lt : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_not_zero_eq_of_zero_lt)
 
-/-- Return `Blaster.nat_zero_lt_of_not_zero_eq` const expression and cache result. -/
 def mkNat_zero_lt_of_not_zero_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.nat_zero_lt_of_not_zero_eq)
 
-/-- Return `Blaster.sub_min_nat_of_eq` const expression and cache result. -/
 def mkNat_sub_min_nat_of_eq : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.sub_min_nat_of_eq)
 
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasProp.lean
+++ b/Blaster/Optimize/Lemmas/LemmasProp.lean
@@ -37,4 +37,24 @@ protected theorem true_or_false_is_true (a : Bool) :
   apply propext;
   rw [Bool.true_eq, Bool.false_eq, Bool.eq_true_or_eq_false_self]
 
+/-! ## Lemmas validating the `Not` simplification rules:
+  - `¬ (¬ e) ==> e`
+  - `¬ (false = e) ==> true = e`
+  - `¬ (true = e) ==> false = e`
+-/
+protected theorem double_not_classical (p : Prop) : (¬ (¬ p)) = p := by
+  apply propext;
+  exact Classical.not_not
+
+
+protected theorem not_false_is_true (e : Bool) :
+  (¬ (false = e)) = (true = e) := by
+  apply propext;
+  rw [Bool.false_eq, Bool.not_eq_false, Bool.true_eq]
+
+protected theorem not_true_is_false (e : Bool):
+  (¬ (true = e)) = (false = e) := by
+  apply propext;
+  rw [Bool.true_eq, Bool.not_eq_true, Bool.false_eq]
+
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasProp.lean
+++ b/Blaster/Optimize/Lemmas/LemmasProp.lean
@@ -11,14 +11,14 @@ def mkBlasterAndLeft : TranslateEnvT Expr := mkExpr (mkConst ``And.left)
 
 def mkBlasterAndRight : TranslateEnvT Expr := mkExpr (mkConst ``And.right)
 
-  /-! ## Lemmas validating the `And simplfication rules:
-        - `a ∧ ¬ a ==> False`
-        - `true = a ∧ false = a ==> False`
-  -/
-theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
-   simp
+/-! ## Lemmas validating the `And` simplification rules:
+    - `a ∧ ¬ a ==> False`
+    - `true = a ∧ false = a ==> False`
+-/
+protected theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
+  simp
 
-theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
+protected theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
   simp
 
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasProp.lean
+++ b/Blaster/Optimize/Lemmas/LemmasProp.lean
@@ -21,4 +21,14 @@ protected theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
 protected theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
   simp
 
+/-! ## Lemmas validating the `Or` simplification rules:
+    - `a ∨ ¬ a ==> True`
+    - `true = a ∨ false = a ==> True`
+-/
+protected theorem or_not_self_is_true (a : Prop) : (a ∨ ¬ a) = True := by
+  simp [Classical.em]
+
+protected theorem true_or_false_is_false (a : Bool) :(true = a ∨ false = a)  = True := by
+  simp
+
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasProp.lean
+++ b/Blaster/Optimize/Lemmas/LemmasProp.lean
@@ -11,4 +11,14 @@ def mkBlasterAndLeft : TranslateEnvT Expr := mkExpr (mkConst ``And.left)
 
 def mkBlasterAndRight : TranslateEnvT Expr := mkExpr (mkConst ``And.right)
 
+  /-! ## Lemmas validating the `And simplfication rules:
+        - `a ∧ ¬ a ==> False`
+        - `true = a ∧ false = a ==> False`
+  -/
+theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
+   simp
+
+theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
+  simp
+
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasProp.lean
+++ b/Blaster/Optimize/Lemmas/LemmasProp.lean
@@ -5,15 +5,10 @@ open Lean Meta Blaster.Optimize
 
 namespace Blaster
 
-/-! ## Lemmas validating the normalization and simplifications rules on `Prop` -/
+/-! ## Const-expression accessors for the `Prop` simplification rules -/
 
-protected theorem Blaster.and_left {a b : Prop} (h : a ∧ b) : a := by apply (And.left h)
-protected theorem Blaster.and_right {a b : Prop} (h : a ∧ b) : b := by apply (And.right h)
+def mkBlasterAndLeft : TranslateEnvT Expr := mkExpr (mkConst ``And.left)
 
-/-- Return `Blaster.and_left` const expression and cache result. -/
-def mkBlasterAndLeft : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.and_left)
-
-/-- Return `Blaster.and_right` const expression and cache result. -/
-def mkBlasterAndRight : TranslateEnvT Expr := mkExpr (mkConst ``Blaster.and_right)
+def mkBlasterAndRight : TranslateEnvT Expr := mkExpr (mkConst ``And.right)
 
 end Blaster

--- a/Blaster/Optimize/Lemmas/LemmasProp.lean
+++ b/Blaster/Optimize/Lemmas/LemmasProp.lean
@@ -15,20 +15,26 @@ def mkBlasterAndRight : TranslateEnvT Expr := mkExpr (mkConst ``And.right)
     - `a ∧ ¬ a ==> False`
     - `true = a ∧ false = a ==> False`
 -/
-protected theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
-  simp
+protected theorem and_not_self_is_false (a : Prop) :
+  (a ∧ ¬ a) = False := by
+  simp only [and_not_self]
 
-protected theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
-  simp
+protected theorem true_and_false_is_false (a : Bool) :
+  (true = a ∧ false = a) = False := by
+  apply propext
+  rw [Bool.true_eq, Bool.false_eq, Bool.eq_true_and_eq_false_self]
 
 /-! ## Lemmas validating the `Or` simplification rules:
     - `a ∨ ¬ a ==> True`
     - `true = a ∨ false = a ==> True`
 -/
-protected theorem or_not_self_is_true (a : Prop) : (a ∨ ¬ a) = True := by
-  simp [Classical.em]
+protected theorem or_not_self_is_true (a : Prop) :
+  (a ∨ ¬ a) = True := by
+  simp only [Classical.em]
 
-protected theorem true_or_false_is_false (a : Bool) :(true = a ∨ false = a)  = True := by
-  simp
+protected theorem true_or_false_is_true (a : Bool) :
+  (true = a ∨ false = a) = True := by
+  apply propext;
+  rw [Bool.true_eq, Bool.false_eq, Bool.eq_true_or_eq_false_self]
 
 end Blaster

--- a/Blaster/Optimize/OptimizeStack.lean
+++ b/Blaster/Optimize/OptimizeStack.lean
@@ -38,8 +38,10 @@ inductive OptimizeStack where
  | InitOpaqueRecExpr (f : Expr) (args : Array Expr)
  | RecFunDefWaitForStorage (args : Array Expr) (instApp : Expr)
                            (subsInts : Expr) (params : ImplicitParameters)
+                           (recCtx : Option (Array ProofStep))
  | RecFunDefStorage (args : Array Expr) (instApp : Expr)
                     (subsInts : Expr) (params : ImplicitParameters) (optBody : Expr)
+                    (recCtx : Option (Array ProofStep))
  | ForallWaitForType (n : Name) (bi : BinderInfo) (body : Expr)
  | ForallWaitForBody (x : Expr) (t : Expr) (hctx : HypsStackContext) (lctx : LocalDeclContext)
  | AppWaitForConst (args : Array Expr)
@@ -67,7 +69,7 @@ abbrev OptimizeContinuity := Sum (List OptimizeStack) Expr
 
 @[always_inline, inline]
 def mkHypStackContext (h : UpdatedHypContext) : TranslateEnvT HypsStackContext := do
-  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, hypothesisContext, _, _, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, hypothesisContext, _, _, _, _, _, _, _, _⟩⟩ ← get
   if h.1 then
     updateHypothesis h.2 Std.HashMap.emptyWithCapacity
     return {newHCtx := h, oldHCtx := some hypothesisContext, oldCache := some localRewriteCache}
@@ -82,7 +84,7 @@ def resetHypContext (h : HypsStackContext) : TranslateEnvT Unit := do
 
 @[always_inline, inline]
 def mkMatchStackContext (h : MatchContextMap) : TranslateEnvT MatchStackContext := do
-  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, _, matchInContext, _, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, _, matchInContext, _, _, _, _, _, _, _⟩⟩ ← get
   updateMatchContext h Std.HashMap.emptyWithCapacity
   return {oldMatchCtx := matchInContext, oldCache := localRewriteCache}
 
@@ -110,10 +112,10 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
        | [] => return Sum.inr optExpr
        | _ => stackContinuity xs optExpr
 
-  | .RecFunDefWaitForStorage args instApp subsInst params :: xs =>
+  | .RecFunDefWaitForStorage args instApp subsInst params recCtx :: xs =>
        -- optExpr corresponds to optimized rec fun body
        -- continuity with normOpaqueAndRecFun
-       return Sum.inl (.RecFunDefStorage args instApp subsInst params optExpr :: xs)
+       return Sum.inl (.RecFunDefStorage args instApp subsInst params optExpr recCtx :: xs)
 
   | .ForallWaitForType n bi body :: xs =>
        -- optExpr corresponds to optimized forall binder type

--- a/Blaster/Optimize/OptimizeStack.lean
+++ b/Blaster/Optimize/OptimizeStack.lean
@@ -67,7 +67,7 @@ abbrev OptimizeContinuity := Sum (List OptimizeStack) Expr
 
 @[always_inline, inline]
 def mkHypStackContext (h : UpdatedHypContext) : TranslateEnvT HypsStackContext := do
-  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, hypothesisContext, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, hypothesisContext, _, _, _, _, _, _⟩⟩ ← get
   if h.1 then
     updateHypothesis h.2 Std.HashMap.emptyWithCapacity
     return {newHCtx := h, oldHCtx := some hypothesisContext, oldCache := some localRewriteCache}
@@ -82,7 +82,7 @@ def resetHypContext (h : HypsStackContext) : TranslateEnvT Unit := do
 
 @[always_inline, inline]
 def mkMatchStackContext (h : MatchContextMap) : TranslateEnvT MatchStackContext := do
-  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, _, matchInContext, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, _, matchInContext, _, _, _, _, _⟩⟩ ← get
   updateMatchContext h Std.HashMap.emptyWithCapacity
   return {oldMatchCtx := matchInContext, oldCache := localRewriteCache}
 

--- a/Blaster/Optimize/OptimizeStack.lean
+++ b/Blaster/Optimize/OptimizeStack.lean
@@ -67,7 +67,7 @@ abbrev OptimizeContinuity := Sum (List OptimizeStack) Expr
 
 @[always_inline, inline]
 def mkHypStackContext (h : UpdatedHypContext) : TranslateEnvT HypsStackContext := do
-  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, hypothesisContext, _, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, hypothesisContext, _, _, _, _, _, _, _⟩⟩ ← get
   if h.1 then
     updateHypothesis h.2 Std.HashMap.emptyWithCapacity
     return {newHCtx := h, oldHCtx := some hypothesisContext, oldCache := some localRewriteCache}
@@ -82,7 +82,7 @@ def resetHypContext (h : HypsStackContext) : TranslateEnvT Unit := do
 
 @[always_inline, inline]
 def mkMatchStackContext (h : MatchContextMap) : TranslateEnvT MatchStackContext := do
-  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, _, matchInContext, _, _, _, _, _⟩⟩ ← get
+  let ⟨_, ⟨_, localRewriteCache, _, _, _, _, _, _, _, matchInContext, _, _, _, _, _, _⟩⟩ ← get
   updateMatchContext h Std.HashMap.emptyWithCapacity
   return {oldMatchCtx := matchInContext, oldCache := localRewriteCache}
 
@@ -120,6 +120,11 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
        -- continuity with optimizing forall body
        withLocalContext $ do
          withLocalDecl' n bi optExpr fun x => do
+           -- Record binder only for top-level foralls (not nested inside another forall's type).
+           -- A nested forall has another ForallWaitForType directly below on the stack.
+           match xs with
+           | .ForallWaitForType .. :: _ => pure ()
+           | _ => pushOptBinder x.fvarId!
            let body' := instantiate1' body x
            let isNotPropBody := !(← isPropEnv body')
            let hyps ← addHypotheses optExpr x isNotPropBody

--- a/Blaster/Optimize/Rewriting/OptimizeApp.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeApp.lean
@@ -138,6 +138,145 @@ def normPartialFun? (f : Expr) (args : Array Expr) : TranslateEnvT (Option Expr)
      | Expr.const ``Blaster.dite' _ => args.size > 4
      | _ => false
 
+/-- Try to rewrite a goal with a single expression.
+    Returns the new goal if the rewrite succeeded, or the original goal unchanged. -/
+private def tryRewriteStep (g : MVarId) (proof : Expr) : MetaM MVarId := do
+  if ← g.isAssigned then return g
+  try
+    let r ← g.rewrite (← g.getType) proof
+    let g' ← g.replaceTargetEq r.eNew r.eqProof
+    try g'.refl; return g' catch _ => pure ()
+    return g'
+  catch _ => return g
+
+/-- Close an induction subgoal for recursive function equivalence.
+    Strategy: unfold head definitions → rewrite with IH → commutativity → refl.
+    Falls back to `admit` if unable to close. -/
+private def closeInductionSubgoal (sg : MVarId) : MetaM Unit := do
+  if ← sg.isAssigned then return
+  try sg.refl; return catch _ => pure ()
+  -- Unfold head definitions on both sides to expose recursive structure
+  let g ← sg.withContext do
+    try
+      let ty ← sg.getType
+      if let some (_, lhs, rhs) := ty.eq? then
+        let lhsU ← unfoldDefinition? lhs
+        let rhsU ← unfoldDefinition? rhs
+        let lhs' := lhsU.getD lhs
+        let rhs' := rhsU.getD rhs
+        if lhs' != lhs || rhs' != rhs then
+          let newTy ← mkEq lhs' rhs'
+          let g' ← sg.change newTy
+          try g'.refl catch _ => pure ()
+          pure g'
+        else pure sg
+      else pure sg
+    catch _ => pure sg
+  if ← g.isAssigned then return
+  -- Rewrite with all propositional hypotheses (including induction hypothesis)
+  let g ← g.withContext do
+    let lctx ← getLCtx
+    let decls := lctx.foldl (init := #[]) fun acc decl =>
+      if decl.isImplementationDetail then acc else acc.push decl
+    let mut g : MVarId := g
+    for decl in decls do
+      if ← g.isAssigned then return g
+      if !(← isProp decl.type) then continue
+      g ← tryRewriteStep g decl.toExpr
+      if ← g.isAssigned then return g
+    return g
+  if ← g.isAssigned then return
+  -- Apply commutativity lemmas
+  let g ← g.withContext do
+    let mut g : MVarId := g
+    for commName in #[``Int.mul_comm, ``Nat.mul_comm, ``Int.add_comm, ``Nat.add_comm] do
+      if ← g.isAssigned then return g
+      g ← tryRewriteStep g (mkConst commName)
+      if ← g.isAssigned then return g
+    return g
+  if ← g.isAssigned then return
+  -- Second pass: retry hypotheses after commutativity may have changed the goal
+  let g ← g.withContext do
+    let lctx ← getLCtx
+    let decls := lctx.foldl (init := #[]) fun acc decl =>
+      if decl.isImplementationDetail then acc else acc.push decl
+    let mut g : MVarId := g
+    for decl in decls do
+      if ← g.isAssigned then return g
+      if !(← isProp decl.type) then continue
+      g ← tryRewriteStep g decl.toExpr
+      if ← g.isAssigned then return g
+    return g
+  unless ← g.isAssigned do g.admit
+
+/-- Prove `uf args = rf args` by structural induction.
+    Abstracts all free variables, inducts on the last inductive-type parameter,
+    and closes subgoals via unfold + IH + commutativity.
+    Falls back to `admit` for subgoals that cannot be closed. -/
+private def proveRecFunEquiv (ufApp rfApp : Expr) : MetaM Expr := do
+  let eq ← mkEq ufApp rfApp
+  -- Collect all free variables, sorted by dependency
+  let fvarIds ← do
+    let s := collectFVars {} eq
+    sortFVarIds s.fvarSet.toArray
+  let allFvars := fvarIds.map mkFVar
+  if allFvars.isEmpty then
+    let proof ← mkFreshExprMVar eq
+    try proof.mvarId!.refl catch _ => proof.mvarId!.admit
+    return proof
+  -- Find the last parameter with an inductive type (the recursion parameter)
+  let mut inductIdx? : Option Nat := none
+  for h : i in [:allFvars.size] do
+    let fvarId := allFvars[i].fvarId!
+    try
+      let ty ← fvarId.getType
+      if let .const tyName _ := ty.getAppFn then
+        if let some (.inductInfo _) := (← getEnv).find? tyName then
+          inductIdx? := some i
+    catch _ => continue
+  -- Abstract over all fvars so the mvar type is closed
+  let forallType ← mkForallFVars allFvars eq
+  let proof ← mkFreshExprMVar forallType
+  let goalId := proof.mvarId!
+  let (introFVarIds, goalId) ← goalId.introNP allFvars.size
+  match inductIdx? with
+  | none =>
+    unless ← goalId.isAssigned do goalId.admit
+  | some idx =>
+    try
+      goalId.withContext do
+        let inductFVarId := introFVarIds[idx]!
+        let ty ← inductFVarId.getType
+        let .const tyName _ := ty.getAppFn
+          | goalId.admit; return
+        let results ← goalId.induction inductFVarId (Name.mkStr tyName "rec")
+        for result in results do
+          closeInductionSubgoal result.mvarId
+        for result in results do
+          unless ← result.mvarId.isAssigned do result.mvarId.admit
+    catch _ =>
+      unless ← goalId.isAssigned do goalId.admit
+  -- Instantiate the universally quantified proof with the original fvars
+  return mkAppN proof allFvars
+
+/-- Emit a rewrite proof step for recursive function equivalence.
+    Skips trivially equal applications. For non-trivial cases, proves
+    `uf args = rf args` by induction and pushes the proof as a rewrite step. -/
+private def emitRecFunEquivStep
+    (uf rf : Expr) (uargs : Array Expr)
+    : TranslateEnvT Unit := do
+  let ufApp := mkAppN uf uargs
+  let rfApp := mkAppN rf uargs
+  -- Skip when both sides are definitionally equal
+  try if ← isDefEq ufApp rfApp then return catch _ => pure ()
+  try
+    let ufTy ← inferType ufApp
+    let rfTy ← inferType rfApp
+    if ← isDefEq ufTy rfTy then
+      let proof ← withLocalContext (proveRecFunEquiv ufApp rfApp)
+      pushProofStep (.rewrite proof)
+  catch _ => pure ()
+
 /-- Given application `f x₁ ... xₙ` perform the following:
     - when `f` corresponds to a recursive definition `λ p₁ ... pₙ → body` the following actions are performed:
         - params ← getImplicitParameters f #[x₁ ... xₙ]
@@ -286,6 +425,7 @@ def normOpaqueAndRecFun (s : OptimizeStack) (xs : List OptimizeStack) :
          -- case when a polymorphic/non-polymorphic function is equivalent to another non-polymorphic one
          let eargs := Array.filterMap (λ p => if !p.isInstance then some p.effectiveArg else none) params
          -- trace[Optimize.recFun.app] "non-polymorphic equivalent case {reprStr rf} {reprStr eargs}"
+         emitRecFunEquivStep uf rf uargs
          optimizeApp rf eargs xs
      else
        let auxApp := rf.beta (← getEffectiveParams params)
@@ -294,10 +434,12 @@ def normOpaqueAndRecFun (s : OptimizeStack) (xs : List OptimizeStack) :
          let appCall := getLambdaBody auxApp
          let (f, largs) := getAppFnWithArgs appCall
          -- trace[Optimize.recFun.app] "partially applied case {reprStr appCall.getAppFn'} {reprStr largs[0:largs.size-auxApp.getNumHeadLambdas]}"
+         emitRecFunEquivStep uf rf uargs
          optimizeApp f (largs.take (largs.size-auxApp.getNumHeadLambdas)) xs
        else
          -- trace[Optimize.recFun.app] "polymorphic equivalent case {reprStr auxApp.getAppFn'} {reprStr auxApp.getAppArgs}"
          let (f, args) := getAppFnWithArgs auxApp
+         emitRecFunEquivStep uf rf uargs
          optimizeApp f args xs
 
 initialize

--- a/Blaster/Optimize/Rewriting/OptimizeApp.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeApp.lean
@@ -150,30 +150,66 @@ private def tryRewriteStep (g : MVarId) (proof : Expr) : MetaM MVarId := do
   catch _ => return g
 
 /-- Close an induction subgoal for recursive function equivalence.
-    Strategy: unfold head definitions → rewrite with IH → commutativity → refl.
-    Falls back to `admit` if unable to close. -/
-private def closeInductionSubgoal (sg : MVarId) : MetaM Unit := do
+    Leaves the goal unassigned if unable to close. -/
+private def closeInductionSubgoal (sg : MVarId)
+    (ufSteps rfSteps : Array ProofStep) : MetaM Unit := do
   if ← sg.isAssigned then return
   try sg.refl; return catch _ => pure ()
-  -- Unfold head definitions on both sides to expose recursive structure
+  -- Iteratively unfold head definitions on both sides
   let g ← sg.withContext do
-    try
-      let ty ← sg.getType
-      if let some (_, lhs, rhs) := ty.eq? then
-        let lhsU ← unfoldDefinition? lhs
-        let rhsU ← unfoldDefinition? rhs
-        let lhs' := lhsU.getD lhs
-        let rhs' := rhsU.getD rhs
-        if lhs' != lhs || rhs' != rhs then
-          let newTy ← mkEq lhs' rhs'
-          let g' ← sg.change newTy
-          try g'.refl catch _ => pure ()
-          pure g'
-        else pure sg
-      else pure sg
-    catch _ => pure sg
+    let mut g := sg
+    let mut progress := true
+    while progress do
+      progress := false
+      if ← g.isAssigned then return g
+      try
+        let ty ← g.getType
+        match ty.eq? with
+        | some (_, lhs, rhs) =>
+          let lhsU ← unfoldDefinition? lhs
+          let rhsU ← unfoldDefinition? rhs
+          let lhs' := lhsU.getD lhs
+          let rhs' := rhsU.getD rhs
+          if lhs' != lhs || rhs' != rhs then
+            let newTy ← mkEq lhs' rhs'
+            g ← g.change newTy
+            try g.refl; return g catch _ => pure ()
+            progress := true
+        | none => pure ()
+      catch _ => pure ()
+    return g
   if ← g.isAssigned then return
-  -- Rewrite with all propositional hypotheses (including induction hypothesis)
+  -- uf local steps
+  let g ← g.withContext do
+    let mut g := g
+    for step in ufSteps do
+      if ← g.isAssigned then return g
+      match step with
+      | .rewrite proof _ =>
+        g ← tryRewriteStep g proof
+      | .exact _ => pure ()
+    return g
+  if ← g.isAssigned then return
+  -- rf local steps (both directions)
+  let g ← g.withContext do
+    let mut g := g
+    for step in rfSteps do
+      if ← g.isAssigned then return g
+      match step with
+      | .rewrite proof _ =>
+        g ← tryRewriteStep g proof
+        if ← g.isAssigned then return g
+        try
+          let r ← g.rewrite (← g.getType) proof (symm := true)
+          let g' ← g.replaceTargetEq r.eNew r.eqProof
+          try g'.refl; return g' catch _ => pure ()
+          g := g'
+        catch _ => pure ()
+      | .exact _ => pure ()
+    return g
+  if ← g.isAssigned then return
+  try g.refl; return catch _ => pure ()
+  -- Rewrite with hypotheses
   let g ← g.withContext do
     let lctx ← getLCtx
     let decls := lctx.foldl (init := #[]) fun acc decl =>
@@ -186,7 +222,7 @@ private def closeInductionSubgoal (sg : MVarId) : MetaM Unit := do
       if ← g.isAssigned then return g
     return g
   if ← g.isAssigned then return
-  -- Apply commutativity lemmas
+  -- Commutativity lemmas
   let g ← g.withContext do
     let mut g : MVarId := g
     for commName in #[``Int.mul_comm, ``Nat.mul_comm, ``Int.add_comm, ``Nat.add_comm] do
@@ -195,27 +231,24 @@ private def closeInductionSubgoal (sg : MVarId) : MetaM Unit := do
       if ← g.isAssigned then return g
     return g
   if ← g.isAssigned then return
-  -- Second pass: retry hypotheses after commutativity may have changed the goal
-  let g ← g.withContext do
+  -- Retry hypotheses after commutativity
+  g.withContext do
     let lctx ← getLCtx
     let decls := lctx.foldl (init := #[]) fun acc decl =>
       if decl.isImplementationDetail then acc else acc.push decl
     let mut g : MVarId := g
     for decl in decls do
-      if ← g.isAssigned then return g
+      if ← g.isAssigned then return
       if !(← isProp decl.type) then continue
       g ← tryRewriteStep g decl.toExpr
-      if ← g.isAssigned then return g
-    return g
-  unless ← g.isAssigned do g.admit
+      if ← g.isAssigned then return
 
-/-- Prove `uf args = rf args` by structural induction.
-    Abstracts all free variables, inducts on the last inductive-type parameter,
-    and closes subgoals via unfold + IH + commutativity.
+/-- Prove `uf = rf` by structural induction, universally quantified over free variables.
+    Returns the forall-quantified proof so that `rewrite` can unify with any instantiation.
     Falls back to `admit` for subgoals that cannot be closed. -/
-private def proveRecFunEquiv (ufApp rfApp : Expr) : MetaM Expr := do
+private def proveRecFunEquiv (ufApp rfApp : Expr)
+    (ufSteps rfSteps : Array ProofStep := #[]) : MetaM Expr := do
   let eq ← mkEq ufApp rfApp
-  -- Collect all free variables, sorted by dependency
   let fvarIds ← do
     let s := collectFVars {} eq
     sortFVarIds s.fvarSet.toArray
@@ -224,7 +257,6 @@ private def proveRecFunEquiv (ufApp rfApp : Expr) : MetaM Expr := do
     let proof ← mkFreshExprMVar eq
     try proof.mvarId!.refl catch _ => proof.mvarId!.admit
     return proof
-  -- Find the last parameter with an inductive type (the recursion parameter)
   let mut inductIdx? : Option Nat := none
   for h : i in [:allFvars.size] do
     let fvarId := allFvars[i].fvarId!
@@ -234,7 +266,6 @@ private def proveRecFunEquiv (ufApp rfApp : Expr) : MetaM Expr := do
         if let some (.inductInfo _) := (← getEnv).find? tyName then
           inductIdx? := some i
     catch _ => continue
-  -- Abstract over all fvars so the mvar type is closed
   let forallType ← mkForallFVars allFvars eq
   let proof ← mkFreshExprMVar forallType
   let goalId := proof.mvarId!
@@ -251,31 +282,59 @@ private def proveRecFunEquiv (ufApp rfApp : Expr) : MetaM Expr := do
           | goalId.admit; return
         let results ← goalId.induction inductFVarId (Name.mkStr tyName "rec")
         for result in results do
-          closeInductionSubgoal result.mvarId
+          closeInductionSubgoal result.mvarId ufSteps rfSteps
         for result in results do
           unless ← result.mvarId.isAssigned do result.mvarId.admit
     catch _ =>
       unless ← goalId.isAssigned do goalId.admit
-  -- Instantiate the universally quantified proof with the original fvars
-  return mkAppN proof allFvars
+  return proof
+
+/-- Retrieve the local proof stack for a function from recFunInstCache.
+    Returns empty array if not found. -/
+private def getRecFunLocalProofStack (f : Expr) (args : Array Expr)
+    : TranslateEnvT (Array ProofStep) := do
+  let cache := (← get).optEnv.recFunInstCache
+  try
+    let params ← getImplicitParameters f args
+    let instApp ← getInstApp f params
+    match cache.get? instApp with
+    | some result => return result.proofStack
+    | none =>
+      match cache.get? f with
+      | some result => return result.proofStack
+      | none => return #[]
+  catch _ => return #[]
 
 /-- Emit a rewrite proof step for recursive function equivalence.
-    Skips trivially equal applications. For non-trivial cases, proves
-    `uf args = rf args` by induction and pushes the proof as a rewrite step. -/
+    Retrieves local proof stacks from recFunInstCache and uses them
+    to close induction subgoals. -/
 private def emitRecFunEquivStep
     (uf rf : Expr) (uargs : Array Expr)
     : TranslateEnvT Unit := do
   let ufApp := mkAppN uf uargs
   let rfApp := mkAppN rf uargs
-  -- Skip when both sides are definitionally equal
   try if ← isDefEq ufApp rfApp then return catch _ => pure ()
+  let ufSteps ← getRecFunLocalProofStack uf uargs
+  let rfSteps ← getRecFunLocalProofStack rf uargs
   try
     let ufTy ← inferType ufApp
     let rfTy ← inferType rfApp
     if ← isDefEq ufTy rfTy then
-      let proof ← withLocalContext (proveRecFunEquiv ufApp rfApp)
-      pushProofStep (.rewrite proof)
+      let proof ← withLocalContext do proveRecFunEquiv ufApp rfApp ufSteps rfSteps
+      let proof ← instantiateMVars proof
+      unless containsSorry proof do
+        pushProofStep (.rewrite proof)
   catch _ => pure ()
+where
+  containsSorry : Expr → Bool
+    | .const ``sorryAx _ => true
+    | .app f a => containsSorry f || containsSorry a
+    | .lam _ t b _ => containsSorry t || containsSorry b
+    | .forallE _ t b _ => containsSorry t || containsSorry b
+    | .letE _ t v b _ => containsSorry t || containsSorry v || containsSorry b
+    | .mdata _ e => containsSorry e
+    | .proj _ _ e => containsSorry e
+    | _ => false
 
 /-- Given application `f x₁ ... xₙ` perform the following:
     - when `f` corresponds to a recursive definition `λ p₁ ... pₙ → body` the following actions are performed:

--- a/Blaster/Optimize/Rewriting/OptimizeApp.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeApp.lean
@@ -191,14 +191,20 @@ def normOpaqueAndRecFun (s : OptimizeStack) (xs : List OptimizeStack) :
             -- trace[Optimize.recFun] "generalizing rec body for {n} got {reprStr fdef}"
             let subsInst ← opaqueInstApp uf uargs isOpaqueRec instApp
             -- optimize recursive fun definition and store
-            return Sum.inl (.InitOptimizeExpr fdef :: .RecFunDefWaitForStorage uargs instApp subsInst params :: xs)
+            let recCtx ← mkRecFuncStackContext
+            updateLocalProofStack #[]
+            return Sum.inl
+              (.InitOptimizeExpr
+                fdef :: .RecFunDefWaitForStorage uargs instApp subsInst params recCtx :: xs)
       else optimizeApp uf uargs xs -- optimizations on opaque functions
 
-  | .RecFunDefStorage uargs instApp subsInst params optDef =>
+  | .RecFunDefStorage uargs instApp subsInst params optDef recCtx =>
         uncacheFunName instApp
         -- trace[Optimize.recFun] "optimized rec body for {reprStr subsInst} got {reprStr optDef}"
-        let fn' ← storeRecFunDef subsInst params optDef
+        let localStack := (← get).optEnv.localProofStack
+        let fn' ← storeRecFunDef subsInst params optDef localStack
         -- trace[Optimize.recFun] "rec function instance {reprStr subsInst} is equivalent to {reprStr fn'}"
+        restoreRecFunStackContext recCtx
         optimizeRecApp subsInst fn' uargs params xs
 
   | _ => throwEnvError "normOpaqueAndRecFun: unexpected continuity {reprStr s} !!!"

--- a/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
@@ -83,10 +83,10 @@ def optimizeBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   return none
 
 /-- Apply the following simplification/normalization rules on `or` :
-     - false || e ==> e
-     - true || e ==> true
+     - false || e ==> e                                                                      [proof: Bool.or_false]
+     - true || e ==> true                                                                    [proof: Bool.or_true]
      - e || not e ==> true
-     - e1 || e2 ==> e1 (if e1 =ₚₜᵣ e2)
+     - e1 || e2 ==> e1 (if e1 =ₚₜᵣ e2)                                                        [proof: Bool.or_self]
      - e1 || e2 ===> true (if true = e1 := _ ∈ hypothesisContext.hypothesisMap)
      - e1 || e2 ===> true (if true = e2 := _ ∈ hypothesisContext.hypothesisMap)
      - e1 || e2 ===> e2 (if ∃ e := _ ∈ hypothesisContext.hypothesisMap, e = false = e1)

--- a/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
@@ -27,8 +27,8 @@ namespace Blaster.Optimize
   return none
 
 /-- Apply the following simplification/normalization rules on `and` :
-     - false && e ==> false                                                                  [proof: Bool.and_false]
-     - true && e ==> e                                                                       [proof: Bool.and_true]
+     - false && e ==> false                                                                  [proof: Bool.false_and]
+     - true && e ==> e                                                                       [proof: Bool.true_and]
      - e && not e ==> false
      - e1 && e2 ==> e1 (if e1 =ₚₜᵣ e2)                                                        [proof: Bool.and_self]
      - e1 && e2 ===> e2 (if true = e1 := _ ∈ hypothesisContext.hypothesisMap)
@@ -49,10 +49,10 @@ def optimizeBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  if let Expr.const ``false _ := op1 then
-   pushProofStep (.rewrite (mkConst ``Bool.and_false))
+   pushProofStep (.rewrite (mkConst ``Bool.false_and))
    return op1
  if let Expr.const ``true _ := op1 then
-   pushProofStep (.rewrite (mkConst ``Bool.and_true))
+   pushProofStep (.rewrite (mkConst ``Bool.true_and))
    return op2
  if exprEq op1 op2 then
    pushProofStep (.rewrite (mkConst ``Bool.and_self))
@@ -83,8 +83,8 @@ def optimizeBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   return none
 
 /-- Apply the following simplification/normalization rules on `or` :
-     - false || e ==> e                                                                      [proof: Bool.or_false]
-     - true || e ==> true                                                                    [proof: Bool.or_true]
+     - false || e ==> e                                                                      [proof: Bool.false_or]
+     - true || e ==> true                                                                    [proof: Bool.true_or]
      - e || not e ==> true
      - e1 || e2 ==> e1 (if e1 =ₚₜᵣ e2)                                                        [proof: Bool.or_self]
      - e1 || e2 ===> true (if true = e1 := _ ∈ hypothesisContext.hypothesisMap)
@@ -105,10 +105,10 @@ def optimizeBoolOr (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  if let Expr.const ``false _ := op1 then
-   pushProofStep (.rewrite (mkConst ``Bool.or_false))
+   pushProofStep (.rewrite (mkConst ``Bool.false_or))
    return op2
  if let Expr.const ``true _ := op1 then
-   pushProofStep (.rewrite (mkConst ``Bool.or_true))
+   pushProofStep (.rewrite (mkConst ``Bool.true_or))
    return op1
  if exprEq op1 op2 then
    pushProofStep (.rewrite (mkConst ``Bool.or_self))

--- a/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
@@ -29,7 +29,7 @@ namespace Blaster.Optimize
 /-- Apply the following simplification/normalization rules on `and` :
      - false && e ==> false                                                                  [proof: Bool.false_and]
      - true && e ==> e                                                                       [proof: Bool.true_and]
-     - e && not e ==> false
+     - e && not e ==> false                                                                  [proof: Bool.and_not_self]
      - e1 && e2 ==> e1 (if e1 =ₚₜᵣ e2)                                                        [proof: Bool.and_self]
      - e1 && e2 ===> e2 (if true = e1 := _ ∈ hypothesisContext.hypothesisMap)
      - e1 && e2 ===> e1 (if true = e2 := _ ∈ hypothesisContext.hypothesisMap)
@@ -57,7 +57,9 @@ def optimizeBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if exprEq op1 op2 then
    pushProofStep (.rewrite (mkConst ``Bool.and_self))
    return op1
- if isBoolNotExprOf op2 op1 then return (← mkBoolFalse)
+ if isBoolNotExprOf op2 op1 then
+   pushProofStep (.rewrite (mkConst ``Bool.and_not_self))
+   return (← mkBoolFalse)
  if let some r ← andBoolReduction? op1 op2 then return r
  -- no caching at this level as optimizeBoolAnd is called by optimizeDecideBoolAnd
  return mkApp2 f op1 op2
@@ -85,7 +87,7 @@ def optimizeBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
 /-- Apply the following simplification/normalization rules on `or` :
      - false || e ==> e                                                                      [proof: Bool.false_or]
      - true || e ==> true                                                                    [proof: Bool.true_or]
-     - e || not e ==> true
+     - e || not e ==> true                                                                   [proof: Bool.or_not_self]
      - e1 || e2 ==> e1 (if e1 =ₚₜᵣ e2)                                                        [proof: Bool.or_self]
      - e1 || e2 ===> true (if true = e1 := _ ∈ hypothesisContext.hypothesisMap)
      - e1 || e2 ===> true (if true = e2 := _ ∈ hypothesisContext.hypothesisMap)

--- a/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
@@ -27,10 +27,10 @@ namespace Blaster.Optimize
   return none
 
 /-- Apply the following simplification/normalization rules on `and` :
-     - false && e ==> false
-     - true && e ==> e
+     - false && e ==> false                                                                  [proof: Bool.and_false]
+     - true && e ==> e                                                                       [proof: Bool.and_true]
      - e && not e ==> false
-     - e1 && e2 ==> e1 (if e1 =ₚₜᵣ e2)
+     - e1 && e2 ==> e1 (if e1 =ₚₜᵣ e2)                                                        [proof: Bool.and_self]
      - e1 && e2 ===> e2 (if true = e1 := _ ∈ hypothesisContext.hypothesisMap)
      - e1 && e2 ===> e1 (if true = e2 := _ ∈ hypothesisContext.hypothesisMap)
      - e1 && e2 ===> false (if ∃ e := _ ∈ hypothesisContext.hypothesisMap, e = false = e1)
@@ -48,9 +48,15 @@ def optimizeBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeBoolAnd: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let Expr.const ``false _ := op1 then return op1
- if let Expr.const ``true _ := op1 then return op2
- if exprEq op1 op2 then return op1
+ if let Expr.const ``false _ := op1 then
+   pushProofStep (.rewrite (mkConst ``Bool.and_false))
+   return op1
+ if let Expr.const ``true _ := op1 then
+   pushProofStep (.rewrite (mkConst ``Bool.and_true))
+   return op2
+ if exprEq op1 op2 then
+   pushProofStep (.rewrite (mkConst ``Bool.and_self))
+   return op1
  if isBoolNotExprOf op2 op1 then return (← mkBoolFalse)
  if let some r ← andBoolReduction? op1 op2 then return r
  -- no caching at this level as optimizeBoolAnd is called by optimizeDecideBoolAnd
@@ -98,10 +104,18 @@ def optimizeBoolOr (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeBoolOr: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let Expr.const ``false _ := op1 then return op2
- if let Expr.const ``true _ := op1 then return op1
- if exprEq op1 op2 then return op1
- if isBoolNotExprOf op2 op1 then return (← mkBoolTrue)
+ if let Expr.const ``false _ := op1 then
+   pushProofStep (.rewrite (mkConst ``Bool.or_false))
+   return op2
+ if let Expr.const ``true _ := op1 then
+   pushProofStep (.rewrite (mkConst ``Bool.or_true))
+   return op1
+ if exprEq op1 op2 then
+   pushProofStep (.rewrite (mkConst ``Bool.or_self))
+   return op1
+ if isBoolNotExprOf op2 op1 then
+   pushProofStep (.rewrite (mkConst ``Bool.or_not_self))
+   return (← mkBoolTrue)
  if let some r ← orBoolReduction? op1 op2 then return r
  -- no caching at this level as optimizeBoolAnd is called by optimizeDecideBoolOr
  return mkApp2 f op1 op2

--- a/Blaster/Optimize/Rewriting/OptimizeBoolNot.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolNot.lean
@@ -17,8 +17,8 @@ def notDecideProp? (op : Expr) : TranslateEnvT (Option Expr) := do
  return mkApp op.getAppFn (mkApp (← mkPropNotOp) e)
 
 /-- Apply the following simplification/normalization rules on `not` :
-     - ! true ==> false
-     - ! false ==> true
+     - ! true ==> false                 [proof: Bool.not_true]
+     - ! false ==> true                 [proof: Bool.not_false]
      - ! (! e) ==> e
      - !(decide' e) ==> decide' (¬ e)
    Assume that f = Expr.const ``not.
@@ -29,8 +29,12 @@ def optimizeBoolNot (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 1 then throwEnvError "optimizeBoolNot: exactly one argument expected"
  let op := args[0]!
  match op with
- | Expr.const ``true _ => mkBoolFalse
- | Expr.const ``false _ => mkBoolTrue
+ | Expr.const ``true _ =>
+    pushProofStep (.rewrite (mkConst ``Bool.not_true))
+    mkBoolFalse
+ | Expr.const ``false _ =>
+    pushProofStep (.rewrite (mkConst ``Bool.not_false))
+    mkBoolTrue
  | _ =>
     if let some e := boolNot? op then return e
     if let some r ← notDecideProp? op then return r

--- a/Blaster/Optimize/Rewriting/OptimizeBoolNot.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolNot.lean
@@ -19,7 +19,7 @@ def notDecideProp? (op : Expr) : TranslateEnvT (Option Expr) := do
 /-- Apply the following simplification/normalization rules on `not` :
      - ! true ==> false                 [proof: Bool.not_true]
      - ! false ==> true                 [proof: Bool.not_false]
-     - ! (! e) ==> e
+     - ! (! e) ==> e                    [proof: Bool.not_not]
      - !(decide' e) ==> decide' (¬ e)
    Assume that f = Expr.const ``not.
    An error is triggered if args.size ≠ 1 (i.e., only fully applied `not` expected at this stage)
@@ -36,7 +36,9 @@ def optimizeBoolNot (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
     pushProofStep (.rewrite (mkConst ``Bool.not_false))
     mkBoolTrue
  | _ =>
-    if let some e := boolNot? op then return e
+    if let some e := boolNot? op then
+      pushProofStep (.rewrite (mkConst ``Bool.not_not))
+      return e
     if let some r ← notDecideProp? op then return r
     return (mkApp f op)
 

--- a/Blaster/Optimize/Rewriting/OptimizeDecide.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeDecide.lean
@@ -1,20 +1,9 @@
 import Lean
 import Blaster.Optimize.Rewriting.Utils
+import Blaster.Optimize.Lemmas.LemmasDecide
 
 open Lean Meta Elab
 namespace Blaster.Optimize
-
-theorem decide'_false_simp : Blaster.decide' False = false := by
-  simp [Blaster.decide'_false]
-
-theorem decide'_true_simp : Blaster.decide' True = true := by
-  simp [Blaster.decide'_true]
-
-theorem decide'_true_eq (p : Bool) : Blaster.decide' (true = p) = p := by
-  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
-
-theorem decide'_false_eq (p : Bool) : Blaster.decide' (false = p) = ! p := by
-  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
 
 /-- Apply the following simplification/normalization rules on `Blaster.decide'`:
       - decide' False ==> false      [proof: decide'_false_simp]
@@ -28,10 +17,10 @@ def optimizeDecideCore (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   -- args[0] proposition
   let p := args[0]!
   if let Expr.const ``False _ := p then
-    pushProofStep (.rewrite (mkConst ``decide'_false_simp))
+    pushProofStep (.rewrite (mkConst ``Blaster.decide'_false_simp))
     return (← mkBoolFalse)
   if let Expr.const ``True _ := p then
-    pushProofStep (.rewrite (mkConst ``decide'_true_simp))
+    pushProofStep (.rewrite (mkConst ``Blaster.decide'_true_simp))
     return (← mkBoolTrue)
   if let some r ← decideBoolEq? p then return r
   return mkApp f p
@@ -44,10 +33,10 @@ where
   decideBoolEq? (e : Expr) : TranslateEnvT (Option Expr) := do
    match eq? e with
    | some (_, Expr.const ``true _, p) =>
-    pushProofStep (.rewrite (mkConst ``decide'_true_eq))
+    pushProofStep (.rewrite (mkConst ``Blaster.decide'_true_eq))
     return (some p)
    | some (_, Expr.const ``false _, p) =>
-    pushProofStep (.rewrite (mkConst ``decide'_false_eq))
+    pushProofStep (.rewrite (mkConst ``Blaster.decide'_false_eq))
     return (mkApp (← mkBoolNotOp) p)
    | _ => return none
 

--- a/Blaster/Optimize/Rewriting/OptimizeDecide.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeDecide.lean
@@ -15,8 +15,12 @@ def optimizeDecideCore (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   if args.size != 1 then throwEnvError "optimizeDecideCore: one argument expected but got {reprStr args}"
   -- args[0] proposition
   let p := args[0]!
-  if let Expr.const ``False _ := p then return (← mkBoolFalse)
-  if let Expr.const ``True _ := p then return (← mkBoolTrue)
+  if let Expr.const ``False _ := p then
+    pushProofStep (.rewrite (mkConst ``decide_false))
+    return (← mkBoolFalse)
+  if let Expr.const ``True _ := p then
+    pushProofStep (.rewrite (mkConst ``decide_true))
+    return (← mkBoolTrue)
   if let some r ← decideBoolEq? p then return r
   return mkApp f p
 
@@ -27,8 +31,12 @@ where
   -/
   decideBoolEq? (e : Expr) : TranslateEnvT (Option Expr) := do
    match eq? e with
-   | some (_, Expr.const ``true _, p) => return (some p)
-   | some (_, Expr.const ``false _, p) => return (mkApp (← mkBoolNotOp) p)
+   | some (_, Expr.const ``true _, p) =>
+    pushProofStep (.rewrite (mkConst ``Blaster.decide'_true))
+    return (some p)
+   | some (_, Expr.const ``false _, p) =>
+    pushProofStep (.rewrite (mkConst ``Blaster.decide'_false))
+    return (mkApp (← mkBoolNotOp) p)
    | _ => return none
 
 /-- Apply simplification/normalization rules on `Blaster.decide'`. -/

--- a/Blaster/Optimize/Rewriting/OptimizeDecide.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeDecide.lean
@@ -6,10 +6,10 @@ open Lean Meta Elab
 namespace Blaster.Optimize
 
 /-- Apply the following simplification/normalization rules on `Blaster.decide'`:
-      - decide' False ==> false      [proof: decide'_false_simp]
-      - decide' True ==> true        [proof: decide'_true_simp]
-      - decide' (true = p) ==> p     [proof: decide'_true_eq]
-      - decide' (false = p) ==> ! p  [proof: decide'_false_eq]
+      - decide' False ==> false      [proof: Blaster.decide'_false_simp]
+      - decide' True ==> true        [proof: Blaster.decide'_true_simp]
+      - decide' (true = p) ==> p     [proof: Blaster.decide'_true_eq]
+      - decide' (false = p) ==> ! p  [proof: Blaster.decide'_false_eq]
     An error is trigerred if args.size ≠ 2.
 -/
 def optimizeDecideCore (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do

--- a/Blaster/Optimize/Rewriting/OptimizeDecide.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeDecide.lean
@@ -4,11 +4,23 @@ import Blaster.Optimize.Rewriting.Utils
 open Lean Meta Elab
 namespace Blaster.Optimize
 
+theorem decide'_false_simp : Blaster.decide' False = false := by
+  simp [Blaster.decide'_false]
+
+theorem decide'_true_simp : Blaster.decide' True = true := by
+  simp [Blaster.decide'_true]
+
+theorem decide'_true_eq (p : Bool) : Blaster.decide' (true = p) = p := by
+  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
+
+theorem decide'_false_eq (p : Bool) : Blaster.decide' (false = p) = ! p := by
+  cases p <;> simp [Blaster.decide'_true, Blaster.decide'_false]
+
 /-- Apply the following simplification/normalization rules on `Blaster.decide'`:
-      - decide' False ==> false
-      - decide' True ==> true
-      - decide' (true = p) ==> p
-      - decide' (false = p) ==> ! p
+      - decide' False ==> false      [proof: decide'_false_simp]
+      - decide' True ==> true        [proof: decide'_true_simp]
+      - decide' (true = p) ==> p     [proof: decide'_true_eq]
+      - decide' (false = p) ==> ! p  [proof: decide'_false_eq]
     An error is trigerred if args.size ≠ 2.
 -/
 def optimizeDecideCore (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
@@ -16,10 +28,10 @@ def optimizeDecideCore (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   -- args[0] proposition
   let p := args[0]!
   if let Expr.const ``False _ := p then
-    pushProofStep (.rewrite (mkConst ``decide_false))
+    pushProofStep (.rewrite (mkConst ``decide'_false_simp))
     return (← mkBoolFalse)
   if let Expr.const ``True _ := p then
-    pushProofStep (.rewrite (mkConst ``decide_true))
+    pushProofStep (.rewrite (mkConst ``decide'_true_simp))
     return (← mkBoolTrue)
   if let some r ← decideBoolEq? p then return r
   return mkApp f p
@@ -32,10 +44,10 @@ where
   decideBoolEq? (e : Expr) : TranslateEnvT (Option Expr) := do
    match eq? e with
    | some (_, Expr.const ``true _, p) =>
-    pushProofStep (.rewrite (mkConst ``Blaster.decide'_true))
+    pushProofStep (.rewrite (mkConst ``decide'_true_eq))
     return (some p)
    | some (_, Expr.const ``false _, p) =>
-    pushProofStep (.rewrite (mkConst ``Blaster.decide'_false))
+    pushProofStep (.rewrite (mkConst ``decide'_false_eq))
     return (mkApp (← mkBoolNotOp) p)
    | _ => return none
 

--- a/Blaster/Optimize/Rewriting/OptimizeDecideBoolBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeDecideBoolBinary.lean
@@ -1,28 +1,52 @@
 import Lean
 import Blaster.Optimize.Rewriting.OptimizeBoolBinary
+import Blaster.Optimize.Lemmas.LemmasDecide
 
 
 open Lean Meta
 namespace Blaster.Optimize
 
+/-- Data type for distinguishing between the two Boolean binary operators handled by
+    `decideOpDecide?` (`and` and `or`), used to select the matching regrouping lemma. -/
+inductive BoolBinOpKind where
+  | and
+  | or
 
 /-- Given `op1` and `op2` corresponding to the operands for a Boolean binary operator:
     - return `some (decide' (mkOpExpr #[e1, e2]))` when `op1 := decide' e1 ∧ op2 := decide' e2`
     - return `some (decide' (mkOpExpr #[e1, true = e2]))` when `op1 := decide' e1 ∧ op2 := e2`
     - return `some (decide' (mkOpExpr #[e1, true = e2]))` when `op1 := e2 ∧ op2 := decide' e1`
     Otherwise `none`.
+
+    `k` selects the operator (`and`/`or`) so the emitted proof step uses the matching
+    regrouping lemma.
 -/
 def decideOpDecide?
   (op1 : Expr) (op2 : Expr)
-  (mkOpExpr : Expr → Expr → Expr) : TranslateEnvT (Option Expr) := do
+  (mkOpExpr : Expr → Expr → Expr) (k : BoolBinOpKind) : TranslateEnvT (Option Expr) := do
   match decide'? op1, decide'? op2 with
   | some e1, some e2 =>
+      -- `(decide' e1 <op> decide' e2) = decide' (e1 <∧/∨> e2)`
+      let lemma := match k with
+        | BoolBinOpKind.and => ``Blaster.decide'_and_decide'
+        | BoolBinOpKind.or  => ``Blaster.decide'_or_decide'
+      pushProofStep (.rewrite (mkApp2 (mkConst lemma) e1 e2))
       setRestart
       return mkApp (← mkBlasterDecideConst) (mkOpExpr e1 e2)
   | some e1, _ =>
+      -- `(decide' e1 <op> op2) = decide' (e1 <∧/∨> (true = op2))`
+      let lemma := match k with
+        | BoolBinOpKind.and => ``Blaster.decide'_and_bool
+        | BoolBinOpKind.or  => ``Blaster.decide'_or_bool
+      pushProofStep (.rewrite (mkApp2 (mkConst lemma) e1 op2))
       setRestart
       return mkApp (← mkBlasterDecideConst) (mkOpExpr e1 (mkApp3 (← mkEqOp) (← mkBoolType) (← mkBoolTrue) op2))
   | _, some e1 =>
+      -- `(op1 <op> decide' e1) = decide' (e1 <∧/∨> (true = op1))`
+      let lemma := match k with
+        | BoolBinOpKind.and => ``Blaster.bool_and_decide'
+        | BoolBinOpKind.or  => ``Blaster.bool_or_decide'
+      pushProofStep (.rewrite (mkApp2 (mkConst lemma) e1 op1))
       setRestart
       return mkApp (← mkBlasterDecideConst) (mkOpExpr e1 (mkApp3 (← mkEqOp) (← mkBoolType) (← mkBoolTrue) op1))
   | _, _ => return none
@@ -42,7 +66,7 @@ def decideOpDecide?
 def optimizeDecideBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let e ← optimizeBoolAnd f args
  let some (op1, op2) := boolAnd? e | return e
- if let some r ← decideOpDecide? op1 op2 (mkApp2 (← mkPropAndOp)) then return r
+ if let some r ← decideOpDecide? op1 op2 (mkApp2 (← mkPropAndOp)) BoolBinOpKind.and then return r
  return e
 
 /-- Call `optimizeBoolOr f args` and apply the following `decide` simplification/normalization
@@ -61,7 +85,7 @@ def optimizeDecideBoolAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr :=
 def optimizeDecideBoolOr (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let e ← optimizeBoolOr f args
  let some (op1, op2) := boolOr? e | return e
- if let some r ← decideOpDecide? op1 op2 (mkApp2 (← mkPropOrOp)) then return r
+ if let some r ← decideOpDecide? op1 op2 (mkApp2 (← mkPropOrOp)) BoolBinOpKind.or then return r
  return e
 
 

--- a/Blaster/Optimize/Rewriting/OptimizeEq.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeEq.lean
@@ -363,7 +363,11 @@ def optimizeEq (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
     return mkApp (← mkPropNotOp) op2
  if let Expr.const ``True _ := op1 then return op2
  if isNotExprOf op2 op1 || isBoolNotExprOf op2 op1 then return ← mkPropFalse
- if exprEq op1 op2 then return ← mkPropTrue
+ if exprEq op1 op2 then
+  let lvl ← mkFreshLevelMVar
+  pushProofStep (.rewrite (mkConst ``eq_self [lvl]))
+  pushProofStep (.exact (mkConst ``True.intro))
+  return ← mkPropTrue
  if let some false ← structEq? op1 op2 then return ← mkPropFalse
  if let some (e1, e2) ← notNegEqSimp? op1 op2 then return mkApp3 f eqType e1 e2
  if let some r ← zeroEqNegReduce? op1 op2 eqType then return r

--- a/Blaster/Optimize/Rewriting/OptimizeEq.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeEq.lean
@@ -368,7 +368,12 @@ def optimizeEq (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
   pushProofStep (.rewrite (mkConst ``eq_self [lvl]))
   pushProofStep (.exact (mkConst ``True.intro))
   return ← mkPropTrue
- if let some false ← structEq? op1 op2 then return ← mkPropFalse
+ if let some false ← structEq? op1 op2 then
+   try
+     let notEq ← mkDecideProof (mkApp (mkConst ``Not) (← mkEq op1 op2))
+     pushProofStep (.rewrite (← mkAppM ``eq_false #[notEq]))
+   catch _ => pure ()
+   return ← mkPropFalse
  if let some (e1, e2) ← notNegEqSimp? op1 op2 then return mkApp3 f eqType e1 e2
  if let some r ← zeroEqNegReduce? op1 op2 eqType then return r
  if let some (e1, e2) ← intNegEqReduce? op1 op2 then return mkApp3 f eqType e1 e2

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -159,6 +159,16 @@ def mulIntDivReduceExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) :
      return none
   | none => return none
 
+/--
+  Data type to distinguish between the three integer division operators:
+   - `Int.ediv`
+   - `Int.tdiv`
+   - `Int.fdiv`
+-/
+inductive DivKind where
+  | ediv
+  | tdiv
+  | fdiv
 
 /-- Given `op1` and `op2` corresponding to the operands for `Int.ediv`, `Int.tdiv` and `Int.fdiv`,
     try to apply the following simplification rules:
@@ -176,11 +186,26 @@ def mulIntDivReduceExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) :
                m < 0 := _ ∈ hypothesisContext.hypothesisMap)
 -/
 @[always_inline, inline]
-def optimizeIntDivCommon (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+def optimizeIntDivCommon (d: DivKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  match isIntValue? op1, isIntValue? op2 with
- | _, some (Int.ofNat 0) => return op2
- | _, some (Int.ofNat 1)
- | some (Int.ofNat 0), _ => return op1
+ | _, some (Int.ofNat 0) =>
+  match d with
+  | DivKind.ediv => pushProofStep (.rewrite (mkConst ``Int.ediv_zero))
+  | DivKind.tdiv => pushProofStep (.rewrite (mkConst ``Int.tdiv_zero))
+  | DivKind.fdiv => pushProofStep (.rewrite (mkConst ``Int.fdiv_zero))
+  return op2
+ | _, some (Int.ofNat 1) =>
+  match d with
+  | DivKind.ediv => pushProofStep (.rewrite (mkConst ``Int.ediv_one))
+  | DivKind.tdiv => pushProofStep (.rewrite (mkConst ``Int.tdiv_one))
+  | DivKind.fdiv => pushProofStep (.rewrite (mkConst ``Int.fdiv_one))
+  return op1
+ | some (Int.ofNat 0), _ =>
+  match d with
+  | DivKind.ediv => pushProofStep (.rewrite (mkConst ``Int.zero_ediv))
+  | DivKind.tdiv => pushProofStep (.rewrite (mkConst ``Int.zero_tdiv))
+  | DivKind.fdiv => pushProofStep (.rewrite (mkConst ``Int.zero_fdiv))
+  return op1
  | some n1, some n2 => evalBinIntOp Int.ediv n1 n2
  | _, _ =>
    if let some r ← intDivSelfReduce? op1 op2 then return r
@@ -209,9 +234,9 @@ def cstCommonDivProp?
 
 
 /-- Apply the following simplification/normalization rules on `Int.ediv`:
-     - n / 0 ==> 0
-     - n / 1 ==> n
-     - 0 / n ==> 0
+     - n / 0 ==> 0                                              [proof: Int.ediv_zero]
+     - n / 1 ==> n                                              [proof: Int.ediv_one]
+     - 0 / n ==> 0                                              [proof: Int.zero_ediv]
      - N1 / N2 ==> N1 "/ₑ" N2
      - n / n ==> 1
          (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
@@ -229,7 +254,7 @@ def optimizeIntEDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntEDiv: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntDivCommon op1 op2 then return r
+ if let some r ← optimizeIntDivCommon DivKind.ediv op1 op2 then return r
  if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.ediv then return mkApp2 f op1' op2'
  return (mkApp2 f op1 op2)
 
@@ -249,6 +274,17 @@ def intModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      return none
   | none => return none
 
+
+/- Data type for distinguishing between the three integer modulus operators:
+   - `Int.emod`
+   - `Int.tmod`
+   - `Int.fmod`
+-/
+inductive ModKind where
+  | emod
+  | tmod
+  | fmod
+
 /--  Given `op1` and `op2` corresponding to the operands for `Int.emod`, `Int.fmod` and `Int.tmod`,
      try to apply the following simplification rules:
      - n % 0 ==> n
@@ -260,11 +296,26 @@ def intModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      - (m * n) % m | (n * m) % m ==> 0
 -/
 @[always_inline, inline]
-def optimizeIntModCommon (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+def optimizeIntModCommon (m : ModKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  match isIntValue? op1, isIntValue? op2 with
- | _, some (Int.ofNat 0) => return op1
- | _, some (Int.ofNat 1) => mkIntLitExpr (Int.ofNat 0)
- | some (Int.ofNat 0), _ => return op1
+ | _, some (Int.ofNat 0) =>
+  match m with
+  | ModKind.emod => pushProofStep (.rewrite (mkConst ``Int.emod_zero))
+  | ModKind.tmod => pushProofStep (.rewrite (mkConst ``Int.tmod_zero))
+  | ModKind.fmod => pushProofStep (.rewrite (mkConst ``Int.fmod_zero))
+  return op1
+ | _, some (Int.ofNat 1) =>
+  match m with
+  | ModKind.emod => pushProofStep (.rewrite (mkConst ``Int.emod_one))
+  | ModKind.tmod => pushProofStep (.rewrite (mkConst ``Int.tmod_one))
+  | ModKind.fmod => pushProofStep (.rewrite (mkConst ``Int.fmod_one))
+  mkIntLitExpr (Int.ofNat 0)
+ | some (Int.ofNat 0), _ =>
+  match m with
+  | ModKind.emod => pushProofStep (.rewrite (mkConst ``Int.zero_emod))
+  | ModKind.tmod => pushProofStep (.rewrite (mkConst ``Int.zero_tmod))
+  | ModKind.fmod => pushProofStep (.rewrite (mkConst ``Int.zero_fmod))
+  return op1
  | some n1, some n2 => evalBinIntOp Int.emod n1 n2
  | _, nv2 =>
    if let some r ← cstModProp? op1 nv2 then return r
@@ -288,9 +339,9 @@ def optimizeIntModCommon (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr)
     | _, _ => return none
 
 /-- Apply the following simplification/normalization rules on `Int.emod` :
-     - n % 0 ==> n
-     - n % 1 ==> 0
-     - 0 % n ==> 0
+     - n % 0 ==> n                            [proof: Int.emod_zero]
+     - n % 1 ==> 0                            [proof: Int.emod_one]
+     - 0 % n ==> 0                            [proof: Int.zero_emod]
      - N1 % N2 ==> N1 "%" N2
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
      - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)
@@ -303,13 +354,13 @@ def optimizeIntEMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntEMod: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntModCommon op1 op2 then return r
+ if let some r ← optimizeIntModCommon ModKind.emod op1 op2 then return r
  return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Int.tdiv`:
-     - n / 0 ==> 0
-     - n / 1 ==> n
-     - 0 / n ==> 0
+     - n / 0 ==> 0                                              [proof: Int.tdiv_zero]
+     - n / 1 ==> n                                              [proof: Int.tdiv_one]
+     - 0 / n ==> 0                                              [proof: Int.zero_tdiv]
      - N1 / N2 ==> N1 "/" N2
      - n / n ==> 1
          (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
@@ -328,7 +379,7 @@ def optimizeIntTDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntTDiv: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntDivCommon op1 op2 then return r
+ if let some r ← optimizeIntDivCommon DivKind.tdiv op1 op2 then return r
  if let some r ← cstTDivProp? op1 op2 then return r
  if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.tdiv then return mkApp2 f op1' op2'
  else return (mkApp2 f op1 op2)
@@ -347,9 +398,9 @@ def optimizeIntTDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      | _, _ => return none
 
 /-- Apply the following simplification/normalization rules on `Int.tmod` :
-     - n % 0 ==> n
-     - n % 1 ==> 0
-     - 0 % n ==> 0
+     - n % 0 ==> n              [proof: Int.tmod_zero]
+     - n % 1 ==> 0              [proof: Int.tmod_one]
+     - 0 % n ==> 0              [proof: Int.zero_tmod]
      - N1 % N2 ==> N1 "%" N2
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
      - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)
@@ -362,13 +413,13 @@ def optimizeIntTMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntTMod: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntModCommon op1 op2 then return r
+ if let some r ← optimizeIntModCommon ModKind.tmod op1 op2 then return r
  return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Int.fdiv`:
-     - n / 0 ==> 0
-     - n / 1 ==> n
-     - 0 / n ==> 0
+     - n / 0 ==> 0                                        [proof: Int.fdiv_zero]
+     - n / 1 ==> n                                        [proof: Int.fdiv_one]
+     - 0 / n ==> 0                                        [proof: Int.zero_fdiv]
      - N1 / N2 ==> N1 "/" N2
      - n / n ==> 1
          (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
@@ -386,14 +437,14 @@ def optimizeIntFDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntFDiv: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntDivCommon op1 op2 then return r
+ if let some r ← optimizeIntDivCommon DivKind.fdiv op1 op2 then return r
  if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.fdiv then return mkApp2 f op1' op2'
  return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Int.fmod` :
-     - n % 0 ==> n
-     - n % 1 ==> 0
-     - 0 % n ==> 0
+     - n % 0 ==> n                          [proof: Int.fmod_zero]
+     - n % 1 ==> 0                          [proof: Int.fmod_one]
+     - 0 % n ==> 0                          [proof: Int.zero_fmod]
      - N1 % N2 ==> N1 "%" N2
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
      - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)
@@ -406,7 +457,7 @@ def optimizeIntFMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntFMod: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntModCommon op1 op2 then return r
+ if let some r ← optimizeIntModCommon ModKind.fmod op1 op2 then return r
  return (mkApp2 f op1 op2)
 
 

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -283,12 +283,17 @@ def optimizeIntDivCommon (d: DivKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT 
 -/
 @[always_inline, inline]
 def cstCommonDivProp?
-  (op1 : Expr) (op2 : Expr) (f_div : Int -> Int -> Int) : TranslateEnvT (Option (Expr × Expr)) := do
+  (op1 : Expr) (op2 : Expr) (dk : DivKind) : TranslateEnvT (Option (Expr × Expr)) := do
  let some (n, e1) := intMul? op1 | return none
  match isIntValue? n, isIntValue? op2 with
  | some n1, some n2 =>
     let gcd := Int.gcd n1 n2
     if gcd == 1 then return none
+    let (f_div, lemma) := match dk with
+      | DivKind.ediv => (Int.ediv, ``Blaster.int_ediv_gcd_norm)
+      | DivKind.tdiv => (Int.tdiv, ``Blaster.int_tdiv_gcd_norm)
+      | DivKind.fdiv => (Int.fdiv, ``Blaster.int_fdiv_gcd_norm)
+    pushProofStep (.rewrite (mkApp3 (mkConst lemma) n op2 e1))
     setRestart
     let mulExpr := mkApp2 (← mkIntMulOp) (← evalBinIntOp f_div n1 gcd) e1
     return (mulExpr, (← evalBinIntOp f_div n2 gcd))
@@ -318,7 +323,7 @@ def optimizeIntEDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  if let some r ← optimizeIntDivCommon DivKind.ediv op1 op2 then return r
- if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.ediv then return mkApp2 f op1' op2'
+ if let some (op1', op2') ← cstCommonDivProp? op1 op2 DivKind.ediv then return mkApp2 f op1' op2'
  return (mkApp2 f op1 op2)
 
 /-- Given `e1` and `e2` corresponding to the operands for `Int.emod`, `Int.fmod` and `Int.tmod`,
@@ -381,7 +386,9 @@ def optimizeIntModCommon (m : ModKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT
   return op1
  | some n1, some n2 => evalBinIntOp Int.emod n1 n2
  | _, nv2 =>
-   if let some r ← cstModProp? op1 nv2 then return r
+   if let some r ← cstModProp? op1 nv2 then
+     emitModGcdZeroProofStep m op1 op2
+     return r
    if let some r ← intModToZeroExpr? op1 op2 then
      if let ModKind.emod := m then emitEModToZeroProofStep op1 op2
      return r
@@ -398,6 +405,18 @@ def optimizeIntModCommon (m : ModKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT
          pushProofStep (.rewrite (mkConst ``Int.mul_emod_right))
        else if exprEq b op2 then
          pushProofStep (.rewrite (mkConst ``Int.mul_emod_left))
+
+   /-- Emit the proof step for (N1 * n) % N2 ==> 0 (when N1 % N2 = 0). The `N1 % N2 = 0`
+       hypothesis holds by reflexivity on the constant operands. -/
+   emitModGcdZeroProofStep (m : ModKind) (op1 op2 : Expr) : TranslateEnvT Unit := do
+     let some (n, e1) := intMul? op1 | return ()
+     let hZero :=
+        mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Int) (← mkIntLitExpr (Int.ofNat 0))
+     let lemma := match m with
+       | ModKind.emod => ``Blaster.int_emod_mul_zero
+       | ModKind.tmod => ``Blaster.int_tmod_mul_zero
+       | ModKind.fmod => ``Blaster.int_fmod_mul_zero
+     pushProofStep (.rewrite (mkApp4 (mkConst lemma) n op2 e1 hZero))
 
    /- Given `op1` and `mv2`, return `some 0`
       when `op1 := N1 * n ∧ mv2 := N2 ∧ N1 % N2 = 0`
@@ -458,7 +477,7 @@ def optimizeIntTDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op2 := args[1]!
  if let some r ← optimizeIntDivCommon DivKind.tdiv op1 op2 then return r
  if let some r ← cstTDivProp? op1 op2 then return r
- if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.tdiv then return mkApp2 f op1' op2'
+ if let some (op1', op2') ← cstCommonDivProp? op1 op2 DivKind.tdiv then return mkApp2 f op1' op2'
  else return (mkApp2 f op1 op2)
 
  where
@@ -515,7 +534,7 @@ def optimizeIntFDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  if let some r ← optimizeIntDivCommon DivKind.fdiv op1 op2 then return r
- if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.fdiv then return mkApp2 f op1' op2'
+ if let some (op1', op2') ← cstCommonDivProp? op1 op2 DivKind.fdiv then return mkApp2 f op1' op2'
  return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Int.fmod` :

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -9,6 +9,17 @@ namespace Blaster.Optimize
 
 theorem int_add_neg_add (a b c : Int) : a + -(b + c) = (a - b) + -c := by omega
 
+/-- Return `true` when `e` corresponds to the zero int literal. -/
+@[always_inline, inline]
+def isZeroInt (e : Expr) : Bool :=
+  match isIntValue? e with
+  | some (Int.ofNat 0) => true
+  | _ => false
+
+theorem int_ne_zero_of_zero_lt {n : Int} (h : 0 < n) : n ≠ 0 := by omega
+theorem int_ne_zero_of_lt_zero {n : Int} (h : n < 0) : n ≠ 0 := by omega
+theorem int_ne_zero_of_not_zero_eq {n : Int} (h : ¬ (0 = n)) : n ≠ 0 := by omega
+
 /-- Apply the following simplification/normalization rules on `Int.neg` :
      - - (N) ==> "-" N
      - - (- n) ==> n      [proof: Int.neg_neg]
@@ -159,6 +170,38 @@ def mulIntDivReduceExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) :
      return none
   | none => return none
 
+/-- Find an FVar proof of `e ≠ 0` in the optimizer's local context, wrapping the
+    hypothesis found (`0 < e`, `e < 0`, or `¬ (0 = e)`) with the matching bridge
+    lemma. Assumes `nonZeroIntInHyps e` has returned `true`. -/
+def findNeZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalContext $ do
+  let lctx ← getLCtx
+  -- First pass: 0 < e
+  for decl in lctx do
+    if decl.isImplementationDetail then continue
+    let ty := decl.type
+    if ty.isAppOfArity ``LT.lt 4 then
+      let args := ty.getAppArgs
+      if args[0]!.isConstOf ``Int && isZeroInt args[2]! && exprEq args[3]! e then
+        return some (mkApp2 (mkConst ``int_ne_zero_of_zero_lt) e (mkFVar decl.fvarId))
+  -- Second pass: e < 0
+  for decl in lctx do
+    if decl.isImplementationDetail then continue
+    let ty := decl.type
+    if ty.isAppOfArity ``LT.lt 4 then
+      let args := ty.getAppArgs
+      if args[0]!.isConstOf ``Int && exprEq args[2]! e && isZeroInt args[3]! then
+        return some (mkApp2 (mkConst ``int_ne_zero_of_lt_zero) e (mkFVar decl.fvarId))
+  -- Third pass: ¬ (0 = e)
+  for decl in lctx do
+    if decl.isImplementationDetail then continue
+    let ty := decl.type
+    if let some inner := ty.not? then
+      if inner.isAppOfArity ``Eq 3 then
+        let args := inner.getAppArgs
+        if args[0]!.isConstOf ``Int && isZeroInt args[1]! && exprEq args[2]! e then
+          return some (mkApp2 (mkConst ``int_ne_zero_of_not_zero_eq) e (mkFVar decl.fvarId))
+  return none
+
 /--
   Data type to distinguish between the three integer division operators:
    - `Int.ediv`
@@ -208,9 +251,28 @@ def optimizeIntDivCommon (d: DivKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT 
   return op1
  | some n1, some n2 => evalBinIntOp Int.ediv n1 n2
  | _, _ =>
-   if let some r ← intDivSelfReduce? op1 op2 then return r
-   if let some r ← mulIntDivReduceExpr? op1 op2 then return r
+   if let some r ← intDivSelfReduce? op1 op2 then
+     if let DivKind.ediv := d then emitEDivSelfProofStep op1
+     return r
+   if let some r ← mulIntDivReduceExpr? op1 op2 then
+     if let DivKind.ediv := d then emitMulEDivProofStep op1 op2
+     return r
    return none
+
+ where
+   /-- Emit the proof step for n / n ==> 1 (requires n ≠ 0). -/
+   emitEDivSelfProofStep (n : Expr) : TranslateEnvT Unit := do
+     if let some h ← findNeZeroIntProof? n then
+       pushProofStep (.rewrite (mkApp2 (mkConst ``Int.ediv_self) n h))
+
+   /-- Emit the proof step for (m * n) / n ==> m or (n * m) / n ==> m (requires n ≠ 0). -/
+   emitMulEDivProofStep (op1 op2 : Expr) : TranslateEnvT Unit := do
+     let some (a, b) := intMul? op1 | return ()
+     let some h ← findNeZeroIntProof? op2 | return ()
+     if exprEq b op2 then
+       pushProofStep (.rewrite (mkApp3 (mkConst ``Int.mul_ediv_cancel) a op2 h))
+     else if exprEq a op2 then
+       pushProofStep (.rewrite (mkApp3 (mkConst ``Int.mul_ediv_cancel_left) op2 b h))
 
 /- Given `op1` and `op2` corresponding to the operands for `Int.ediv`, `Int.tdiv` and `Int.fdiv`,
    and `f_div` the corresponding divisor operator,
@@ -238,11 +300,12 @@ def cstCommonDivProp?
      - n / 1 ==> n                                              [proof: Int.ediv_one]
      - 0 / n ==> 0                                              [proof: Int.zero_ediv]
      - N1 / N2 ==> N1 "/ₑ" N2
-     - n / n ==> 1
+     - n / n ==> 1                                              [proof: Int.ediv_self]
          (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
              ¬ (0 = n) := _ ∈ hypothesisContext.hypothesisMap ∨
              n < 0 := _ ∈ hypothesisContext.hypothesisMap )
-     - (m * n) / m | (n * m) / m ==> n
+     - (m * n) / m ==> n                                        [proof: Int.mul_ediv_cancel_left]
+     - (n * m) / m ==> n                                        [proof: Int.mul_ediv_cancel]
          (if  0 < m := _ ∈ hypothesisContext.hypothesisMap ∨
               ¬ (0 = m) := _ ∈ hypothesisContext.hypothesisMap ∨
               m < 0 := _ ∈ hypothesisContext.hypothesisMap)
@@ -319,10 +382,23 @@ def optimizeIntModCommon (m : ModKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT
  | some n1, some n2 => evalBinIntOp Int.emod n1 n2
  | _, nv2 =>
    if let some r ← cstModProp? op1 nv2 then return r
-   if let some r ← intModToZeroExpr? op1 op2 then return r
+   if let some r ← intModToZeroExpr? op1 op2 then
+     if let ModKind.emod := m then emitEModToZeroProofStep op1 op2
+     return r
    return none
 
  where
+   /-- Emit the proof step for n % n ==> 0, (m * n) % m ==> 0, or (n * m) % m ==> 0. -/
+   emitEModToZeroProofStep (op1 op2 : Expr) : TranslateEnvT Unit := do
+     if exprEq op1 op2 then
+       pushProofStep (.rewrite (mkConst ``Int.emod_self))
+     else
+       let some (a, b) := intMul? op1 | return ()
+       if exprEq a op2 then
+         pushProofStep (.rewrite (mkConst ``Int.mul_emod_right))
+       else if exprEq b op2 then
+         pushProofStep (.rewrite (mkConst ``Int.mul_emod_left))
+
    /- Given `op1` and `mv2`, return `some 0`
       when `op1 := N1 * n ∧ mv2 := N2 ∧ N1 % N2 = 0`
       Otherwise `none`.
@@ -344,8 +420,9 @@ def optimizeIntModCommon (m : ModKind) (op1 : Expr) (op2 : Expr) : TranslateEnvT
      - 0 % n ==> 0                            [proof: Int.zero_emod]
      - N1 % N2 ==> N1 "%" N2
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
-     - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)
-     - (m * n) % m | (n * m) % m ==> 0
+     - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)          [proof: Int.emod_self]
+     - (m * n) % m ==> 0                      [proof: Int.mul_emod_right]
+     - (n * m) % m ==> 0                      [proof: Int.mul_emod_left]
    Assume that f = Expr.const ``Int.emod.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Int.emod` expected at this stage)
 -/

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -7,6 +7,7 @@ import Blaster.Optimize.Env
 open Lean Meta
 namespace Blaster.Optimize
 
+theorem int_add_neg_add (a b c : Int) : a + -(b + c) = (a - b) + -c := by omega
 
 /-- Apply the following simplification/normalization rules on `Int.neg` :
      - - (N) ==> "-" N
@@ -26,10 +27,10 @@ def optimizeIntNeg (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
 /-- Apply the following simplification/normalization rules on `Int.add` :
      - 0 + n ==> n                          [proof: Int.zero_add]
      - N1 + N2 ==> N1 "+" N2
-     - N1 + (N2 + n) ==> (N1 "+" N2) + n
-     - N1 + -(N2 + n) ==> (N1 "-" N2) + -n
+     - N1 + (N2 + n) ==> (N1 "+" N2) + n    [proof: ← Int.add_assoc]
+     - N1 + -(N2 + n) ==> (N1 "-" N2) + -n  [proof: int_add_neg_add]
      - n1 + (-n2) ==> 0 if (if n1 =ₚₜᵣ n2)
-     - n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)
+     - n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)    [proof: Int.add_comm, see reorderOperands]
    Assume that f = Expr.const ``Int.add.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Int.add` expected at this stage)
 
@@ -46,25 +47,31 @@ def optimizeIntAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   return op2
  | some n1, some n2 => evalBinIntOp Int.add n1 n2
  | nv1, _ =>
-   if let some r ← cstAddProp? nv1 op2 then return r
+   if let some r ← cstAddProp? nv1 op1 op2 then return r
    if isIntNegExprOf op2 op1 then return (← mkIntLitExpr (Int.ofNat 0))
    return (mkApp2 f op1 op2)
 
  where
-  /- Given `mv1` and `op2`,
+  /- Given `mv1`, `op1` and `op2`,
       - return `some ((N1 "+" N2) + n)` when `mv1 := some N1 ∧ op2 := (N2 + n)`
       - return `some ((N1 "-" N2) + -n)` when `mv1 := some N1 ∧ op2 := -(N2 + n)`
      Otherwise `none`
   -/
  @[always_inline, inline]
- cstAddProp? (mv1 : Option Int) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+ cstAddProp? (mv1 : Option Int) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
   match mv1 with
   | some n1 =>
      match (toIntCstOpExpr? op2) with
      | some (IntCstOpInfo.IntAddExpr n2 e2) =>
+         -- `op2 := Int.add N2 n`, so `op2.appFn!.appArg!` is the `N2` operand.
+         let n2Expr := op2.appFn!.appArg!
+         pushProofStep (.rewrite (mkApp3 (mkConst ``Int.add_assoc) op1 n2Expr e2) (symm := true))
          setRestart
          return mkApp2 f (← evalBinIntOp Int.add n1 n2) e2
      | some (IntCstOpInfo.IntNegAddExpr n2 e2) =>
+         -- `op2 := Int.neg (Int.add N2 n)`, so `op2.appArg!.appFn!.appArg!` is `N2`.
+         let n2Expr := op2.appArg!.appFn!.appArg!
+         pushProofStep (.rewrite (mkApp3 (mkConst ``int_add_neg_add) op1 n2Expr e2))
          setRestart
          return mkApp2 f (← evalBinIntOp Int.sub n1 n2) (mkApp (← mkIntNegOp) e2)
      | _ => return none
@@ -73,10 +80,10 @@ def optimizeIntAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
 /-- Apply the following simplification/normalization rules on `Int.mul` :
      - 0 * n ==> 0                          [proof: Int.zero_mul]
      - 1 * n ==> n                          [proof: Int.one_mul]
-     - -1 * n ==> -n
+     - -1 * n ==> -n                        [proof: Int.neg_one_mul]
      - N1 * N2 ==> N1 "*" N2
-     - N1 * (N2 * n) ==> (N1 "*" N2) * n
-     - n1 * n2 ==> n2 * n1 (if n2 <ₒ n1)
+     - N1 * (N2 * n) ==> (N1 "*" N2) * n    [proof: ← Int.mul_assoc]
+     - n1 * n2 ==> n2 * n1 (if n2 <ₒ n1)    [proof: Int.mul_comm, see reorderOperands]
    Assume that f = Expr.const ``Int.mul.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Int.mul` expected at this stage)
 -/
@@ -92,21 +99,25 @@ def optimizeIntMul (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   pushProofStep (.rewrite (mkConst ``Int.one_mul))
   return op2
  | some (Int.negSucc 0), _ =>
+      pushProofStep (.rewrite (mkConst ``Int.neg_one_mul))
       setRestart
       return mkApp (← mkIntNegOp) op2
  | some n1, some n2 => evalBinIntOp Int.mul n1 n2
  | nv1, _ =>
-   if let some r ← cstMulProp? nv1 op2 then return r
+   if let some r ← cstMulProp? nv1 op1 op2 then return r
    return (mkApp2 f op1 op2)
 
  where
-   /- Given `mv1` and `op2` return `some ((N1 "*" N2) * n)` when
+   /- Given `mv1`, `op1` and `op2` return `some ((N1 "*" N2) * n)` when
       `mv1 := some N1 ∧ op2 := (N2 * n)`. Otherwise `none`
    -/
    @[always_inline, inline]
-   cstMulProp? (mv1 : Option Int) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+   cstMulProp? (mv1 : Option Int) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
     match mv1, toIntCstOpExpr? op2 with
     | some n1, some (IntCstOpInfo.IntMulExpr n2 e2) =>
+       -- `op2 := Int.mul N2 n`, so `op2.appFn!.appArg!` is the `N2` operand.
+       let n2Expr := op2.appFn!.appArg!
+       pushProofStep (.rewrite (mkApp3 (mkConst ``Int.mul_assoc) op1 n2Expr e2) (symm := true))
        return (mkApp2 f (← evalBinIntOp Int.mul n1 n2) e2)
     | _, _ => return none
 

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -10,7 +10,7 @@ namespace Blaster.Optimize
 
 /-- Apply the following simplification/normalization rules on `Int.neg` :
      - - (N) ==> "-" N
-     - - (- n) ==> n
+     - - (- n) ==> n      [proof: Int.neg_neg]
    Assume that f = Expr.const ``Int.neg.
    An error is triggered if args.size ≠ 1 (i.e., only fully applied `Int.neg` expected at this stage)
    TODO: consider additional simplification rules

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -71,8 +71,8 @@ def optimizeIntAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
   | none => return none
 
 /-- Apply the following simplification/normalization rules on `Int.mul` :
-     - 0 * n ==> 0
-     - 1 * n ==> n
+     - 0 * n ==> 0                          [proof: Int.zero_mul]
+     - 1 * n ==> n                          [proof: Int.one_mul]
      - -1 * n ==> -n
      - N1 * N2 ==> N1 "*" N2
      - N1 * (N2 * n) ==> (N1 "*" N2) * n
@@ -85,8 +85,12 @@ def optimizeIntMul (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  match isIntValue? op1, isIntValue? op2 with
- | some (Int.ofNat 0), _ => return op1
- | some (Int.ofNat 1), _ => return op2
+ | some (Int.ofNat 0), _ =>
+  pushProofStep (.rewrite (mkConst ``Int.zero_mul))
+  return op1
+ | some (Int.ofNat 1), _ =>
+  pushProofStep (.rewrite (mkConst ``Int.one_mul))
+  return op2
  | some (Int.negSucc 0), _ =>
       setRestart
       return mkApp (← mkIntNegOp) op2

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -275,7 +275,7 @@ def intModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
   | none => return none
 
 
-/- Data type for distinguishing between the three integer modulus operators:
+/-- Data type for distinguishing between the three integer modulo operators:
    - `Int.emod`
    - `Int.tmod`
    - `Int.fmod`

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -7,18 +7,12 @@ import Blaster.Optimize.Env
 open Lean Meta
 namespace Blaster.Optimize
 
-theorem int_add_neg_add (a b c : Int) : a + -(b + c) = (a - b) + -c := by omega
-
 /-- Return `true` when `e` corresponds to the zero int literal. -/
 @[always_inline, inline]
 def isZeroInt (e : Expr) : Bool :=
   match isIntValue? e with
   | some (Int.ofNat 0) => true
   | _ => false
-
-theorem int_ne_zero_of_zero_lt {n : Int} (h : 0 < n) : n ≠ 0 := by omega
-theorem int_ne_zero_of_lt_zero {n : Int} (h : n < 0) : n ≠ 0 := by omega
-theorem int_ne_zero_of_not_zero_eq {n : Int} (h : ¬ (0 = n)) : n ≠ 0 := by omega
 
 /-- Apply the following simplification/normalization rules on `Int.neg` :
      - - (N) ==> "-" N
@@ -41,7 +35,7 @@ def optimizeIntNeg (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      - 0 + n ==> n                          [proof: Int.zero_add]
      - N1 + N2 ==> N1 "+" N2
      - N1 + (N2 + n) ==> (N1 "+" N2) + n    [proof: ← Int.add_assoc]
-     - N1 + -(N2 + n) ==> (N1 "-" N2) + -n  [proof: int_add_neg_add]
+     - N1 + -(N2 + n) ==> (N1 "-" N2) + -n  [proof: Blaster.int_add_neg_add]
      - n1 + (-n2) ==> 0 if (if n1 =ₚₜᵣ n2)
      - n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)    [proof: Int.add_comm, see reorderOperands]
    Assume that f = Expr.const ``Int.add.
@@ -84,7 +78,7 @@ def optimizeIntAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      | some (IntCstOpInfo.IntNegAddExpr n2 e2) =>
          -- `op2 := Int.neg (Int.add N2 n)`, so `op2.appArg!.appFn!.appArg!` is `N2`.
          let n2Expr := op2.appArg!.appFn!.appArg!
-         pushProofStep (.rewrite (mkApp3 (mkConst ``int_add_neg_add) op1 n2Expr e2))
+         pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.int_add_neg_add) op1 n2Expr e2))
          setRestart
          return mkApp2 f (← evalBinIntOp Int.sub n1 n2) (mkApp (← mkIntNegOp) e2)
      | _ => return none
@@ -182,7 +176,7 @@ def findNeZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalCon
     if ty.isAppOfArity ``LT.lt 4 then
       let args := ty.getAppArgs
       if args[0]!.isConstOf ``Int && isZeroInt args[2]! && exprEq args[3]! e then
-        return some (mkApp2 (mkConst ``int_ne_zero_of_zero_lt) e (mkFVar decl.fvarId))
+        return some (mkApp2 (mkConst ``Blaster.int_ne_zero_of_zero_lt) e (mkFVar decl.fvarId))
   -- Second pass: e < 0
   for decl in lctx do
     if decl.isImplementationDetail then continue
@@ -190,7 +184,7 @@ def findNeZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalCon
     if ty.isAppOfArity ``LT.lt 4 then
       let args := ty.getAppArgs
       if args[0]!.isConstOf ``Int && exprEq args[2]! e && isZeroInt args[3]! then
-        return some (mkApp2 (mkConst ``int_ne_zero_of_lt_zero) e (mkFVar decl.fvarId))
+        return some (mkApp2 (mkConst ``Blaster.int_ne_zero_of_lt_zero) e (mkFVar decl.fvarId))
   -- Third pass: ¬ (0 = e)
   for decl in lctx do
     if decl.isImplementationDetail then continue
@@ -199,7 +193,7 @@ def findNeZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalCon
       if inner.isAppOfArity ``Eq 3 then
         let args := inner.getAppArgs
         if args[0]!.isConstOf ``Int && isZeroInt args[1]! && exprEq args[2]! e then
-          return some (mkApp2 (mkConst ``int_ne_zero_of_not_zero_eq) e (mkFVar decl.fvarId))
+          return some (mkApp2 (mkConst ``Blaster.int_ne_zero_of_not_zero_eq) e (mkFVar decl.fvarId))
   return none
 
 /--

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -36,7 +36,7 @@ def optimizeIntNeg (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      - N1 + N2 ==> N1 "+" N2
      - N1 + (N2 + n) ==> (N1 "+" N2) + n    [proof: ← Int.add_assoc]
      - N1 + -(N2 + n) ==> (N1 "-" N2) + -n  [proof: Blaster.int_add_neg_add]
-     - n1 + (-n2) ==> 0 if (if n1 =ₚₜᵣ n2)
+     - n1 + (-n2) ==> 0 if (if n1 =ₚₜᵣ n2)   [proof: Int.add_right_neg]
      - n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)    [proof: Int.add_comm, see reorderOperands]
    Assume that f = Expr.const ``Int.add.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Int.add` expected at this stage)
@@ -55,7 +55,9 @@ def optimizeIntAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  | some n1, some n2 => evalBinIntOp Int.add n1 n2
  | nv1, _ =>
    if let some r ← cstAddProp? nv1 op1 op2 then return r
-   if isIntNegExprOf op2 op1 then return (← mkIntLitExpr (Int.ofNat 0))
+   if isIntNegExprOf op2 op1 then
+    pushProofStep (.rewrite (mkConst ``Int.add_right_neg))
+    return (← mkIntLitExpr (Int.ofNat 0))
    return (mkApp2 f op1 op2)
 
  where

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -19,7 +19,9 @@ def optimizeIntNeg (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 1 then throwEnvError "optimizeIntNeg: only one argument expected"
  let op := args[0]!
  if let some n1 := isIntValue? op then return (← mkIntLitExpr (Int.neg n1))
- if let some e := intNeg? op then return e
+ if let some e := intNeg? op then
+  pushProofStep (.rewrite (mkConst ``Int.neg_neg))
+  return e
  return (mkApp f op)
 
 

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -24,7 +24,7 @@ def optimizeIntNeg (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
 
 
 /-- Apply the following simplification/normalization rules on `Int.add` :
-     - 0 + n ==> n
+     - 0 + n ==> n                          [proof: Int.zero_add]
      - N1 + N2 ==> N1 "+" N2
      - N1 + (N2 + n) ==> (N1 "+" N2) + n
      - N1 + -(N2 + n) ==> (N1 "-" N2) + -n
@@ -41,7 +41,9 @@ def optimizeIntAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  -- let op1 := opArgs[0]!
  -- let op2 := opArgs[1]!
  match isIntValue? op1, isIntValue? op2 with
- | some (Int.ofNat 0), _ => return op2
+ | some (Int.ofNat 0), _ =>
+  pushProofStep (.rewrite (mkConst ``Int.zero_add))
+  return op2
  | some n1, some n2 => evalBinIntOp Int.add n1 n2
  | nv1, _ =>
    if let some r ← cstAddProp? nv1 op2 then return r

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -7,45 +7,8 @@ import Blaster.Optimize.Env
 open Lean Meta
 namespace Blaster.Optimize
 
-theorem nat_add_sub_of_ble {c a : Nat} (b : Nat) (h : Nat.ble c a = true) :
-    (a + b) - c = (a - c) + b := by
-  have h : c ≤ a := by simpa [Nat.ble] using h
-  simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using Nat.add_sub_assoc h b
-
-theorem nat_mul_div_cancel_gcd {a b g : Nat} (x : Nat)
-    (hg : Nat.ble 1 g = true)
-    (ha : Nat.beq (a % g) 0 = true)
-    (hb : Nat.beq (b % g) 0 = true) :
-    (a * x) / b = ((a / g) * x) / (b / g) := by
-  have hg' : 0 < g := by simp [Nat.ble_eq] at hg; omega
-  have ha' : a % g = 0 := by simp [Nat.beq_eq] at ha; exact ha
-  have hb' : b % g = 0 := by simp [Nat.beq_eq] at hb; exact hb
-  have hag : a = a / g * g := (Nat.div_mul_cancel (Nat.dvd_of_mod_eq_zero ha')).symm
-  have hbg : b = b / g * g := (Nat.div_mul_cancel (Nat.dvd_of_mod_eq_zero hb')).symm
-  have key : a / g * g * x / (b / g * g) = a / g * x / (b / g) := by
-    rw [Nat.mul_assoc, Nat.mul_comm g x, ← Nat.mul_assoc]
-    exact Nat.mul_div_mul_right _ _ hg'
-  rw [← hag, ← hbg] at key
-  exact key
-
-theorem nat_pos_of_ne_zero {n : Nat} (h : ¬ (0 = n)) : 0 < n := by omega
-
-theorem nat_mul_div_cancel_left_of_pos {n : Nat} (m : Nat) (h : 0 < n) : n * m / n = m :=
-  Nat.mul_div_cancel_left m h
-
-theorem nat_mul_mod_of_mod_eq_zero {a b : Nat} (x : Nat)
-    (h : Nat.beq (a % b) 0 = true) : (a * x) % b = 0 := by
-  have h' : a % b = 0 := by simp [Nat.beq_eq] at h; exact h
-  rw [Nat.mul_mod, h', Nat.zero_mul, Nat.zero_mod]
-
-theorem nat_mul_mod_left (n m : Nat) : (n * m) % n = 0 := by
-  rw [Nat.mul_mod, Nat.mod_self, Nat.zero_mul, Nat.zero_mod]
-
-theorem nat_mul_mod_right (m n : Nat) : (m * n) % n = 0 := by
-  rw [Nat.mul_comm]; exact nat_mul_mod_left n m
-
 /-- Find an FVar proof of `0 < e` in the optimizer's local context.
-    If only `¬(0 = e)` is found, wraps it with `nat_pos_of_ne_zero`.
+    If only `¬(0 = e)` is found, wraps it with `Blaster.nat_pos_of_ne_zero`.
     Assumes `nonZeroNatInHyps e` has returned `true`. -/
 def findPosNatProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalContext $ do
   let lctx ← getLCtx
@@ -57,7 +20,7 @@ def findPosNatProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalContex
       let args := ty.getAppArgs
       if args[0]!.isConstOf ``Nat && isZeroNat args[2]! && exprEq args[3]! e then
         return some (mkFVar decl.fvarId)
-  -- Second pass: look for ¬(0 = e) and wrap with nat_pos_of_ne_zero
+  -- Second pass: look for ¬(0 = e) and wrap with Blaster.nat_pos_of_ne_zero
   for decl in lctx do
     if decl.isImplementationDetail then continue
     let ty := decl.type
@@ -65,7 +28,7 @@ def findPosNatProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalContex
       if inner.isAppOfArity ``Eq 3 then
         let args := inner.getAppArgs
         if args[0]!.isConstOf ``Nat && isZeroNat args[1]! && exprEq args[2]! e then
-          return some (mkApp2 (mkConst ``nat_pos_of_ne_zero) e (mkFVar decl.fvarId))
+          return some (mkApp2 (mkConst ``Blaster.nat_pos_of_ne_zero) e (mkFVar decl.fvarId))
   return none
 
 /-- Apply the following simplification/normalization rules on `Nat.add` :
@@ -111,7 +74,7 @@ def optimizeNatAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      - N1 - (N2 + n) ==> (N1 "-" N2) - n               [proof: Nat.sub_add_eq]
      - (N1 - n) - N2 ==> (N1 "-" N2) - n               [proof: Nat.sub_right_comm]
      - (n - N1) - N2 ==> n - (N1 "+" N2)               [proof: Nat.sub_sub]
-     - (N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)  [proof: nat_add_sub_of_ble]
+     - (N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)  [proof: Blaster.nat_add_sub_of_ble]
    Assume that f = Expr.const ``Nat.sub.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.sub` expected at this stage)
 -/
@@ -174,7 +137,7 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
                 let hProof :=
                   mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
                 pushProofStep
-                  (.rewrite (mkApp4 (mkConst ``nat_add_sub_of_ble) op2 n1Expr e1 hProof))
+                  (.rewrite (mkApp4 (mkConst ``Blaster.nat_add_sub_of_ble) op2 n1Expr e1 hProof))
                 setRestart
                 return mkApp2 (← mkNatAddOp) (← evalBinNatOp Nat.sub n1 n2) e1
               else return none
@@ -294,7 +257,7 @@ def natDivSelfReduce? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      - N1 / N2 ==> N1 "/" N2
      - (n / N1) / N2 ==> n / (N1 "*" N2)               [proof: Nat.div_div_eq_div_mul]
      - (N1 * n) / N2 ===> ((N1 "/" Nat.gcd N1 N2) * n) / (N2 "/" Nat.gcd N1 N2)
-       (if N2 > 0 ∧ Nat.gcd N1 N2 ≠ 1)                 [proof: nat_mul_div_cancel_gcd]
+       (if N2 > 0 ∧ Nat.gcd N1 N2 ≠ 1)                 [proof: Blaster.nat_mul_div_cancel_gcd]
      - n / n ==> 1 (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
                        ¬ (0 = n) := _ ∈ hypothesisContext.hypothesisMap)
                                                         [proof: Nat.div_self]
@@ -303,7 +266,7 @@ def natDivSelfReduce? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
                                                          [proof: Nat.mul_div_cancel]
      - (n * m) / n ==> m (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
                              ¬ (0 = n) := _ ∈ hypothesisContext.hypothesisMap)
-                                                         [proof: nat_mul_div_cancel_left_of_pos]
+                                                         [proof: Nat.mul_div_cancel_left]
    Assume that f = Expr.const ``Nat.div.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.div` expected at this stage)
 
@@ -346,7 +309,7 @@ def optimizeNatDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
        pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.mul_div_cancel) a op2 h))
      else if exprEq a op2 then
        -- n * m / n = m
-       pushProofStep (.rewrite (mkApp3 (mkConst ``nat_mul_div_cancel_left_of_pos) op2 b h))
+       pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.mul_div_cancel_left) b op2 h))
 
    /- Given `op1` and `mv2`,
         - return `some (n / (N1 "*" N2))` when `op1 := (n / N1) ∧ mv2 := some N2`
@@ -376,7 +339,7 @@ def optimizeNatDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
              let boolRefl :=
                mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
              pushProofStep (.rewrite
-               (mkAppN (mkConst ``nat_mul_div_cancel_gcd)
+               (mkAppN (mkConst ``Blaster.nat_mul_div_cancel_gcd)
                   #[n1Expr, outerOp2, gExpr, e1, boolRefl, boolRefl, boolRefl]))
              setRestart
              let mulExpr := mkApp2 (← mkNatMulOp) (← evalBinNatOp Nat.div n1 gcd) e1
@@ -405,10 +368,10 @@ def natModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      - 0 % n ==> 0                           [proof: Nat.zero_mod]
      - N1 % N2 ==> N1 "%" N2
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
-                                             [proof: nat_mul_mod_of_mod_eq_zero]
+                                             [proof: Blaster.nat_mul_mod_of_mod_eq_zero]
      - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)         [proof: Nat.mod_self]
-     - (n * m) % n ==> 0                     [proof: nat_mul_mod_left]
-     - (m * n) % n ==> 0                     [proof: nat_mul_mod_right]
+     - (n * m) % n ==> 0                     [proof: Nat.mul_mod_right]
+     - (m * n) % n ==> 0                     [proof: Nat.mul_mod_left]
    Assume that f = Expr.const ``Nat.mod.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.mod` expected at this stage)
 -/
@@ -443,9 +406,9 @@ def optimizeNatMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      else
        let some (a, b) := natMul? op1 | return ()
        if exprEq a op2 then
-         pushProofStep (.rewrite (mkConst ``nat_mul_mod_left))
+         pushProofStep (.rewrite (mkConst ``Nat.mul_mod_right))
        else if exprEq b op2 then
-         pushProofStep (.rewrite (mkConst ``nat_mul_mod_right))
+         pushProofStep (.rewrite (mkConst ``Nat.mul_mod_left))
 
    /- Given `op1`, `outerOp2` and `mv2`, return `some 0`
       when `op1 := N1 * n ∧ mv2 := N2 ∧ N1 % N2 = 0`
@@ -461,7 +424,7 @@ def optimizeNatMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
           let boolRefl :=
             mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
           pushProofStep (.rewrite
-            (mkAppN (mkConst ``nat_mul_mod_of_mod_eq_zero)
+            (mkAppN (mkConst ``Blaster.nat_mul_mod_of_mod_eq_zero)
                #[n1Expr, outerOp2, e1, boolRefl]))
           some <$> mkNatLitExpr 0
         else return none

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -33,6 +33,17 @@ theorem nat_pos_of_ne_zero {n : Nat} (h : ¬ (0 = n)) : 0 < n := by omega
 theorem nat_mul_div_cancel_left_of_pos {n : Nat} (m : Nat) (h : 0 < n) : n * m / n = m :=
   Nat.mul_div_cancel_left m h
 
+theorem nat_mul_mod_of_mod_eq_zero {a b : Nat} (x : Nat)
+    (h : Nat.beq (a % b) 0 = true) : (a * x) % b = 0 := by
+  have h' : a % b = 0 := by simp [Nat.beq_eq] at h; exact h
+  rw [Nat.mul_mod, h', Nat.zero_mul, Nat.zero_mod]
+
+theorem nat_mul_mod_left (n m : Nat) : (n * m) % n = 0 := by
+  rw [Nat.mul_mod, Nat.mod_self, Nat.zero_mul, Nat.zero_mod]
+
+theorem nat_mul_mod_right (m n : Nat) : (m * n) % n = 0 := by
+  rw [Nat.mul_comm]; exact nat_mul_mod_left n m
+
 /-- Find an FVar proof of `0 < e` in the optimizer's local context.
     If only `¬(0 = e)` is found, wraps it with `nat_pos_of_ne_zero`.
     Assumes `nonZeroNatInHyps e` has returned `true`. -/
@@ -389,13 +400,15 @@ def natModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
   | none => return none
 
 /-- Apply the following simplification/normalization rules on `Nat.mod` :
-     - n % 0 ==> n
-     - n % 1 ==> 0
-     - 0 % n ==> 0
+     - n % 0 ==> n                           [proof: Nat.mod_zero]
+     - n % 1 ==> 0                           [proof: Nat.mod_one]
+     - 0 % n ==> 0                           [proof: Nat.zero_mod]
      - N1 % N2 ==> N1 "%" N2
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
-     - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)
-     - (m * n) % m | (n * m) % m ==> 0
+                                             [proof: nat_mul_mod_of_mod_eq_zero]
+     - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)         [proof: Nat.mod_self]
+     - (n * m) % n ==> 0                     [proof: nat_mul_mod_left]
+     - (m * n) % n ==> 0                     [proof: nat_mul_mod_right]
    Assume that f = Expr.const ``Nat.mod.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.mod` expected at this stage)
 -/
@@ -405,26 +418,52 @@ def optimizeNatMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  match isNatValue? op1, isNatValue? op2 with
- | _, some 0 => return op1
- | _, some 1 => mkNatLitExpr 0
- | some 0, _ => return op1
+ | _, some 0 =>
+    pushProofStep (.rewrite (mkConst ``Nat.mod_zero))
+    return op1
+ | _, some 1 =>
+    pushProofStep (.rewrite (mkConst ``Nat.mod_one))
+    mkNatLitExpr 0
+ | some 0, _ =>
+    pushProofStep (.rewrite (mkConst ``Nat.zero_mod))
+    return op1
  | some n1, some n2 => evalBinNatOp Nat.mod n1 n2
  | _, nv2 =>
-   if let some r ← cstModProp? op1 nv2 then return r
-   if let some r ← natModToZeroExpr? op1 op2 then return r
+   if let some r ← cstModProp? op1 op2 nv2 then return r
+   if let some r ← natModToZeroExpr? op1 op2 then
+     emitModToZeroProofStep op1 op2
+     return r
    return (mkApp2 f op1 op2)
 
  where
-   /- Given `op1` and `mv2`, return `some 0`
+   /-- Emit the proof step for n % n ==> 0, (n * m) % n ==> 0, or (m * n) % n ==> 0. -/
+   emitModToZeroProofStep (op1 op2 : Expr) : TranslateEnvT Unit := do
+     if exprEq op1 op2 then
+       pushProofStep (.rewrite (mkConst ``Nat.mod_self))
+     else
+       let some (a, b) := natMul? op1 | return ()
+       if exprEq a op2 then
+         pushProofStep (.rewrite (mkConst ``nat_mul_mod_left))
+       else if exprEq b op2 then
+         pushProofStep (.rewrite (mkConst ``nat_mul_mod_right))
+
+   /- Given `op1`, `outerOp2` and `mv2`, return `some 0`
       when `op1 := N1 * n ∧ mv2 := N2 ∧ N1 % N2 = 0`
       Otherwise `none`.
       Assumes that N2 > 0
    -/
-   cstModProp? (op1 : Expr) (mv2 : Option Nat) : TranslateEnvT (Option Expr) := do
+   cstModProp? (op1 : Expr) (outerOp2 : Expr) (mv2 : Option Nat)
+       : TranslateEnvT (Option Expr) := do
     match toNatCstOpExpr? op1, mv2 with
-    | some (NatCstOpInfo.NatMulExpr n1 _e1), some n2 =>
-        if Nat.mod n1 n2 == 0
-        then some <$> mkNatLitExpr 0
+    | some (NatCstOpInfo.NatMulExpr n1 e1), some n2 =>
+        if Nat.mod n1 n2 == 0 then
+          let n1Expr := op1.appFn!.appArg!
+          let boolRefl :=
+            mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
+          pushProofStep (.rewrite
+            (mkAppN (mkConst ``nat_mul_mod_of_mod_eq_zero)
+               #[n1Expr, outerOp2, e1, boolRefl]))
+          some <$> mkNatLitExpr 0
         else return none
     | _, _ => return none
 

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -12,6 +12,51 @@ theorem nat_add_sub_of_ble {c a : Nat} (b : Nat) (h : Nat.ble c a = true) :
   have h : c ≤ a := by simpa [Nat.ble] using h
   simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using Nat.add_sub_assoc h b
 
+theorem nat_mul_div_cancel_gcd {a b g : Nat} (x : Nat)
+    (hg : Nat.ble 1 g = true)
+    (ha : Nat.beq (a % g) 0 = true)
+    (hb : Nat.beq (b % g) 0 = true) :
+    (a * x) / b = ((a / g) * x) / (b / g) := by
+  have hg' : 0 < g := by simp [Nat.ble_eq] at hg; omega
+  have ha' : a % g = 0 := by simp [Nat.beq_eq] at ha; exact ha
+  have hb' : b % g = 0 := by simp [Nat.beq_eq] at hb; exact hb
+  have hag : a = a / g * g := (Nat.div_mul_cancel (Nat.dvd_of_mod_eq_zero ha')).symm
+  have hbg : b = b / g * g := (Nat.div_mul_cancel (Nat.dvd_of_mod_eq_zero hb')).symm
+  have key : a / g * g * x / (b / g * g) = a / g * x / (b / g) := by
+    rw [Nat.mul_assoc, Nat.mul_comm g x, ← Nat.mul_assoc]
+    exact Nat.mul_div_mul_right _ _ hg'
+  rw [← hag, ← hbg] at key
+  exact key
+
+theorem nat_pos_of_ne_zero {n : Nat} (h : ¬ (0 = n)) : 0 < n := by omega
+
+theorem nat_mul_div_cancel_left_of_pos {n : Nat} (m : Nat) (h : 0 < n) : n * m / n = m :=
+  Nat.mul_div_cancel_left m h
+
+/-- Find an FVar proof of `0 < e` in the optimizer's local context.
+    If only `¬(0 = e)` is found, wraps it with `nat_pos_of_ne_zero`.
+    Assumes `nonZeroNatInHyps e` has returned `true`. -/
+def findPosNatProof? (e : Expr) : TranslateEnvT (Option Expr) := withLocalContext $ do
+  let lctx ← getLCtx
+  -- First pass: look for 0 < e directly
+  for decl in lctx do
+    if decl.isImplementationDetail then continue
+    let ty := decl.type
+    if ty.isAppOfArity ``LT.lt 4 then
+      let args := ty.getAppArgs
+      if args[0]!.isConstOf ``Nat && isZeroNat args[2]! && exprEq args[3]! e then
+        return some (mkFVar decl.fvarId)
+  -- Second pass: look for ¬(0 = e) and wrap with nat_pos_of_ne_zero
+  for decl in lctx do
+    if decl.isImplementationDetail then continue
+    let ty := decl.type
+    if let some inner := ty.not? then
+      if inner.isAppOfArity ``Eq 3 then
+        let args := inner.getAppArgs
+        if args[0]!.isConstOf ``Nat && isZeroNat args[1]! && exprEq args[2]! e then
+          return some (mkApp2 (mkConst ``nat_pos_of_ne_zero) e (mkFVar decl.fvarId))
+  return none
+
 /-- Apply the following simplification/normalization rules on `Nat.add` :
      - 0 + n ==> n                          [proof: Nat.zero_add]
      - N1 + N2 ===> N1 "+" N2
@@ -232,17 +277,22 @@ def natDivSelfReduce? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
   else return none
 
 /-- Apply the following simplification/normalization rules on `Nat.div` :
-     - n / 0 ==> 0
-     - n / 1 ==> n
-     - 0 / n ==> 0
+     - n / 0 ==> 0                                     [proof: Nat.div_zero]
+     - n / 1 ==> n                                     [proof: Nat.div_one]
+     - 0 / n ==> 0                                     [proof: Nat.zero_div]
      - N1 / N2 ==> N1 "/" N2
-     - (n / N1) / N2 ==> n / (N1 "*" N2)
-     - (N1 * n) / N2 ===> ((N1 "/" Nat.gcd N1 N2) * n) / (N2 "/" Nat.gcd N1 N2) (if N2 > 0 ∧ Nat.gcd N1 N2 ≠ 1)
+     - (n / N1) / N2 ==> n / (N1 "*" N2)               [proof: Nat.div_div_eq_div_mul]
+     - (N1 * n) / N2 ===> ((N1 "/" Nat.gcd N1 N2) * n) / (N2 "/" Nat.gcd N1 N2)
+       (if N2 > 0 ∧ Nat.gcd N1 N2 ≠ 1)                 [proof: nat_mul_div_cancel_gcd]
      - n / n ==> 1 (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
                        ¬ (0 = n) := _ ∈ hypothesisContext.hypothesisMap)
-     - (m * n) / m | (n * m) / m ==> n (if 0 < m := _ ∈ hypothesisContext.hypothesisMap ∨
-                                           ¬ (0 = m) := _ ∈ hypothesisContext.hypothesisMap)
-
+                                                        [proof: Nat.div_self]
+     - (m * n) / n ==> m (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
+                             ¬ (0 = n) := _ ∈ hypothesisContext.hypothesisMap)
+                                                         [proof: Nat.mul_div_cancel]
+     - (n * m) / n ==> m (if 0 < n := _ ∈ hypothesisContext.hypothesisMap ∨
+                             ¬ (0 = n) := _ ∈ hypothesisContext.hypothesisMap)
+                                                         [proof: nat_mul_div_cancel_left_of_pos]
    Assume that f = Expr.const ``Nat.div.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.div` expected at this stage)
 
@@ -252,17 +302,40 @@ def optimizeNatDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  match isNatValue? op1, isNatValue? op2 with
- | _, some 0 => return op2
- | _, some 1
- | some 0, _ => return op1
+ | _, some 0 =>
+    pushProofStep (.rewrite (mkConst ``Nat.div_zero))
+    return op2
+ | _, some 1 =>
+    pushProofStep (.rewrite (mkConst ``Nat.div_one))
+    return op1
+ | some 0, _ =>
+    pushProofStep (.rewrite (mkConst ``Nat.zero_div))
+    return op1
  | some n1, some n2 => evalBinNatOp Nat.div n1 n2
  | _, nv2 =>
-   if let some r ← cstDivProp? op1 nv2 then return r
-   if let some r ← natDivSelfReduce? op1 op2 then return r
-   if let some r ← mulNatDivReduceExpr? op1 op2 then return r
+   if let some r ← cstDivProp? op1 op2 nv2 then return r
+   if let some r ← natDivSelfReduce? op1 op2 then
+     -- n / n ==> 1, with hypothesis 0 < n
+     if let some h ← findPosNatProof? op1 then
+       pushProofStep (.rewrite (mkApp2 (mkConst ``Nat.div_self) op1 h))
+     return r
+   if let some r ← mulNatDivReduceExpr? op1 op2 then
+     -- (m * n) / n ==> m  or  (n * m) / n ==> m
+     emitMulDivProofStep op1 op2
+     return r
    return (mkApp2 f op1 op2)
 
  where
+   /-- Emit the proof step for (m * n) / n ==> m or (n * m) / n ==> m. -/
+   emitMulDivProofStep (op1 op2 : Expr) : TranslateEnvT Unit := do
+     let some (a, b) := natMul? op1 | return ()
+     let some h ← findPosNatProof? op2 | return ()
+     if exprEq b op2 then
+       -- m * n / n = m
+       pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.mul_div_cancel) a op2 h))
+     else if exprEq a op2 then
+       -- n * m / n = m
+       pushProofStep (.rewrite (mkApp3 (mkConst ``nat_mul_div_cancel_left_of_pos) op2 b h))
 
    /- Given `op1` and `mv2`,
         - return `some (n / (N1 "*" N2))` when `op1 := (n / N1) ∧ mv2 := some N2`
@@ -271,16 +344,29 @@ def optimizeNatDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
       Otherwise `none`.
       Assumes that N2 > 0
    -/
-   cstDivProp? (op1 : Expr) (mv2 : Option Nat) : TranslateEnvT (Option Expr) := do
+   cstDivProp? (op1 : Expr) (outerOp2 : Expr) (mv2 : Option Nat)
+       : TranslateEnvT (Option Expr) := do
      match mv2 with
      | some n2 =>
          match toNatCstOpExpr? op1 with
          | some (NatCstOpInfo.NatDivRightExpr e1 n1) =>
+             -- (e1 / N1) / N2  ==>  e1 / (N1 * N2)
+             let n1Expr := op1.appArg!
+             pushProofStep (.rewrite
+               (mkApp3 (mkConst ``Nat.div_div_eq_div_mul) e1 n1Expr outerOp2))
              -- no need to restart here
              return (mkApp2 f e1 (← evalBinNatOp Nat.mul n1 n2))
          | some (NatCstOpInfo.NatMulExpr n1 e1) =>
+             -- (N1 * x) / N2  ==>  ((N1/g) * x) / (N2/g)
              let gcd := if n1 < n2 then Nat.gcd n1 n2 else Nat.gcd n2 n1
              if gcd == 1 then return none
+             let n1Expr := op1.appFn!.appArg!
+             let gExpr ← mkNatLitExpr gcd
+             let boolRefl :=
+               mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
+             pushProofStep (.rewrite
+               (mkAppN (mkConst ``nat_mul_div_cancel_gcd)
+                  #[n1Expr, outerOp2, gExpr, e1, boolRefl, boolRefl, boolRefl]))
              setRestart
              let mulExpr := mkApp2 (← mkNatMulOp) (← evalBinNatOp Nat.div n1 gcd) e1
              return mkApp2 f mulExpr (← evalBinNatOp Nat.div n2 gcd)

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -7,6 +7,11 @@ import Blaster.Optimize.Env
 open Lean Meta
 namespace Blaster.Optimize
 
+theorem natAddSubOfBle {c a : Nat} (b : Nat) (h : Nat.ble c a = true) :
+    (a + b) - c = (a - c) + b := by
+  have h : c ≤ a := by simpa [Nat.ble] using h
+  simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using Nat.add_sub_assoc h b
+
 /-- Apply the following simplification/normalization rules on `Nat.add` :
      - 0 + n ==> n                          [proof: Nat.zero_add]
      - N1 + N2 ===> N1 "+" N2
@@ -109,7 +114,10 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
               return (mkApp2 f e1 (← evalBinNatOp Nat.add n1 n2))
           | some (NatCstOpInfo.NatAddExpr n1 e1) =>
               if Nat.ble n2 n1 then
-                -- TODO: composed proof (add_comm + add_sub_assoc + add_comm)
+                let n1Expr := op1.appFn!.appArg!
+                let hProof :=
+                  mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
+                pushProofStep (.rewrite (mkApp4 (mkConst ``natAddSubOfBle) op2 n1Expr e1 hProof))
                 setRestart
                 return mkApp2 (← mkNatAddOp) (← evalBinNatOp Nat.sub n1 n2) e1
               else return none

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -7,7 +7,7 @@ import Blaster.Optimize.Env
 open Lean Meta
 namespace Blaster.Optimize
 
-theorem natAddSubOfBle {c a : Nat} (b : Nat) (h : Nat.ble c a = true) :
+theorem nat_add_sub_of_ble {c a : Nat} (b : Nat) (h : Nat.ble c a = true) :
     (a + b) - c = (a - c) + b := by
   have h : c ≤ a := by simpa [Nat.ble] using h
   simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using Nat.add_sub_assoc h b
@@ -55,7 +55,7 @@ def optimizeNatAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      - N1 - (N2 + n) ==> (N1 "-" N2) - n               [proof: Nat.sub_add_eq]
      - (N1 - n) - N2 ==> (N1 "-" N2) - n               [proof: Nat.sub_right_comm]
      - (n - N1) - N2 ==> n - (N1 "+" N2)               [proof: Nat.sub_sub]
-     - (N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)
+     - (N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)  [proof: nat_add_sub_of_ble]
    Assume that f = Expr.const ``Nat.sub.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.sub` expected at this stage)
 -/
@@ -117,7 +117,8 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
                 let n1Expr := op1.appFn!.appArg!
                 let hProof :=
                   mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
-                pushProofStep (.rewrite (mkApp4 (mkConst ``natAddSubOfBle) op2 n1Expr e1 hProof))
+                pushProofStep
+                  (.rewrite (mkApp4 (mkConst ``nat_add_sub_of_ble) op2 n1Expr e1 hProof))
                 setRestart
                 return mkApp2 (← mkNatAddOp) (← evalBinNatOp Nat.sub n1 n2) e1
               else return none

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -8,9 +8,9 @@ open Lean Meta
 namespace Blaster.Optimize
 
 /-- Apply the following simplification/normalization rules on `Nat.add` :
-     - 0 + n ==> n
+     - 0 + n ==> n                          [proof: Nat.zero_add]
      - N1 + N2 ===> N1 "+" N2
-     - N1 + (N2 + n) ==> (N1 "+" N2) + n
+     - N1 + (N2 + n) ==> (N1 "+" N2) + n    [proof: ← Nat.add_assoc]
      - n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)
    Assume that f = Expr.const ``Nat.add.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.add` expected at this stage)
@@ -20,7 +20,9 @@ def optimizeNatAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  match isNatValue? op1, isNatValue? op2 with
- | some 0, _ =>  return op2
+ | some 0, _ =>
+    pushProofStep (.rewrite (mkConst ``Nat.zero_add))
+    return op2
  | some n1, some n2 => evalBinNatOp Nat.add n1 n2
  | nv1,  _ =>
     if let some r ← cstAddProp? nv1 op2 then return r
@@ -33,18 +35,20 @@ def optimizeNatAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
    -/
    cstAddProp? (mv1 : Option Nat) (op2 : Expr) : TranslateEnvT (Option Expr) := do
     match mv1, toNatCstOpExpr? op2 with
-    | some n1, (NatCstOpInfo.NatAddExpr n2 e2) => return (mkApp2 f (← evalBinNatOp Nat.add n1 n2) e2)
+    | some n1, (NatCstOpInfo.NatAddExpr n2 e2) =>
+        pushProofStep (.rewrite (mkConst ``Nat.add_assoc) (symm := true) (once := true))
+        return (mkApp2 f (← evalBinNatOp Nat.add n1 n2) e2)
     | _, _ => return none
 
 
 /-- Apply the following simplification/normalization rules on `Nat.sub` :
-     - n1 - n2 ==> 0 (if n1 =ₚₜᵣ n2)
-     - 0 - n ==> 0
-     - n - 0 ==> n
+     - n1 - n2 ==> 0 (if n1 =ₚₜᵣ n2)                   [proof: Nat.sub_self]
+     - 0 - n ==> 0                                     [proof: Nat.zero_sub]
+     - n - 0 ==> n                                     [proof: Nat.sub_zero]
      - N1 - N2 ==> N1 "-" N2
-     - N1 - (N2 + n) ==> (N1 "-" N2) - n
-     - (N1 - n) - N2 ==> (N1 "-" N2) - n
-     - (n - N1) - N2 ==> n - (N1 "+" N2)
+     - N1 - (N2 + n) ==> (N1 "-" N2) - n               [proof: Nat.sub_add_eq]
+     - (N1 - n) - N2 ==> (N1 "-" N2) - n               [proof: Nat.sub_right_comm]
+     - (n - N1) - N2 ==> n - (N1 "+" N2)               [proof: Nat.sub_sub]
      - (N1 + n) - N2 ==> (N1 "-" N2) + n (if N1 ≥ N2)
    Assume that f = Expr.const ``Nat.sub.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.sub` expected at this stage)
@@ -53,10 +57,16 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeNatSub: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if exprEq op1 op2 then return (← mkNatLitExpr 0)
+ if exprEq op1 op2 then
+   pushProofStep (.rewrite (mkConst ``Nat.sub_self))
+   return (← mkNatLitExpr 0)
  match isNatValue? op1, isNatValue? op2 with
- | some 0, _
- | _, some 0 => return op1
+ | some 0, _ =>
+    pushProofStep (.rewrite (mkConst ``Nat.zero_sub))
+    return op1
+ | _, some 0 =>
+    pushProofStep (.rewrite (mkConst ``Nat.sub_zero))
+    return op1
  | some n1, some n2 => evalBinNatOp Nat.sub n1 n2
  | nv1, nv2 =>
    if let some r ← cstSubPropRight? nv1 op2 then return r
@@ -70,6 +80,7 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
    cstSubPropRight? (mv1 : Option Nat) (op2 : Expr) : TranslateEnvT (Option Expr) := do
     match mv1, toNatCstOpExpr? op2 with
     | some n1, NatCstOpInfo.NatAddExpr n2 e2 =>
+        pushProofStep (.rewrite (mkConst ``Nat.sub_add_eq) (once := true))
         setRestart
         return mkApp2 f (← evalBinNatOp Nat.sub n1 n2) e2
     | _, _ => return none
@@ -85,13 +96,16 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
      | some n2 =>
           match toNatCstOpExpr? op1 with
           | some (NatCstOpInfo.NatSubLeftExpr n1 e1) =>
+              pushProofStep (.rewrite (mkConst ``Nat.sub_right_comm) (once := true))
               setRestart
               return mkApp2 f (← evalBinNatOp Nat.sub n1 n2) e1
           | some (NatCstOpInfo.NatSubRightExpr e1 n1) =>
+              pushProofStep (.rewrite (mkConst ``Nat.sub_sub) (once := true))
               -- no need to restart here
               return (mkApp2 f e1 (← evalBinNatOp Nat.add n1 n2))
           | some (NatCstOpInfo.NatAddExpr n1 e1) =>
               if Nat.ble n2 n1 then
+                -- TODO: composed proof (add_comm + add_sub_assoc + add_comm)
                 setRestart
                 return mkApp2 (← mkNatAddOp) (← evalBinNatOp Nat.sub n1 n2) e1
               else return none
@@ -124,10 +138,10 @@ def optimizeNatPow (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  | _, _ => return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Nat.mul` :
-     - 0 * n ==> 0
-     - 1 * n ==> n
-     - N1 + N2 ==> N1 "*" N2
-     - N1 * (N2 * n) ==> (N1 "*" N2) * n
+     - 0 * n ==> 0                          [proof: Nat.zero_mul]
+     - 1 * n ==> n                          [proof: Nat.one_mul]
+     - N1 * N2 ==> N1 "*" N2
+     - N1 * (N2 * n) ==> (N1 "*" N2) * n    [proof: ← Nat.mul_assoc]
      - n1 * n2 ==> n2 * n1 (if n2 <ₒ n1)
      - n * n^m ===> n ^ (m + 1)
    Assume that f = Expr.const ``Nat.mul.
@@ -138,8 +152,12 @@ def optimizeNatMul (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  match isNatValue? op1, isNatValue? op2 with
- | some 0, _ => return op1
- | some 1, _ => return op2
+ | some 0, _ =>
+    pushProofStep (.rewrite (mkConst ``Nat.zero_mul))
+    return op1
+ | some 1, _ =>
+    pushProofStep (.rewrite (mkConst ``Nat.one_mul))
+    return op2
  | some n1, some n2 => evalBinNatOp Nat.mul n1 n2
  | nv1, _ =>
    if let some r ← cstMulProp? nv1 op2 then return r
@@ -154,6 +172,7 @@ def optimizeNatMul (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
    cstMulProp? (mv1 : Option Nat) (op2 : Expr) : TranslateEnvT (Option Expr) := do
      match mv1, toNatCstOpExpr? op2 with
      | some n1, some (NatCstOpInfo.NatMulExpr n2 e2) =>
+         pushProofStep (.rewrite (mkConst ``Nat.mul_assoc) (symm := true) (once := true))
          return (mkApp2 f (← evalBinNatOp Nat.mul n1 n2) e2)
      | _, _ => return none
 

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -154,7 +154,7 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
 -- -/
 
 /-- Apply the following simplification/normalization rules on `Nat.pow` :
-     - n ^ 0 ==> 1
+     - n ^ 0 ==> 1            [proof: Nat.pow_zero]
      - N1 ^ N2 ==> N1 "^" N2
    Assume that f = Expr.const ``Nat.pow.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.pow` expected at this stage)
@@ -165,7 +165,9 @@ def optimizeNatPow (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  let op1 := args[0]!
  let op2 := args[1]!
  match isNatValue? op1, isNatValue? op2 with
- | _, some 0 => return (← mkNatLitExpr 1)
+ | _, some 0 =>
+  pushProofStep (.rewrite (mkConst ``Nat.pow_zero))
+  return (← mkNatLitExpr 1)
  | some n1, some n2 => evalBinNatOp Nat.pow n1 n2
  | _, _ => return (mkApp2 f op1 op2)
 

--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -25,7 +25,7 @@ def optimizeNatAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
     return op2
  | some n1, some n2 => evalBinNatOp Nat.add n1 n2
  | nv1,  _ =>
-    if let some r ← cstAddProp? nv1 op2 then return r
+    if let some r ← cstAddProp? nv1 op1 op2 then return r
     return (mkApp2 f op1 op2)
 
  where
@@ -33,10 +33,11 @@ def optimizeNatAdd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
       `mv1 := some N1 ∧ op2 := N2 + n`.
       Otherwise `none`
    -/
-   cstAddProp? (mv1 : Option Nat) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+   cstAddProp? (mv1 : Option Nat) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
     match mv1, toNatCstOpExpr? op2 with
     | some n1, (NatCstOpInfo.NatAddExpr n2 e2) =>
-        pushProofStep (.rewrite (mkConst ``Nat.add_assoc) (symm := true) (once := true))
+        let n2Expr := op2.appFn!.appArg!
+        pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.add_assoc) op1 n2Expr e2) (symm := true))
         return (mkApp2 f (← evalBinNatOp Nat.add n1 n2) e2)
     | _, _ => return none
 
@@ -69,18 +70,19 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
     return op1
  | some n1, some n2 => evalBinNatOp Nat.sub n1 n2
  | nv1, nv2 =>
-   if let some r ← cstSubPropRight? nv1 op2 then return r
-   if let some r ← cstSubPropLeft? op1 nv2 then return r
+   if let some r ← cstSubPropRight? nv1 op1 op2 then return r
+   if let some r ← cstSubPropLeft? op1 op2 nv2 then return r
    return (mkApp2 f op1 op2)
 
  where
    /- Given `mv1` and `op2` return `some ((N1 "-" N2) - n)` when
       `mv1 := some N1 ∧ op2 := (N2 + n)`. Otherwise `none`.
    -/
-   cstSubPropRight? (mv1 : Option Nat) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+   cstSubPropRight? (mv1 : Option Nat) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
     match mv1, toNatCstOpExpr? op2 with
     | some n1, NatCstOpInfo.NatAddExpr n2 e2 =>
-        pushProofStep (.rewrite (mkConst ``Nat.sub_add_eq) (once := true))
+        let n2Expr := op2.appFn!.appArg!
+        pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.sub_add_eq) op1 n2Expr e2))
         setRestart
         return mkApp2 f (← evalBinNatOp Nat.sub n1 n2) e2
     | _, _ => return none
@@ -91,16 +93,18 @@ def optimizeNatSub (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
        - return `some ((N1 "-" N2) + n)` when `op1 := N1 + n ∧ mv2 := some N2 ∧ N1 ≥ N2`
       Otherwise `none`
    -/
-   cstSubPropLeft? (op1 : Expr) (mv2 : Option Nat) : TranslateEnvT (Option Expr) := do
+   cstSubPropLeft? (op1 : Expr) (op2 : Expr) (mv2 : Option Nat) : TranslateEnvT (Option Expr) := do
      match mv2 with
      | some n2 =>
           match toNatCstOpExpr? op1 with
           | some (NatCstOpInfo.NatSubLeftExpr n1 e1) =>
-              pushProofStep (.rewrite (mkConst ``Nat.sub_right_comm) (once := true))
+              let n1Expr := op1.appFn!.appArg!
+              pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.sub_right_comm) n1Expr e1 op2))
               setRestart
               return mkApp2 f (← evalBinNatOp Nat.sub n1 n2) e1
           | some (NatCstOpInfo.NatSubRightExpr e1 n1) =>
-              pushProofStep (.rewrite (mkConst ``Nat.sub_sub) (once := true))
+              let n1Expr := op1.appArg!
+              pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.sub_sub) e1 n1Expr op2))
               -- no need to restart here
               return (mkApp2 f e1 (← evalBinNatOp Nat.add n1 n2))
           | some (NatCstOpInfo.NatAddExpr n1 e1) =>
@@ -160,7 +164,7 @@ def optimizeNatMul (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
     return op2
  | some n1, some n2 => evalBinNatOp Nat.mul n1 n2
  | nv1, _ =>
-   if let some r ← cstMulProp? nv1 op2 then return r
+   if let some r ← cstMulProp? nv1 op1 op2 then return r
    if let some r ← mulPowReduceExpr? op1 op2 then return r
    return (mkApp2 f op1 op2)
 
@@ -169,10 +173,11 @@ def optimizeNatMul (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
       when `mv1 := some N1 ∧ op2 := (N2 * n)`
       Otherwise `none`.
    -/
-   cstMulProp? (mv1 : Option Nat) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+   cstMulProp? (mv1 : Option Nat) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
      match mv1, toNatCstOpExpr? op2 with
      | some n1, some (NatCstOpInfo.NatMulExpr n2 e2) =>
-         pushProofStep (.rewrite (mkConst ``Nat.mul_assoc) (symm := true) (once := true))
+         let n2Expr := op2.appFn!.appArg!
+         pushProofStep (.rewrite (mkApp3 (mkConst ``Nat.mul_assoc) op1 n2Expr e2) (symm := true))
          return (mkApp2 f (← evalBinNatOp Nat.mul n1 n2) e2)
      | _, _ => return none
 

--- a/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
@@ -30,8 +30,8 @@ namespace Blaster.Optimize
      - False ∧ e ==> False                                  [proof: false_and]
      - True ∧ e ==> e                                       [proof: true_and]
      - e1 ∧ e2 ==> e1 (if e1 =ₚₜᵣ e2)                        [proof: and_self]
-     - e ∧ ¬ e ==> False                                    [proof: and_not_self_is_false]
-     - true = e ∧ false = e ==> False                       [proof: true_and_false_is_false]
+     - e ∧ ¬ e ==> False                                    [proof: Blaster.and_not_self_is_false]
+     - true = e ∧ false = e ==> False                       [proof: Blaster.true_and_false_is_false]
      - e1 ∧ (e1 → e2) ==> e1 ∧ e2 (if ¬ e2.hasLooseBVars)
      - e1 ∧ (e2 → e1) ==> e1
      - (e1 → e2) ∧ (¬ e1 → e2) ==> e2

--- a/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
@@ -4,6 +4,13 @@ import Blaster.Optimize.Rewriting.OptimizeForAll
 open Lean Meta
 namespace Blaster.Optimize
 
+
+theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
+   simp
+
+theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
+  simp
+
  /-- Given `a` and `b` the operands for `And`, apply the simplification rules:
      - When a := _ ∈ hypothesisContext.hypothesisMap,
         - return `some b`
@@ -26,11 +33,11 @@ namespace Blaster.Optimize
 
 
 /-- Apply the following simplification/normalization rules on `And` :
-     - False ∧ e ==> False
-     - True ∧ e ==> e
-     - e1 ∧ e2 ==> e1 (if e1 =ₚₜᵣ e2)
-     - e ∧ ¬ e ==> False
-     - true = e ∧ false = e ==> False
+     - False ∧ e ==> False                                  [proof: false_and]
+     - True ∧ e ==> e                                       [proof: true_and]
+     - e1 ∧ e2 ==> e1 (if e1 =ₚₜᵣ e2)                        [proof: and_self]
+     - e ∧ ¬ e ==> False                                    [proof: and_not_self_is_false]
+     - true = e ∧ false = e ==> False                       [proof: true_and_false_is_false]
      - e1 ∧ (e1 → e2) ==> e1 ∧ e2 (if ¬ e2.hasLooseBVars)
      - e1 ∧ (e2 → e1) ==> e1
      - (e1 → e2) ∧ (¬ e1 → e2) ==> e2
@@ -47,11 +54,21 @@ def optimizeAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeAnd: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let Expr.const ``False _  := op1 then return op1
- if let Expr.const ``True _ := op1 then return op2
- if exprEq op1 op2 then return op1
- if isNotExprOf op2 op1 then return ← mkPropFalse
- if isNegBoolEqOf op2 op1 then return ← mkPropFalse
+ if let Expr.const ``False _  := op1 then
+   pushProofStep (.rewrite (mkConst ``false_and))
+   return op1
+ if let Expr.const ``True _ := op1 then
+   pushProofStep (.rewrite (mkConst ``true_and))
+   return op2
+ if exprEq op1 op2 then
+   pushProofStep (.rewrite (mkConst ``and_self))
+   return op1
+ if isNotExprOf op2 op1 then
+   pushProofStep (.rewrite (mkConst ``and_not_self_is_false))
+   return ← mkPropFalse
+ if isNegBoolEqOf op2 op1 then
+   pushProofStep (.rewrite (mkConst ``true_and_false_is_false))
+   return ← mkPropFalse
  if let some r ← andImpliesReduce? op1 op2 then return r
  if let some r ← andPropReduction? op1 op2 then return r
  -- no caching at this level as optimizeAnd is called by optimizeBoolPropAnd

--- a/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
@@ -137,7 +137,7 @@ def orImpliesReduce? (a : Expr) (b : Expr) : TranslateEnvT (Option Expr) := do
      - True ∨ e ==> True               [proof: true_or]
      - e1 ∨ e2 ==> e1 (if e1 =ₚₜᵣ e2)   [proof: or_self]
      - e ∨ ¬ e ==> True (classical)    [proof: Blaster.or_not_self_is_true]
-     - true = e ∨ false = e ==> True   [proof: Blaster.true_or_false_is_false]
+     - true = e ∨ false = e ==> True   [proof: Blaster.true_or_false_is_true]
      - e1 ∨ (e1 → e2) ==> True
      - e1 ∨ (e2 → e1) ==> (e2 → e1)
      - e1 ∨ e2 ==> True (if e1 := _ ∈ hypothesisContext.hypothesisMap)
@@ -168,7 +168,7 @@ def optimizeOr (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
    pushProofStep (.exact (mkConst ``True.intro))
    return (← mkPropTrue)
  if isNegBoolEqOf op2 op1 then
-   pushProofStep (.rewrite (mkConst ``Blaster.true_or_false_is_false))
+   pushProofStep (.rewrite (mkConst ``Blaster.true_or_false_is_true))
    pushProofStep (.exact (mkConst ``True.intro))
    return (← mkPropTrue)
  if let some r ← orImpliesReduce? op1 op2 then return r

--- a/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
@@ -5,12 +5,6 @@ open Lean Meta
 namespace Blaster.Optimize
 
 
-theorem and_not_self_is_false (a : Prop) : (a ∧ ¬ a) = False := by
-   simp
-
-theorem true_and_false_is_false (a : Bool) : (true = a ∧ false = a) = False := by
-  simp
-
  /-- Given `a` and `b` the operands for `And`, apply the simplification rules:
      - When a := _ ∈ hypothesisContext.hypothesisMap,
         - return `some b`
@@ -64,10 +58,10 @@ def optimizeAnd (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
    pushProofStep (.rewrite (mkConst ``and_self))
    return op1
  if isNotExprOf op2 op1 then
-   pushProofStep (.rewrite (mkConst ``and_not_self_is_false))
+   pushProofStep (.rewrite (mkConst ``Blaster.and_not_self_is_false))
    return ← mkPropFalse
  if isNegBoolEqOf op2 op1 then
-   pushProofStep (.rewrite (mkConst ``true_and_false_is_false))
+   pushProofStep (.rewrite (mkConst ``Blaster.true_and_false_is_false))
    return ← mkPropFalse
  if let some r ← andImpliesReduce? op1 op2 then return r
  if let some r ← andPropReduction? op1 op2 then return r

--- a/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropBinary.lean
@@ -133,11 +133,11 @@ def orImpliesReduce? (a : Expr) (b : Expr) : TranslateEnvT (Option Expr) := do
   | _ => return none
 
 /-- Apply the following simplification/normalization rules on `Or` :
-     - False ∨ e ==> e
-     - True ∨ e ==> True
-     - e1 ∨ e2 ==> e1 (if e1 =ₚₜᵣ e2)
-     - e ∨ ¬ e ==> True (classical)
-     - true = e ∨ false = e ==> True
+     - False ∨ e ==> e                 [proof: false_or]
+     - True ∨ e ==> True               [proof: true_or]
+     - e1 ∨ e2 ==> e1 (if e1 =ₚₜᵣ e2)   [proof: or_self]
+     - e ∨ ¬ e ==> True (classical)    [proof: Blaster.or_not_self_is_true]
+     - true = e ∨ false = e ==> True   [proof: Blaster.true_or_false_is_false]
      - e1 ∨ (e1 → e2) ==> True
      - e1 ∨ (e2 → e1) ==> (e2 → e1)
      - e1 ∨ e2 ==> True (if e1 := _ ∈ hypothesisContext.hypothesisMap)
@@ -153,11 +153,24 @@ def optimizeOr (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeOr: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let Expr.const ``False _ := op1 then return op2
- if let Expr.const ``True _ := op1 then return op1
- if exprEq op1 op2 then return op1
- if isNotExprOf op2 op1 then return (← mkPropTrue)
- if isNegBoolEqOf op2 op1 then return (← mkPropTrue)
+ if let Expr.const ``False _ := op1 then
+   pushProofStep (.rewrite (mkConst ``false_or))
+   return op2
+ if let Expr.const ``True _ := op1 then
+   pushProofStep (.rewrite (mkConst ``true_or))
+   pushProofStep (.exact (mkConst ``True.intro))
+   return op1
+ if exprEq op1 op2 then
+   pushProofStep (.rewrite (mkConst ``or_self))
+   return op1
+ if isNotExprOf op2 op1 then
+   pushProofStep (.rewrite (mkConst ``Blaster.or_not_self_is_true))
+   pushProofStep (.exact (mkConst ``True.intro))
+   return (← mkPropTrue)
+ if isNegBoolEqOf op2 op1 then
+   pushProofStep (.rewrite (mkConst ``Blaster.true_or_false_is_false))
+   pushProofStep (.exact (mkConst ``True.intro))
+   return (← mkPropTrue)
  if let some r ← orImpliesReduce? op1 op2 then return r
  if let some r ← orPropReduction? op1 op2 then return r
  -- no caching at this level as optimizeOr is called by optimizeBoolPropOr

--- a/Blaster/Optimize/Rewriting/OptimizePropNot.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropNot.lean
@@ -49,7 +49,7 @@ def notLTNumNorm? (ne : Expr) (restart := true) : TranslateEnvT (Option Expr) :=
 
 /-- Apply the following simplification/normalization rules on `Not` :
      - ¬ False ==> True             [proof: not_false_eq_true]
-     - ¬ True ==> False             [proof: true_ne_false]
+     - ¬ True ==> False             [proof: not_true_eq_false]
      - ¬ (¬ e) ==> e (classical)    [proof: Blaster.double_not_classical]
      - ¬ (false = e) ==> true = e   [proof: Blaster.not_false_is_true]
      - ¬ (true = e) ==> false = e   [proof: Blaster.not_true_is_false]

--- a/Blaster/Optimize/Rewriting/OptimizePropNot.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropNot.lean
@@ -1,5 +1,6 @@
 import Lean
 import Blaster.Optimize.Rewriting.Utils
+import Blaster.Optimize.Lemmas.LemmasProp
 
 open Lean Meta
 namespace Blaster.Optimize
@@ -24,8 +25,10 @@ def notEqSimp? (ne : Expr) : TranslateEnvT (Option Expr) := do
   | some (eq_sort, op1, op2) =>
      match op1 with
      | Expr.const ``false _ =>
+         pushProofStep (.rewrite (mkConst ``Blaster.not_false_is_true))
          return (mkApp3 ne.getAppFn eq_sort (← mkBoolTrue) op2)
      | Expr.const ``true _ =>
+         pushProofStep (.rewrite (mkConst ``Blaster.not_true_is_false))
          return (mkApp3 ne.getAppFn eq_sort (← mkBoolFalse) op2)
      | _ => return none
   | none => return none
@@ -46,10 +49,10 @@ def notLTNumNorm? (ne : Expr) (restart := true) : TranslateEnvT (Option Expr) :=
 
 /-- Apply the following simplification/normalization rules on `Not` :
      - ¬ False ==> True             [proof: not_false_eq_true]
-     - ¬ True ==> False
-     - ¬ (¬ e) ==> e (classical)
-     - ¬ (false = e) ==> true = e
-     - ¬ (true = e) ==> false = e
+     - ¬ True ==> False             [proof: true_ne_false]
+     - ¬ (¬ e) ==> e (classical)    [proof: Blaster.double_not_classical]
+     - ¬ (false = e) ==> true = e   [proof: Blaster.not_false_is_true]
+     - ¬ (true = e) ==> false = e   [proof: Blaster.not_true_is_false]
      - ¬ (0 < e) ==> (0 = e) (if Type(e) = Nat)
    Assume that f = Expr.const ``Not.
    An error is triggered if args.size ≠ 1 (i.e., only fully applied `Not` expected at this stage)
@@ -62,8 +65,12 @@ def optimizeNot (f : Expr) (args : Array Expr) (cacheResult := true) : Translate
   pushProofStep (.rewrite (mkConst ``not_false_eq_true))
   pushProofStep (.exact (mkConst ``True.intro))
   return (← mkPropTrue)
- if let Expr.const ``True _ := e then return (← mkPropFalse)
- if let some op := propNot? e then return op
+ if let Expr.const ``True _ := e then
+  pushProofStep (.rewrite (mkConst ``not_true_eq_false))
+  return (← mkPropFalse)
+ if let some op := propNot? e then
+  pushProofStep (.rewrite (mkConst ``Blaster.double_not_classical))
+  return op
  if let some r ← notEqSimp? e then return r
  if let some r ← notLTNumNorm? e cacheResult then return r
  return (mkApp f e)

--- a/Blaster/Optimize/Rewriting/OptimizePropNot.lean
+++ b/Blaster/Optimize/Rewriting/OptimizePropNot.lean
@@ -45,7 +45,7 @@ def notLTNumNorm? (ne : Expr) (restart := true) : TranslateEnvT (Option Expr) :=
 
 
 /-- Apply the following simplification/normalization rules on `Not` :
-     - ¬ False ==> True
+     - ¬ False ==> True             [proof: not_false_eq_true]
      - ¬ True ==> False
      - ¬ (¬ e) ==> e (classical)
      - ¬ (false = e) ==> true = e
@@ -58,7 +58,10 @@ def notLTNumNorm? (ne : Expr) (restart := true) : TranslateEnvT (Option Expr) :=
 def optimizeNot (f : Expr) (args : Array Expr) (cacheResult := true) : TranslateEnvT Expr := do
  if args.size != 1 then throwEnvError "optimizeNot: exactly one argument expected"
  let e := args[0]!
- if let Expr.const ``False _ := e then return (← mkPropTrue)
+ if let Expr.const ``False _ := e then
+  pushProofStep (.rewrite (mkConst ``not_false_eq_true))
+  pushProofStep (.exact (mkConst ``True.intro))
+  return (← mkPropTrue)
  if let Expr.const ``True _ := e then return (← mkPropFalse)
  if let some op := propNot? e then return op
  if let some r ← notEqSimp? e then return r

--- a/Blaster/Optimize/Rewriting/OptimizeRelational.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeRelational.lean
@@ -4,16 +4,6 @@ import Blaster.Optimize.Hypotheses
 open Lean Meta
 namespace Blaster.Optimize
 
-theorem nat_le_eq_not_lt (a b : Nat) : (a ≤ b) = (¬ (b < a)) :=
-  propext ⟨fun h hlt => Nat.lt_irrefl b (Nat.lt_of_lt_of_le hlt h),
-           Nat.le_of_not_lt⟩
-
-theorem int_le_eq_not_lt (a b : Int) : (a ≤ b) = (¬ (b < a)) :=
-  propext ⟨fun h hlt => absurd (Int.lt_of_lt_of_le hlt h) (Int.lt_irrefl b), Int.not_lt.mp⟩
-
-theorem nat_lt_zero_eq_false (a : Nat) : (a < 0) = False :=
-  propext ⟨fun h => Nat.not_lt_zero a h, fun h => h.elim⟩
-
 /-- Return `true` when `e` corresponds to the one nat literal. -/
 def isOneNat (e : Expr) : Bool :=
   match isNatValue? e with
@@ -256,7 +246,7 @@ def predCstLTInHyp (op1 : Expr) (op2 : Expr) : TranslateEnvT Bool := do
 
 /-- Apply the following simplification/normalization rules on `LT.lt` :
      - e1 < e2 ==> False (if e1 =ₚₜᵣ e2)
-     - e < 0 ==> False (if Type(e) = Nat)    [proof: nat_lt_zero_eq_false]
+     - e < 0 ==> False (if Type(e) = Nat)    [proof: Blaster.nat_lt_zero_eq_false]
      - 0 < -e ==> e < 0 (if Type(e) = Int)
      - N1 < N2 ==> N1 "<" N2
      - N < e ==> False (if ¬ (N - 1 < e) := _ ∈ hypothesisContext.hypothesisMap ∧ Type(e) ∈ [Nat, Int])
@@ -299,7 +289,7 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
  let op2 := args[3]!
  if (exprEq op1 op2) then return (← mkPropFalse)
  if (isZeroNat op2) then
-   pushProofStep (.rewrite (mkConst ``nat_lt_zero_eq_false))
+   pushProofStep (.rewrite (mkConst ``Blaster.nat_lt_zero_eq_false))
    return (← mkPropFalse)
  if let some r ← intZeroLtNorm? op1 op2 then return r
  if let some r ← cstLTProp? op1 op2 then return r
@@ -359,8 +349,8 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
 
 
 /-- Apply the following normalization rule on `LE.le` :
-     - e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Nat)   [proof: nat_le_eq_not_lt]
-     - e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Int)   [proof: int_le_eq_not_lt]
+     - e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Nat)   [proof: Blaster.nat_le_eq_not_lt]
+     - e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Int)   [proof: Blaster.int_le_eq_not_lt]
 
    This normalization rule is applied only when isOpaqueRelational predicate is satisfied
    Assume that f = Expr.const ``LE.le.
@@ -376,9 +366,9 @@ def optimizeLE (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
    let op1 := args[2]!
    let op2 := args[3]!
    if le_type.isConstOf ``Nat then
-     pushProofStep (.rewrite (mkApp2 (mkConst ``nat_le_eq_not_lt) op1 op2))
+     pushProofStep (.rewrite (mkApp2 (mkConst ``Blaster.nat_le_eq_not_lt) op1 op2))
    else if le_type.isConstOf ``Int then
-     pushProofStep (.rewrite (mkApp2 (mkConst ``int_le_eq_not_lt) op1 op2))
+     pushProofStep (.rewrite (mkApp2 (mkConst ``Blaster.int_le_eq_not_lt) op1 op2))
    setRestart
    mkNotLtExpr le_type op2 op1
  else if args.size == 2 then

--- a/Blaster/Optimize/Rewriting/OptimizeRelational.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeRelational.lean
@@ -4,6 +4,13 @@ import Blaster.Optimize.Hypotheses
 open Lean Meta
 namespace Blaster.Optimize
 
+theorem natLeEqNotLt (a b : Nat) : (a ≤ b) = (¬ (b < a)) :=
+  propext ⟨fun h hlt => Nat.lt_irrefl b (Nat.lt_of_lt_of_le hlt h),
+           Nat.le_of_not_lt⟩
+
+theorem intLeEqNotLt (a b : Int) : (a ≤ b) = (¬ (b < a)) :=
+  propext ⟨fun h hlt => absurd (Int.lt_of_lt_of_le hlt h) (Int.lt_irrefl b), Int.not_lt.mp⟩
+
 /-- Return `true` when `e` corresponds to the one nat literal. -/
 def isOneNat (e : Expr) : Bool :=
   match isNatValue? e with
@@ -362,6 +369,10 @@ def optimizeLE (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
    let le_type := args[0]!
    let op1 := args[2]!
    let op2 := args[3]!
+   if le_type.isConstOf ``Nat then
+     pushProofStep (.rewrite (mkApp2 (mkConst ``natLeEqNotLt) op1 op2))
+   else if le_type.isConstOf ``Int then
+     pushProofStep (.rewrite (mkApp2 (mkConst ``intLeEqNotLt) op1 op2))
    setRestart
    mkNotLtExpr le_type op2 op1
  else if args.size == 2 then

--- a/Blaster/Optimize/Rewriting/OptimizeRelational.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeRelational.lean
@@ -19,6 +19,62 @@ def isOneNat (e : Expr) : Bool :=
   | some 1 => true
   | _ => false
 
+/-- Proof-returning companion to `geqZeroIntInHyps` for a non-literal `e`: when a hypothesis
+    entailing `0 ≤ e` is in context (stored as `0 < e`, `0 = e`, or `¬ (e < 0)`), return a proof
+    of the canonical `0 ≤ e`; otherwise `none`. -/
+def geqZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := do
+ let hyps := (← get).optEnv.hypothesisContext.hypothesisMap
+ let zero ← mkIntLitExpr (Int.ofNat 0)
+ if let some p := hyps.get? (← mkIntLtExpr zero e) then
+   return mkApp2 (mkConst ``Blaster.int_le_of_zero_lt) e p
+ if let some p := hyps.get? (← mkIntEqExpr zero e) then
+   return mkApp2 (mkConst ``Blaster.int_le_of_zero_eq) e p
+ if let some p := hyps.get? (mkApp (← mkPropNotOp) (← mkIntLtExpr e zero)) then
+   return mkApp2 (mkConst ``Blaster.int_le_of_not_lt_zero) e p
+ return none
+
+/-- Proof-returning companion to `ltZeroIntInHyps` for a non-literal `e`: when `e < 0` is a
+    hypothesis in context, return its proof; otherwise `none`. -/
+def ltZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := do
+ let hyps := (← get).optEnv.hypothesisContext.hypothesisMap
+ let zero ← mkIntLitExpr (Int.ofNat 0)
+ return hyps.get? (← mkIntLtExpr e zero)
+
+/-- Proof-returning companion to `gtZeroIntInHyps` for a non-literal `e`: when `0 < e` is a
+    hypothesis in context, return its proof; otherwise `none`. -/
+def gtZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := do
+ let hyps := (← get).optEnv.hypothesisContext.hypothesisMap
+ let zero ← mkIntLitExpr (Int.ofNat 0)
+ return hyps.get? (← mkIntLtExpr zero e)
+
+/-- Proof-returning companion to `leqZeroIntInHyps` for a non-literal `e`: when a hypothesis
+    entailing `e ≤ 0` is in context (stored as `e < 0`, `0 = e`, or `¬ (0 < e)`), return a proof
+    of the canonical `e ≤ 0`; otherwise `none`. -/
+def leqZeroIntProof? (e : Expr) : TranslateEnvT (Option Expr) := do
+ let hyps := (← get).optEnv.hypothesisContext.hypothesisMap
+ let zero ← mkIntLitExpr (Int.ofNat 0)
+ if let some p := hyps.get? (← mkIntLtExpr e zero) then
+   return mkApp2 (mkConst ``Blaster.int_le_zero_of_lt_zero) e p
+ if let some p := hyps.get? (← mkIntEqExpr zero e) then
+   return mkApp2 (mkConst ``Blaster.int_le_zero_of_zero_eq) e p
+ if let some p := hyps.get? (mkApp (← mkPropNotOp) (← mkIntLtExpr zero e)) then
+   return mkApp2 (mkConst ``Blaster.int_le_zero_of_not_zero_lt) e p
+ return none
+
+/-- Proof-returning companion to `eqZeroNatInHyps` for a non-literal `e`: when `0 = e` is a
+    hypothesis in context, return its proof; otherwise `none`. -/
+def eqZeroNatProof? (e : Expr) : TranslateEnvT (Option Expr) := do
+ let hyps := (← get).optEnv.hypothesisContext.hypothesisMap
+ let zero ← mkNatLitExpr 0
+ return hyps.get? (← mkNatEqExpr zero e)
+
+/-- Proof-returning companion to `gtZeroNatInHyps` for a non-literal `e`: when `0 < e` is a
+    hypothesis in context, return its proof; otherwise `none`. -/
+def gtZeroNatProof? (e : Expr) : TranslateEnvT (Option Expr) := do
+ let hyps := (← get).optEnv.hypothesisContext.hypothesisMap
+ let zero ← mkNatLitExpr 0
+ return hyps.get? (← mkNatLtExpr zero e)
+
 /-- Given `op1` and `op2` corresponding to the operands for `LT.lt`:
       - return `some False` when `op1 := N + e ∧ op2 := e ∧ N > 0 ∧ Type(N) = Int`
       - return `some True` when `op1 := N + e ∧ op2 := e ∧ N < 0 ∧ Type(N) = Int`
@@ -44,11 +100,23 @@ def intRelLeftReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :=
       return ← mkPropTrue
  | none =>
      if exprEq e1 op2 then
-       if ← geqZeroIntInHyps e2 then return ← mkPropFalse
-       if ← ltZeroIntInHyps e2 then return ← mkPropTrue
+       if let some p ← geqZeroIntProof? e2 then
+         pushProofStep
+           (.rewrite (mkApp3 (mkConst ``Blaster.int_add_lt_self_eq_false_of_nonneg) op2 e2 p))
+         return ← mkPropFalse
+       if let some p ← ltZeroIntProof? e2 then
+         pushProofStep
+           (.rewrite (mkApp3 (mkConst ``Blaster.int_add_lt_self_eq_true_of_neg) op2 e2 p))
+         return ← mkPropTrue
      if exprEq e2 op2 then
-       if ← geqZeroIntInHyps e1 then return ← mkPropFalse
-       if ← ltZeroIntInHyps e1 then return ← mkPropTrue
+       if let some p ← geqZeroIntProof? e1 then
+         pushProofStep
+           (.rewrite (mkApp3 (mkConst ``Blaster.int_add_lt_self_right_eq_false_of_nonneg) op2 e1 p))
+         return ← mkPropFalse
+       if let some p ← ltZeroIntProof? e1 then
+         pushProofStep
+           (.rewrite (mkApp3 (mkConst ``Blaster.int_add_lt_self_right_eq_true_of_neg) op2 e1 p))
+         return ← mkPropTrue
      return none
 
 /-- Given `op1` and `op2` corresponding to the operands for `LT.lt`:
@@ -76,11 +144,23 @@ def intRelRightReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :
         return ← mkPropFalse
  | none =>
       if exprEq e1 op1 then
-        if ← leqZeroIntInHyps e2 then return ← mkPropFalse
-        if ← gtZeroIntInHyps e2 then return ← mkPropTrue
+        if let some p ← leqZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_add_self_eq_false_of_nonpos) op1 e2 p))
+          return ← mkPropFalse
+        if let some p ← gtZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_add_self_eq_true_of_pos) op1 e2 p))
+          return ← mkPropTrue
       if exprEq e2 op1 then
-        if ← leqZeroIntInHyps e1 then return ← mkPropFalse
-        if ← gtZeroIntInHyps e1 then return ← mkPropTrue
+        if let some p ← leqZeroIntProof? e1 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_add_self_right_eq_false_of_nonpos) op1 e1 p))
+          return ← mkPropFalse
+        if let some p ← gtZeroIntProof? e1 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_add_self_right_eq_true_of_pos) op1 e1 p))
+          return ← mkPropTrue
       return none
 
 /-- Given `op1` and `op2` corresponding to the operands for `LT.lt`:
@@ -118,11 +198,23 @@ def natRelRightReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :
       return none
  | none =>
       if (exprEq e1 op1) then
-        if ← eqZeroNatInHyps e2 then return ← mkPropFalse
-        if ← gtZeroNatInHyps e2 then return ← mkPropTrue
+        if let some p ← eqZeroNatProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_add_self_eq_false_of_zero_eq) op1 e2 p))
+          return ← mkPropFalse
+        if let some p ← gtZeroNatProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_add_self_eq_true_of_zero_lt) op1 e2 p))
+          return ← mkPropTrue
       if (exprEq e2 op1) then
-        if ← eqZeroNatInHyps e1 then return ← mkPropFalse
-        if ← gtZeroNatInHyps e1 then return ← mkPropTrue
+        if let some p ← eqZeroNatProof? e1 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_add_self_right_eq_false_of_zero_eq) op1 e1 p))
+          return ← mkPropFalse
+        if let some p ← gtZeroNatProof? e1 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_add_self_right_eq_true_of_zero_lt) op1 e1 p))
+          return ← mkPropTrue
       return none
 
 /-- Given `op1` and `op2` corresponding to the operands for `LT.lt`:
@@ -187,16 +279,48 @@ def intZeroLtNorm? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
 def intZeroLtSum? (op1 op2 : Expr) : TranslateEnvT (Option Expr) := do
   match isIntValue? op1, isIntValue? op2, intAdd? op1, intAdd? op2 with
   | some 0, _, _, some (e1, e2) =>
-      if (← geqZeroIntInHyps e1 <&&> gtZeroIntInHyps e2) then return (← mkPropTrue)
-      if (← gtZeroIntInHyps e1 <&&> geqZeroIntInHyps e2) then return (← mkPropTrue)
-      if (← leqZeroIntInHyps e1 <&&> ltZeroIntInHyps e2) then return (← mkPropFalse)
-      if (← ltZeroIntInHyps e1 <&&> leqZeroIntInHyps e2) then return (← mkPropFalse)
+      if let some p1 ← geqZeroIntProof? e1 then
+        if let some p2 ← gtZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_zero_lt_add_eq_true_of_nonneg_pos) e1 e2 p1 p2))
+          return (← mkPropTrue)
+      if let some p1 ← gtZeroIntProof? e1 then
+        if let some p2 ← geqZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_zero_lt_add_eq_true_of_pos_nonneg) e1 e2 p1 p2))
+          return (← mkPropTrue)
+      if let some p1 ← leqZeroIntProof? e1 then
+        if let some p2 ← ltZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_zero_lt_add_eq_false_of_nonpos_neg) e1 e2 p1 p2))
+          return (← mkPropFalse)
+      if let some p1 ← ltZeroIntProof? e1 then
+        if let some p2 ← leqZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_zero_lt_add_eq_false_of_neg_nonpos) e1 e2 p1 p2))
+          return (← mkPropFalse)
       return none
   | _, some 0, some (e1, e2), _ =>
-      if (← geqZeroIntInHyps e1 <&&> gtZeroIntInHyps e2) then return (← mkPropFalse)
-      if (← gtZeroIntInHyps e1 <&&> geqZeroIntInHyps e2) then return (← mkPropFalse)
-      if (← leqZeroIntInHyps e1 <&&> ltZeroIntInHyps e2) then return (← mkPropTrue)
-      if (← ltZeroIntInHyps e1 <&&> leqZeroIntInHyps e2) then return (← mkPropTrue)
+      if let some p1 ← geqZeroIntProof? e1 then
+        if let some p2 ← gtZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_add_lt_zero_eq_false_of_nonneg_pos) e1 e2 p1 p2))
+          return (← mkPropFalse)
+      if let some p1 ← gtZeroIntProof? e1 then
+        if let some p2 ← geqZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_add_lt_zero_eq_false_of_pos_nonneg) e1 e2 p1 p2))
+          return (← mkPropFalse)
+      if let some p1 ← leqZeroIntProof? e1 then
+        if let some p2 ← ltZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_add_lt_zero_eq_true_of_nonpos_neg) e1 e2 p1 p2))
+          return (← mkPropTrue)
+      if let some p1 ← ltZeroIntProof? e1 then
+        if let some p2 ← leqZeroIntProof? e2 then
+          pushProofStep
+            (.rewrite (mkApp4 (mkConst ``Blaster.int_add_lt_zero_eq_true_of_neg_nonpos) e1 e2 p1 p2))
+          return (← mkPropTrue)
       return none
   | _, _, _, _ => return none
 
@@ -290,30 +414,36 @@ def predCstLTInHyp (op1 : Expr) (op2 : Expr) : TranslateEnvT Bool := do
  match isNatValue? op1 with
  | some n =>
       let pred_n ← evalBinNatOp Nat.sub n 1
-      return hyps.contains (mkApp (← mkPropNotOp) (← mkNatLtExpr pred_n op2))
+      if let some p := hyps.get? (mkApp (← mkPropNotOp) (← mkNatLtExpr pred_n op2)) then
+        pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_false_of_not_pred_lt) op1 op2 p))
+        return true
+      return false
  | none =>
     let some n := isIntValue? op1 | return false
     let pred_n ← evalBinIntOp Int.sub n 1
-    return hyps.contains (mkApp (← mkPropNotOp) (← mkIntLtExpr pred_n op2))
+    if let some p := hyps.get? (mkApp (← mkPropNotOp) (← mkIntLtExpr pred_n op2)) then
+      pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_false_of_not_pred_lt) op1 op2 p))
+      return true
+    return false
 
 /-- Apply the following simplification/normalization rules on `LT.lt` :
      - e1 < e2 ==> False (if e1 =ₚₜᵣ e2)    [proof: Blaster.{nat,int}_lt_self_eq_false]
      - e < 0 ==> False (if Type(e) = Nat)   [proof: Blaster.nat_lt_zero_eq_false]
      - 0 < -e ==> e < 0 (if Type(e) = Int   [proof: Blaster.int_zero_lt_neg_eq_lt_zero]
      - N1 < N2 ==> N1 "<" N2    [proof: Blaster.{nat,int}_lt_eq_{true,false}]
-     - N < e ==> False (if ¬ (N - 1 < e) := _ ∈ hypothesisContext.hypothesisMap ∧ Type(e) ∈ [Nat, Int])
+     - N < e ==> False (if ¬ (N - 1 < e) := _ ∈ hypothesisContext.hypothesisMap ∧ Type(e) ∈ [Nat, Int])    [proof: Blaster.{nat,int}_lt_false_of_not_pred_lt]
      - e < 1 ==> 0 = e (if Type(e) = Nat)    [proof: Blaster.nat_lt_one_eq_zero_eq]
      - a + b < a | b + a < a ==> False (if Type(a) = Nat)    [proof: Blaster.nat_add_lt_self{,_right}_eq_false]
      - N + e < e ==> False (if N > 0 ∧ Type(e) = Int)        [proof: Blaster.int_add_pos_lt_self_eq_false]
      - N + e < e ==> True (if N < 0 ∧ Type(e) = Int)         [proof: Blaster.int_add_neg_lt_self_eq_true]
-     - a + b < a | b + a < a ==> False (if Type(a) = Int ∧ geqZeroIntInHyps b)
-     - a + b < a | b + a < a ==> True (if Type(a) = Int ∧ ltZeroIntInHyps b)
+     - a + b < a | b + a < a ==> False (if Type(a) = Int ∧ geqZeroIntInHyps b)    [proof: Blaster.int_add_lt_self{,_right}_eq_false_of_nonneg]
+     - a + b < a | b + a < a ==> True (if Type(a) = Int ∧ ltZeroIntInHyps b)    [proof: Blaster.int_add_lt_self{,_right}_eq_true_of_neg]
      - e < N + e ==> True (if N > 0 ∧ Type(N) ∈ [Nat, Int])  [proof: Blaster.nat_lt_add_left_eq_true, Blaster.int_lt_add_pos_eq_true]
      - e < N + e ==> False (if N < 0 ∧ Type(N) = Int)        [proof: Blaster.int_lt_add_neg_eq_false]
-     - a < a + b | a < b + a ==> False (if Type(a) = Nat ∧ eqZeroNatInHyps b)
-     - a < a + b | a < b + a ==> True (if Type(a) = Nat ∧ gtZeroNatInHyps b)
-     - a < a + b | a < b + a ==> False (if Type(a) = Int ∧ leqZeroIntInHyps b)
-     - a < a + b | a < b + a ==> True (if Type(a) = Int ∧ gtZeroIntInHyps b)
+     - a < a + b | a < b + a ==> False (if Type(a) = Nat ∧ eqZeroNatInHyps b)    [proof: Blaster.nat_lt_add_self{,_right}_eq_false_of_zero_eq]
+     - a < a + b | a < b + a ==> True (if Type(a) = Nat ∧ gtZeroNatInHyps b)    [proof: Blaster.nat_lt_add_self{,_right}_eq_true_of_zero_lt]
+     - a < a + b | a < b + a ==> False (if Type(a) = Int ∧ leqZeroIntInHyps b)    [proof: Blaster.int_lt_add_self{,_right}_eq_false_of_nonpos]
+     - a < a + b | a < b + a ==> True (if Type(a) = Int ∧ gtZeroIntInHyps b)    [proof: Blaster.int_lt_add_self{,_right}_eq_true_of_pos]
      - N1 + a < N2 ==> False (if Type(a) = Nat ∧ N2 ≤ N1)    [proof: Blaster.nat_add_const_lt_eq_false]
      - N1 + a < N2 ==> a < N2 "-" N1 (if Type(a) = Nat ∧ N2 > N1)    [proof: Blaster.nat_add_const_lt_eq_lt_sub]
      - N1 + a < N2 ==> a < N2 "-" N1 (if Type(a) = Int)    [proof: Blaster.int_add_const_lt_eq_lt_sub]
@@ -322,10 +452,14 @@ def predCstLTInHyp (op1 : Expr) (op2 : Expr) : TranslateEnvT Bool := do
      - N1 < N2 + a ==> N1 "-" N2 < a  (if Type(a) = Int)    [proof: Blaster.int_const_lt_add_eq_sub_lt]
      - N1 + a < N2 + b ==> N1 "-" min(N1, N2) + a < N2 "-" min(N1, N2) + b (if Type(a) ∈ [Nat, Int])    [proof: Blaster.{nat,int}_add_both_lt]
      - a < 1 + b ==> ¬ (b < a) (if Type(a) ∈ [Nat, Int])    [proof: Blaster.{nat,int}_lt_one_add_eq_not_lt]
-     - 0 < x + y ==> True (if Type (x) ∈ Int ∧ geqZeroIntInHyps x ∧ gtZeroIntInHyps y)
-     - 0 < x + y ==> True (if Type (x) ∈ Int ∧ gtZeroIntInHyps x ∧ geqZeroIntInHyps y)
-     - 0 < x + y ==> False (if Type (x) = Int ∧ ltZeroIntInHyps x ∧ leqZeroIntInHyps y)
-     - 0 < x + y ==> False (if Type (x) = Int ∧ leqZeroIntInHyps x ∧ ltZeroIntInHyps y)
+     - 0 < x + y ==> True (if Type (x) ∈ Int ∧ geqZeroIntInHyps x ∧ gtZeroIntInHyps y)    [proof: Blaster.int_zero_lt_add_eq_true_of_nonneg_pos]
+     - 0 < x + y ==> True (if Type (x) ∈ Int ∧ gtZeroIntInHyps x ∧ geqZeroIntInHyps y)    [proof: Blaster.int_zero_lt_add_eq_true_of_pos_nonneg]
+     - 0 < x + y ==> False (if Type (x) = Int ∧ ltZeroIntInHyps x ∧ leqZeroIntInHyps y)    [proof: Blaster.int_zero_lt_add_eq_false_of_neg_nonpos]
+     - 0 < x + y ==> False (if Type (x) = Int ∧ leqZeroIntInHyps x ∧ ltZeroIntInHyps y)    [proof: Blaster.int_zero_lt_add_eq_false_of_nonpos_neg]
+     - x + y < 0 ==> False (if Type (x) = Int ∧ geqZeroIntInHyps x ∧ gtZeroIntInHyps y)    [proof: Blaster.int_add_lt_zero_eq_false_of_nonneg_pos]
+     - x + y < 0 ==> False (if Type (x) = Int ∧ gtZeroIntInHyps x ∧ geqZeroIntInHyps y)    [proof: Blaster.int_add_lt_zero_eq_false_of_pos_nonneg]
+     - x + y < 0 ==> True (if Type (x) = Int ∧ leqZeroIntInHyps x ∧ ltZeroIntInHyps y)    [proof: Blaster.int_add_lt_zero_eq_true_of_nonpos_neg]
+     - x + y < 0 ==> True (if Type (x) = Int ∧ ltZeroIntInHyps x ∧ leqZeroIntInHyps y)    [proof: Blaster.int_add_lt_zero_eq_true_of_neg_nonpos]
    The simplifications are only applied when isOpaqueRelational predicate is satisfied
    Assume that f = Expr.const ``LT.lt.
    Do nothing if operator is partially applied (i.e., args.size < 4)

--- a/Blaster/Optimize/Rewriting/OptimizeRelational.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeRelational.lean
@@ -4,6 +4,15 @@ import Blaster.Optimize.Hypotheses
 open Lean Meta
 namespace Blaster.Optimize
 
+/-- `@Eq.refl Bool true`, used as a defeq proof of a decidable condition `b = true`
+    (e.g. `Nat.ble n1 n2 = true` or `decide (0 < n) = true`) when `b` reduces to `true`. -/
+private def boolTrueRefl : Expr :=
+  mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.true)
+
+/-- `@Eq.refl Bool false`, the `false` counterpart of `boolTrueRefl`. -/
+private def boolFalseRefl : Expr :=
+  mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Bool) (mkConst ``Bool.false)
+
 /-- Return `true` when `e` corresponds to the one nat literal. -/
 def isOneNat (e : Expr) : Bool :=
   match isNatValue? e with
@@ -25,8 +34,14 @@ def intRelLeftReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :=
  | some n =>
     if !(exprEq e2 op2) then return none
     if n > 0
-    then return ← mkPropFalse
-    else return ← mkPropTrue
+    then
+      pushProofStep
+        (.rewrite (mkApp3 (mkConst ``Blaster.int_add_pos_lt_self_eq_false) op2 e1 boolTrueRefl))
+      return ← mkPropFalse
+    else
+      pushProofStep
+        (.rewrite (mkApp3 (mkConst ``Blaster.int_add_neg_lt_self_eq_true) op2 e1 boolTrueRefl))
+      return ← mkPropTrue
  | none =>
      if exprEq e1 op2 then
        if ← geqZeroIntInHyps e2 then return ← mkPropFalse
@@ -51,8 +66,14 @@ def intRelRightReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :
  | some n =>
       if !(exprEq e2 op1) then return none
       if n > 0
-      then return ← mkPropTrue
-      else return ← mkPropFalse
+      then
+        pushProofStep
+          (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_add_pos_eq_true) op1 e1 boolTrueRefl))
+        return ← mkPropTrue
+      else
+        pushProofStep
+          (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_add_neg_eq_false) op1 e1 boolTrueRefl))
+        return ← mkPropFalse
  | none =>
       if exprEq e1 op1 then
         if ← leqZeroIntInHyps e2 then return ← mkPropFalse
@@ -69,8 +90,12 @@ def intRelRightReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :
 -/
 def natRelLeftReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  let some (e1, e2) := natAdd? op1 | return none
- if (exprEq e1 op2) then return ← mkPropFalse
- if (exprEq e2 op2) then return ← mkPropFalse
+ if (exprEq e1 op2) then
+   pushProofStep (.rewrite (mkApp2 (mkConst ``Blaster.nat_add_lt_self_eq_false) op2 e2))
+   return ← mkPropFalse
+ if (exprEq e2 op2) then
+   pushProofStep (.rewrite (mkApp2 (mkConst ``Blaster.nat_add_lt_self_right_eq_false) op2 e1))
+   return ← mkPropFalse
  return none
 
 /-- Given `op1` and `op2` corresponding to the operands for `LT.lt`:
@@ -85,7 +110,11 @@ def natRelRightReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :
  let some (e1, e2) := natAdd? op2 | return none
  match isNatValue? e1 with
  | some n =>
-      if (exprEq e2 op1) then if n > 0 then return ← mkPropTrue
+      if (exprEq e2 op1) then
+        if n > 0 then
+          pushProofStep
+            (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_add_left_eq_true) op1 e1 boolTrueRefl))
+          return ← mkPropTrue
       return none
  | none =>
       if (exprEq e1 op1) then
@@ -103,13 +132,21 @@ def natRelRightReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :
     NOTE: This function need to be updated each time we are opacifying other Lean inductive types.
     Otheriwse `none`.
 -/
-def cstLTProp? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :=
+def cstLTProp? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  match op1, op2 with
- | Expr.lit (Literal.natVal n1), Expr.lit (Literal.natVal n2) => mkPropLit (Nat.blt n1 n2)
+ | Expr.lit (Literal.natVal n1), Expr.lit (Literal.natVal n2) =>
+   if Nat.blt n1 n2
+   then pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_eq_true) op1 op2 boolTrueRefl))
+   else pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.nat_lt_eq_false) op1 op2 boolFalseRefl))
+   mkPropLit (Nat.blt n1 n2)
  | Expr.lit (Literal.strVal s1), Expr.lit (Literal.strVal s2) => mkPropLit (s1 < s2)
  | _, _ =>
    match isIntValue? op1, isIntValue? op2 with
-   | some n1, some n2 => mkPropLit (n1 < n2)
+   | some n1, some n2 =>
+     if n1 < n2
+     then pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_eq_true) op1 op2 boolTrueRefl))
+     else pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.int_lt_eq_false) op1 op2 boolFalseRefl))
+     mkPropLit (n1 < n2)
    | _, _ => return none
 
 /-- Given `op1` and `op2` corresponding to the operands for `LT.lt`:
@@ -119,6 +156,7 @@ def cstLTProp? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :=
 def intLtNorm? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  let some (e1, e2) := intAdd? op2 | return none
  let some 1 := isIntValue? e1 | return none
+ pushProofStep (.rewrite (mkApp2 (mkConst ``Blaster.int_lt_one_add_eq_not_lt) op1 e2))
  setRestart
  return mkApp (← mkPropNotOp) (← mkIntLtExpr e2 op1)
 
@@ -129,6 +167,7 @@ def intLtNorm? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
 def intZeroLtNorm? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  let some 0 := isIntValue? op1 | return none
  let some op2' := intNeg? op2 | return none
+ pushProofStep (.rewrite (mkApp (mkConst ``Blaster.int_zero_lt_neg_eq_lt_zero) op2'))
  setRestart
  mkIntLtExpr op2' op1
 
@@ -168,6 +207,7 @@ def intZeroLtSum? (op1 op2 : Expr) : TranslateEnvT (Option Expr) := do
 def natLtNorm? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
  let some (e1, e2) := natAdd? op2 | return none
  let some 1 := isNatValue? e1 | return none
+ pushProofStep (.rewrite (mkApp2 (mkConst ``Blaster.nat_lt_one_add_eq_not_lt) op1 e2))
  setRestart
  return (mkApp (← mkPropNotOp) (← mkNatLtExpr e2 op1))
 
@@ -182,8 +222,13 @@ def addNatLeftLtReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) 
  let some (e1, e2) := natAdd? op1 | return none
  let some n2 := isNatValue? op2 | return none
  let some n1 := isNatValue? e1 | return none
- if n2 ≤ n1 then mkPropFalse
+ if n2 ≤ n1 then
+   pushProofStep
+    (.rewrite (mkApp4 (mkConst ``Blaster.nat_add_const_lt_eq_false) e2 e1 op2 boolTrueRefl))
+   mkPropFalse
  else
+   pushProofStep
+    (.rewrite (mkApp3 (mkConst ``Blaster.nat_add_const_lt_eq_lt_sub) e2 e1 op2))
    setRestart -- restart necessary to cache new expression
    mkNatLtExpr e2 (← evalBinNatOp Nat.sub n2 n1)
 
@@ -197,8 +242,13 @@ def addNatRightLtReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr)
  let some (e1, e2) := natAdd? op2 | return none
  let some n1 := isNatValue? op1 | return none
  let some n2 := isNatValue? e1 | return none
- if n1 < n2 then mkPropTrue
+ if n1 < n2 then
+   pushProofStep
+    (.rewrite (mkApp4 (mkConst ``Blaster.nat_const_lt_add_eq_true) e2 op1 e1 boolTrueRefl))
+   mkPropTrue
  else
+   pushProofStep
+    (.rewrite (mkApp4 (mkConst ``Blaster.nat_const_lt_add_eq_sub_lt) e2 op1 e1 boolTrueRefl))
    setRestart -- restart necessary to cache new expression
    mkNatLtExpr (← evalBinNatOp Nat.sub n1 n2) e2
 
@@ -212,6 +262,7 @@ def addIntLeftLtReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) 
  let some (e1, e2) := intAdd? op1 | return none
  let some n2 := isIntValue? op2 | return none
  let some n1 := isIntValue? e1 | return none
+ pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.int_add_const_lt_eq_lt_sub) e2 e1 op2))
  setRestart -- restart necessary to cache new expression
  mkIntLtExpr e2 (← evalBinIntOp Int.sub n2 n1)
 
@@ -224,6 +275,7 @@ def addIntRightLtReduce? (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr)
  let some (e1, e2) := intAdd? op2 | return none
  let some n1 := isIntValue? op1 | return none
  let some n2 := isIntValue? e1 | return none
+ pushProofStep (.rewrite (mkApp3 (mkConst ``Blaster.int_const_lt_add_eq_sub_lt) e2 op1 e1))
  setRestart -- restart necessary to cache new expression
  mkIntLtExpr (← evalBinIntOp Int.sub n1 n2) e2
 
@@ -245,31 +297,31 @@ def predCstLTInHyp (op1 : Expr) (op2 : Expr) : TranslateEnvT Bool := do
     return hyps.contains (mkApp (← mkPropNotOp) (← mkIntLtExpr pred_n op2))
 
 /-- Apply the following simplification/normalization rules on `LT.lt` :
-     - e1 < e2 ==> False (if e1 =ₚₜᵣ e2)
-     - e < 0 ==> False (if Type(e) = Nat)    [proof: Blaster.nat_lt_zero_eq_false]
-     - 0 < -e ==> e < 0 (if Type(e) = Int)
-     - N1 < N2 ==> N1 "<" N2
+     - e1 < e2 ==> False (if e1 =ₚₜᵣ e2)    [proof: Blaster.{nat,int}_lt_self_eq_false]
+     - e < 0 ==> False (if Type(e) = Nat)   [proof: Blaster.nat_lt_zero_eq_false]
+     - 0 < -e ==> e < 0 (if Type(e) = Int   [proof: Blaster.int_zero_lt_neg_eq_lt_zero]
+     - N1 < N2 ==> N1 "<" N2    [proof: Blaster.{nat,int}_lt_eq_{true,false}]
      - N < e ==> False (if ¬ (N - 1 < e) := _ ∈ hypothesisContext.hypothesisMap ∧ Type(e) ∈ [Nat, Int])
-     - e < 1 ==> 0 = e (if Type(e) = Nat)
-     - a + b < a | b + a < a ==> False (if Type(a) = Nat)
-     - N + e < e ==> False (if N > 0 ∧ Type(e) = Int)
-     - N + e < e ==> True (if N < 0 ∧ Type(e) = Int)
+     - e < 1 ==> 0 = e (if Type(e) = Nat)    [proof: Blaster.nat_lt_one_eq_zero_eq]
+     - a + b < a | b + a < a ==> False (if Type(a) = Nat)    [proof: Blaster.nat_add_lt_self{,_right}_eq_false]
+     - N + e < e ==> False (if N > 0 ∧ Type(e) = Int)        [proof: Blaster.int_add_pos_lt_self_eq_false]
+     - N + e < e ==> True (if N < 0 ∧ Type(e) = Int)         [proof: Blaster.int_add_neg_lt_self_eq_true]
      - a + b < a | b + a < a ==> False (if Type(a) = Int ∧ geqZeroIntInHyps b)
      - a + b < a | b + a < a ==> True (if Type(a) = Int ∧ ltZeroIntInHyps b)
-     - e < N + e ==> True (if N > 0 ∧ Type(N) ∈ [Nat, Int])
-     - e < N + e ==> False (if N < 0 ∧ Type(N) = Int)
+     - e < N + e ==> True (if N > 0 ∧ Type(N) ∈ [Nat, Int])  [proof: Blaster.nat_lt_add_left_eq_true, Blaster.int_lt_add_pos_eq_true]
+     - e < N + e ==> False (if N < 0 ∧ Type(N) = Int)        [proof: Blaster.int_lt_add_neg_eq_false]
      - a < a + b | a < b + a ==> False (if Type(a) = Nat ∧ eqZeroNatInHyps b)
      - a < a + b | a < b + a ==> True (if Type(a) = Nat ∧ gtZeroNatInHyps b)
      - a < a + b | a < b + a ==> False (if Type(a) = Int ∧ leqZeroIntInHyps b)
      - a < a + b | a < b + a ==> True (if Type(a) = Int ∧ gtZeroIntInHyps b)
-     - N1 + a < N2 ==> False (if Type(a) = Nat ∧ N2 ≤ N1)
-     - N1 + a < N2 ==> a < N2 "-" N1 (if Type(a) = Nat ∧ N2 > N1)
-     - N1 + a < N2 ==> a < N2 "-" N1 (if Type(a) = Int)
-     - N1 < N2 + a ==> True (if Type(a) = Nat ∧ N1 < N2)
-     - N1 < N2 + a ==> N1 "-" N2 < a (if Type(a) = Nat ∧ N1 ≥ N2)
-     - N1 < N2 + a ==> N1 "-" N2 < a  (if Type(a) = Int)
-     - N1 + a < N2 + b ==> N1 "-" min(N1, N2) + a < N2 "-" min(N1, N2) + b (if Type(a) ∈ [Nat, Int])
-     - a < 1 + b ==> ¬ (b < a) (if Type(a) ∈ [Nat, Int])
+     - N1 + a < N2 ==> False (if Type(a) = Nat ∧ N2 ≤ N1)    [proof: Blaster.nat_add_const_lt_eq_false]
+     - N1 + a < N2 ==> a < N2 "-" N1 (if Type(a) = Nat ∧ N2 > N1)    [proof: Blaster.nat_add_const_lt_eq_lt_sub]
+     - N1 + a < N2 ==> a < N2 "-" N1 (if Type(a) = Int)    [proof: Blaster.int_add_const_lt_eq_lt_sub]
+     - N1 < N2 + a ==> True (if Type(a) = Nat ∧ N1 < N2)    [proof: Blaster.nat_const_lt_add_eq_true]
+     - N1 < N2 + a ==> N1 "-" N2 < a (if Type(a) = Nat ∧ N1 ≥ N2)    [proof: Blaster.nat_const_lt_add_eq_sub_lt]
+     - N1 < N2 + a ==> N1 "-" N2 < a  (if Type(a) = Int)    [proof: Blaster.int_const_lt_add_eq_sub_lt]
+     - N1 + a < N2 + b ==> N1 "-" min(N1, N2) + a < N2 "-" min(N1, N2) + b (if Type(a) ∈ [Nat, Int])    [proof: Blaster.{nat,int}_add_both_lt]
+     - a < 1 + b ==> ¬ (b < a) (if Type(a) ∈ [Nat, Int])    [proof: Blaster.{nat,int}_lt_one_add_eq_not_lt]
      - 0 < x + y ==> True (if Type (x) ∈ Int ∧ geqZeroIntInHyps x ∧ gtZeroIntInHyps y)
      - 0 < x + y ==> True (if Type (x) ∈ Int ∧ gtZeroIntInHyps x ∧ geqZeroIntInHyps y)
      - 0 < x + y ==> False (if Type (x) = Int ∧ ltZeroIntInHyps x ∧ leqZeroIntInHyps y)
@@ -287,14 +339,22 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
  -- args[3] right operand
  let op1 := args[2]!
  let op2 := args[3]!
- if (exprEq op1 op2) then return (← mkPropFalse)
+ if (exprEq op1 op2) then
+   let lt_type := args[0]!
+   if lt_type.isConstOf ``Nat then
+     pushProofStep (.rewrite (mkApp (mkConst ``Blaster.nat_lt_self_eq_false) op1))
+   else if lt_type.isConstOf ``Int then
+     pushProofStep (.rewrite (mkApp (mkConst ``Blaster.int_lt_self_eq_false) op1))
+   return (← mkPropFalse)
  if (isZeroNat op2) then
    pushProofStep (.rewrite (mkConst ``Blaster.nat_lt_zero_eq_false))
    return (← mkPropFalse)
  if let some r ← intZeroLtNorm? op1 op2 then return r
  if let some r ← cstLTProp? op1 op2 then return r
  if ← predCstLTInHyp op1 op2 then return (← mkPropFalse)
- if (isOneNat op2) then return (← mkNatEqExpr (← mkNatLitExpr 0) op1)
+ if (isOneNat op2) then
+   pushProofStep (.rewrite (mkApp (mkConst ``Blaster.nat_lt_one_eq_zero_eq) op1))
+   return (← mkNatEqExpr (← mkNatLitExpr 0) op1)
  if let some r ← intRelLeftReduce? op1 op2 then return r
  if let some r ← intRelRightReduce? op1 op2 then return r
  if let some r ← natRelLeftReduce? op1 op2 then return r
@@ -325,8 +385,14 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
      let minValue := min n1 n2
      let leftValue := n1 - minValue
      let rightValue := n2 - minValue
-     let op1' := mkApp2 (← mkNatAddOp) (← mkNatLitExpr leftValue) e2
-     let op2' := mkApp2 (← mkNatAddOp) (← mkNatLitExpr rightValue) e4
+     let leftLit ← mkNatLitExpr leftValue
+     let rightLit ← mkNatLitExpr rightValue
+     let op1' := mkApp2 (← mkNatAddOp) leftLit e2
+     let op2' := mkApp2 (← mkNatAddOp) rightLit e4
+     let hLeft := mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Nat) leftLit
+     let hRight := mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Nat) rightLit
+     pushProofStep
+       (.rewrite (mkAppN (mkConst ``Blaster.nat_add_both_lt) #[e2, e4, e1, e3, leftLit, rightLit, hLeft, hRight]))
      return mkApp4 f args[0]! args[1]! op1' op2'
 
    /-- Given `op1` and `op2` corresponding to the operands for `LT.lt` such that,
@@ -343,8 +409,14 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
      let minValue := min n1 n2
      let leftValue := n1 - minValue
      let rightValue := n2 - minValue
-     let op1' := mkApp2 (← mkIntAddOp) (← mkIntLitExpr leftValue) e2
-     let op2' := mkApp2 (← mkIntAddOp) (← mkIntLitExpr rightValue) e4
+     let leftLit ← mkIntLitExpr leftValue
+     let rightLit ← mkIntLitExpr rightValue
+     let op1' := mkApp2 (← mkIntAddOp) leftLit e2
+     let op2' := mkApp2 (← mkIntAddOp) rightLit e4
+     let hLeft := mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Int) leftLit
+     let hRight := mkApp2 (mkConst ``Eq.refl [.succ .zero]) (mkConst ``Int) rightLit
+     pushProofStep
+       (.rewrite (mkAppN (mkConst ``Blaster.int_add_both_lt) #[e2, e4, e1, e3, leftLit, rightLit, hLeft, hRight]))
      return mkApp4 f args[0]! args[1]! op1' op2'
 
 

--- a/Blaster/Optimize/Rewriting/OptimizeRelational.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeRelational.lean
@@ -4,12 +4,15 @@ import Blaster.Optimize.Hypotheses
 open Lean Meta
 namespace Blaster.Optimize
 
-theorem natLeEqNotLt (a b : Nat) : (a ≤ b) = (¬ (b < a)) :=
+theorem nat_le_eq_not_lt (a b : Nat) : (a ≤ b) = (¬ (b < a)) :=
   propext ⟨fun h hlt => Nat.lt_irrefl b (Nat.lt_of_lt_of_le hlt h),
            Nat.le_of_not_lt⟩
 
-theorem intLeEqNotLt (a b : Int) : (a ≤ b) = (¬ (b < a)) :=
+theorem int_le_eq_not_lt (a b : Int) : (a ≤ b) = (¬ (b < a)) :=
   propext ⟨fun h hlt => absurd (Int.lt_of_lt_of_le hlt h) (Int.lt_irrefl b), Int.not_lt.mp⟩
+
+theorem nat_lt_zero_eq_false (a : Nat) : (a < 0) = False :=
+  propext ⟨fun h => Nat.not_lt_zero a h, fun h => h.elim⟩
 
 /-- Return `true` when `e` corresponds to the one nat literal. -/
 def isOneNat (e : Expr) : Bool :=
@@ -253,7 +256,7 @@ def predCstLTInHyp (op1 : Expr) (op2 : Expr) : TranslateEnvT Bool := do
 
 /-- Apply the following simplification/normalization rules on `LT.lt` :
      - e1 < e2 ==> False (if e1 =ₚₜᵣ e2)
-     - e < 0 ==> False (if Type(e) = Nat)
+     - e < 0 ==> False (if Type(e) = Nat)    [proof: nat_lt_zero_eq_false]
      - 0 < -e ==> e < 0 (if Type(e) = Int)
      - N1 < N2 ==> N1 "<" N2
      - N < e ==> False (if ¬ (N - 1 < e) := _ ∈ hypothesisContext.hypothesisMap ∧ Type(e) ∈ [Nat, Int])
@@ -295,7 +298,9 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
  let op1 := args[2]!
  let op2 := args[3]!
  if (exprEq op1 op2) then return (← mkPropFalse)
- if (isZeroNat op2) then return (← mkPropFalse)
+ if (isZeroNat op2) then
+   pushProofStep (.rewrite (mkConst ``nat_lt_zero_eq_false))
+   return (← mkPropFalse)
  if let some r ← intZeroLtNorm? op1 op2 then return r
  if let some r ← cstLTProp? op1 op2 then return r
  if ← predCstLTInHyp op1 op2 then return (← mkPropFalse)
@@ -353,8 +358,9 @@ def optimizeLT (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
      return mkApp4 f args[0]! args[1]! op1' op2'
 
 
-/-- Apply the following snormalization rule on `LE.le` :
-     - e1 ≤ e2 ==> ¬ (e2 < e1)
+/-- Apply the following normalization rule on `LE.le` :
+     - e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Nat)   [proof: nat_le_eq_not_lt]
+     - e1 ≤ e2 ==> ¬ (e2 < e1) (if Type(e1) = Int)   [proof: int_le_eq_not_lt]
 
    This normalization rule is applied only when isOpaqueRelational predicate is satisfied
    Assume that f = Expr.const ``LE.le.
@@ -370,9 +376,9 @@ def optimizeLE (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
    let op1 := args[2]!
    let op2 := args[3]!
    if le_type.isConstOf ``Nat then
-     pushProofStep (.rewrite (mkApp2 (mkConst ``natLeEqNotLt) op1 op2))
+     pushProofStep (.rewrite (mkApp2 (mkConst ``nat_le_eq_not_lt) op1 op2))
    else if le_type.isConstOf ``Int then
-     pushProofStep (.rewrite (mkApp2 (mkConst ``intLeEqNotLt) op1 op2))
+     pushProofStep (.rewrite (mkApp2 (mkConst ``int_le_eq_not_lt) op1 op2))
    setRestart
    mkNotLtExpr le_type op2 op1
  else if args.size == 2 then

--- a/Blaster/Optimize/Rewriting/Utils.lean
+++ b/Blaster/Optimize/Rewriting/Utils.lean
@@ -386,6 +386,16 @@ def reorderOperands (f : Expr) (args : Array Expr) : TranslateEnvT (Array Expr) 
   | ``Nat.mul =>
        if args.size != 2 then return args
        let (op1, op2) := reorderNatOp args
+       if !exprEq op1 args[0]! then
+         if n == ``Nat.add then
+           match isNatValue? op1 with
+           | some 0 => pushProofStep (.rewrite (mkConst ``Nat.add_zero))
+           | _ => pushProofStep (.rewrite (mkConst ``Nat.add_comm) (once := true))
+         else
+           match isNatValue? op1 with
+           | some 0 => pushProofStep (.rewrite (mkConst ``Nat.mul_zero))
+           | some 1 => pushProofStep (.rewrite (mkConst ``Nat.mul_one))
+           | _ => pushProofStep (.rewrite (mkConst ``Nat.mul_comm) (once := true))
        return #[op1, op2]
 
   | ``Int.add

--- a/Blaster/Optimize/Rewriting/Utils.lean
+++ b/Blaster/Optimize/Rewriting/Utils.lean
@@ -419,6 +419,9 @@ def reorderOperands (f : Expr) (args : Array Expr) : TranslateEnvT (Array Expr) 
   | ``Eq =>
        if args.size != 3 then return args
        let (op1, op2) ← reorderEq #[args[1]!, args[2]!]
+       if !exprEq op1 args[1]! then
+         let iff ← mkAppOptM ``eq_comm #[args[0]!, args[1]!, args[2]!]
+         pushProofStep (.rewrite (← mkAppM ``propext #[iff]))
        return (args.set! 1 op1).set! 2 op2
 
   | ``BEq.beq =>

--- a/Blaster/Optimize/Rewriting/Utils.lean
+++ b/Blaster/Optimize/Rewriting/Utils.lean
@@ -383,7 +383,14 @@ def reorderIntOp (args: Array Expr) : (Expr × Expr) :=
       let (e1', e2') := reorderCommon e1 e2
       if isIntNegExprOf e1' e2' then (e2', e1') else (e1', e2')
 
-/-- Reorder operands for commutative operators -/
+/-- Reorder operands for commutative operators.
+    The following proof steps are emitted during reordering:
+     - Nat.add: n1 + n2 ==> n2 + n1          [proof: Nat.add_comm]
+     - Nat.add: n + 0 ==> 0 + n              [proof: Nat.add_zero]
+     - Nat.mul: n1 * n2 ==> n2 * n1          [proof: Nat.mul_comm]
+     - Nat.mul: n * 0 ==> 0 * n              [proof: Nat.mul_zero]
+     - Nat.mul: n * 1 ==> 1 * n              [proof: Nat.mul_one]
+-/
 def reorderOperands (f : Expr) (args : Array Expr) : TranslateEnvT (Array Expr) := do
   let Expr.const n _ := f | return args
   match n with

--- a/Blaster/Optimize/Rewriting/Utils.lean
+++ b/Blaster/Optimize/Rewriting/Utils.lean
@@ -390,6 +390,11 @@ def reorderIntOp (args: Array Expr) : (Expr × Expr) :=
      - Nat.mul: n1 * n2 ==> n2 * n1          [proof: Nat.mul_comm]
      - Nat.mul: n * 0 ==> 0 * n              [proof: Nat.mul_zero]
      - Nat.mul: n * 1 ==> 1 * n              [proof: Nat.mul_one]
+     - Int.add: n1 + n2 ==> n2 + n1          [proof: Int.add_comm]
+     - Int.add: n + 0 ==> 0 + n              [proof: Int.add_zero]
+     - Int.mul: n1 * n2 ==> n2 * n1          [proof: Int.mul_comm]
+     - Int.mul: n * 0 ==> 0 * n              [proof: Int.mul_zero]
+     - Int.mul: n * 1 ==> 1 * n              [proof: Int.mul_one]
 -/
 def reorderOperands (f : Expr) (args : Array Expr) : TranslateEnvT (Array Expr) := do
   let Expr.const n _ := f | return args
@@ -414,6 +419,16 @@ def reorderOperands (f : Expr) (args : Array Expr) : TranslateEnvT (Array Expr) 
   | ``Int.mul =>
        if args.size != 2 then return args
        let (op1, op2) := reorderIntOp args
+       if !exprEq op1 args[0]! then
+         if n == ``Int.add then
+           match isIntValue? op1 with
+           | some 0 => pushProofStep (.rewrite (mkConst ``Int.add_zero))
+           | _ => pushProofStep (.rewrite (mkApp2 (mkConst ``Int.add_comm) args[0]! args[1]!))
+         else
+           match isIntValue? op1 with
+           | some 0 => pushProofStep (.rewrite (mkConst ``Int.mul_zero))
+           | some 1 => pushProofStep (.rewrite (mkConst ``Int.mul_one))
+           | _ => pushProofStep (.rewrite (mkApp2 (mkConst ``Int.mul_comm) args[0]! args[1]!))
        return #[op1, op2]
 
   | ``Eq =>

--- a/Blaster/Optimize/Rewriting/Utils.lean
+++ b/Blaster/Optimize/Rewriting/Utils.lean
@@ -390,12 +390,12 @@ def reorderOperands (f : Expr) (args : Array Expr) : TranslateEnvT (Array Expr) 
          if n == ``Nat.add then
            match isNatValue? op1 with
            | some 0 => pushProofStep (.rewrite (mkConst ``Nat.add_zero))
-           | _ => pushProofStep (.rewrite (mkConst ``Nat.add_comm) (once := true))
+           | _ => pushProofStep (.rewrite (mkApp2 (mkConst ``Nat.add_comm) args[0]! args[1]!))
          else
            match isNatValue? op1 with
            | some 0 => pushProofStep (.rewrite (mkConst ``Nat.mul_zero))
            | some 1 => pushProofStep (.rewrite (mkConst ``Nat.mul_one))
-           | _ => pushProofStep (.rewrite (mkConst ``Nat.mul_comm) (once := true))
+           | _ => pushProofStep (.rewrite (mkApp2 (mkConst ``Nat.mul_comm) args[0]! args[1]!))
        return #[op1, op2]
 
   | ``Int.add

--- a/Blaster/Smt/Translate/Application.lean
+++ b/Blaster/Smt/Translate/Application.lean
@@ -671,9 +671,9 @@ partial def translateRecFun
         let auxApp := finfos[i]!.1
         let smtId := finfos[i]!.2
         let instApp ← getInstApp auxApp params
-        let some fbody := env.optEnv.recFunInstCache.get? instApp
+        let some result := env.optEnv.recFunInstCache.get? instApp
           | throwEnvError "translateRecFun: function body expected for {reprStr instApp}"
-        let fbody' := fbody.replace (replaceGenericRecFun auxApp params)
+        let fbody' := result.optimizedBody.replace (replaceGenericRecFun auxApp params)
         -- apply polymorphic instances on body
         let genFVars ← retrieveGenericFVars params
         funDefs ← updateFunDefinitions smtId (Expr.beta fbody' genFVars) funDefs

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -1,6 +1,5 @@
-
 import Tests.FixedIssues
 import Tests.Optimize
+import Tests.Reconstruct.Basic
 import Tests.Smt
 import Tests.StateMachine
-

--- a/Tests/Optimize.lean
+++ b/Tests/Optimize.lean
@@ -8,6 +8,7 @@ import Tests.Optimize.OptimizeEq
 import Tests.Optimize.OptimizeExists
 import Tests.Optimize.OptimizeDecide
 import Tests.Optimize.OptimizeForAll
+import Tests.Optimize.OptimizeInt
 import Tests.Optimize.OptimizeITE
 import Tests.Optimize.OptimizeLet
 import Tests.Optimize.OptimizeMatch

--- a/Tests/Optimize.lean
+++ b/Tests/Optimize.lean
@@ -16,3 +16,4 @@ import Tests.Optimize.OptimizeNat
 import Tests.Optimize.OptimizeProp
 import Tests.Optimize.OptimizeRecFun
 import Tests.Optimize.OptimizeUnfold
+import Tests.Optimize.ReconstructLT

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
@@ -92,13 +92,13 @@ namespace Test.OptimizeBoolAnd
 /-! Test cases for simplification rule `e && not e ==> false`. -/
 
 -- (a && not a) = false ===> True
-#testOptimize [ "BoolAndNot_1" ] ∀ (a : Bool), (a && not a) = false ===> True
+#testOptimize [ "BoolAndNot_1", proof ] ∀ (a : Bool), (a && not a) = false ===> True
 
 -- a && not a ===> False
-#testOptimize [ "BoolAndNot_2" ] ∀ (a : Bool), a && not a ===> False
+#testOptimize [ "BoolAndNot_2", proof ] ∀ (a : Bool), a && not a ===> False
 
 -- a && !a ===> False
-#testOptimize [ "BoolAndNot_3" ] ∀ (a : Bool), a && !a ===> False
+#testOptimize [ "BoolAndNot_3", proof ] ∀ (a : Bool), a && !a ===> False
 
 -- (a && b) && !(b && a) ===> False
 #testOptimize [ "BoolAndNot_4" ] ∀ (a b : Bool), (a && b) && !(b && a) ===> False

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
@@ -31,22 +31,22 @@ namespace Test.OptimizeBoolAnd
 /-! Test cases for simplification rule `false && e ==> false`. -/
 
 -- (a && false) = false ===> True
-#testOptimize [ "BoolAndFalse_1", proof ] ∀ (a : Bool), (a && false) = false ===> True
+#testOptimize [ "BoolAndFalse_1" ] ∀ (a : Bool), (a && false) = false ===> True
 
 -- (a && false) ===> False
-#testOptimize [ "BoolAndFalse_2", proof ] ∀ (a : Bool), a && false ===> False
+#testOptimize [ "BoolAndFalse_2" ] ∀ (a : Bool), a && false ===> False
 
 -- (false && a) = false ===> True
 #testOptimize [ "BoolAndFalse_3", proof ] ∀ (a : Bool), (false && a) = false ===> True
 
 -- false && a ===> False
-#testOptimize [ "BoolAndFalse_4" ] ∀ (a : Bool), false && a ===> False
+#testOptimize [ "BoolAndFalse_4", proof ] ∀ (a : Bool), false && a ===> False
 
 -- false && (a || b) ===> False
-#testOptimize [ "BoolAndFalse_5" ] ∀ (a b : Bool), false && (a || b) ===> False
+#testOptimize [ "BoolAndFalse_5", proof ] ∀ (a b : Bool), false && (a || b) ===> False
 
 -- false && (a && b) ===> False
-#testOptimize [ "BoolAndFalse_6" ] ∀ (a b : Bool), false && (a && b) ===> False
+#testOptimize [ "BoolAndFalse_6", proof ] ∀ (a b : Bool), false && (a && b) ===> False
 
 -- a && (false && b) ===> False
 #testOptimize [ "BoolAndFalse_7" ] ∀ (a b : Bool), a && (false && b) ===> False
@@ -63,10 +63,10 @@ namespace Test.OptimizeBoolAnd
 /-! Test cases for simplification rule `true && e ==> e`. -/
 
 -- (a && true) = a ===> True
-#testOptimize [ "BoolAndTrue_1", proof ] ∀ (a : Bool), (a && true) = a ===> True
+#testOptimize [ "BoolAndTrue_1"] ∀ (a : Bool), (a && true) = a ===> True
 
 -- (a && true) ===> a (i.e., true = a)
-#testOptimize [ "BoolAndTrue_2", proof ] ∀ (a : Bool), a && true ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolAndTrue_2" ] ∀ (a : Bool), a && true ===> ∀ (a : Bool), true = a
 
 -- (true && a) = a ===> True
 #testOptimize [ "BoolAndTrue_3", proof ] ∀ (a : Bool), (true && a) = a ===> True
@@ -75,10 +75,10 @@ namespace Test.OptimizeBoolAnd
 #testOptimize [ "BoolAndTrue_4", proof ] ∀ (a b : Bool), (true && (a || b)) = (a || b) ===> True
 
 -- ((a && b) && true) = (a && b) ===> True
-#testOptimize [ "BoolAndTrue_5", proof ] ∀ (a b : Bool), ((a && b) && true) = (a && b) ===> True
+#testOptimize [ "BoolAndTrue_5" ] ∀ (a b : Bool), ((a && b) && true) = (a && b) ===> True
 
 -- ((a && true) && b) = (a && b) ===> True
-#testOptimize [ "BoolAndTrue_6", proof ] ∀ (a b : Bool), ((a && true) && b) = (a && b) ===> True
+#testOptimize [ "BoolAndTrue_6" ] ∀ (a b : Bool), ((a && true) && b) = (a && b) ===> True
 
 -- ((true && a) && b) = (a && b) ===> True
 #testOptimize [ "BoolAndTrue_7", proof ] ∀ (a b : Bool), ((true && a) && b) = (a && b) ===> True

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
@@ -34,7 +34,7 @@ namespace Test.OptimizeBoolAnd
 #testOptimize [ "BoolAndFalse_1", proof ] ∀ (a : Bool), (a && false) = false ===> True
 
 -- (a && false) ===> False
-#testOptimize [ "BoolAndFalse_2" ] ∀ (a : Bool), a && false ===> False
+#testOptimize [ "BoolAndFalse_2", proof ] ∀ (a : Bool), a && false ===> False
 
 -- (false && a) = false ===> True
 #testOptimize [ "BoolAndFalse_3", proof ] ∀ (a : Bool), (false && a) = false ===> True
@@ -66,7 +66,7 @@ namespace Test.OptimizeBoolAnd
 #testOptimize [ "BoolAndTrue_1", proof ] ∀ (a : Bool), (a && true) = a ===> True
 
 -- (a && true) ===> a (i.e., true = a)
-#testOptimize [ "BoolAndTrue_2" ] ∀ (a : Bool), a && true ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolAndTrue_2", proof ] ∀ (a : Bool), a && true ===> ∀ (a : Bool), true = a
 
 -- (true && a) = a ===> True
 #testOptimize [ "BoolAndTrue_3", proof ] ∀ (a : Bool), (true && a) = a ===> True
@@ -158,7 +158,7 @@ namespace Test.OptimizeBoolAnd
 #testOptimize [ "BoolAndSubsumption_1", proof ] ∀ (a : Bool), (a && a) = a ===> True
 
 -- (a && a) ===> a
-#testOptimize [ "BoolAndSubsumption_2" ] ∀ (a : Bool), a && a ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolAndSubsumption_2", proof ] ∀ (a : Bool), a && a ===> ∀ (a : Bool), true = a
 
 
 -- (a || b) && (b || a) ===> (a || b)
@@ -180,10 +180,10 @@ namespace Test.OptimizeBoolAnd
      -`e1 && e2 ==> e1 (if e1 =ₚₜᵣ e2)`
 -/
 -- a && b ===> a && b
-#testOptimize [ "BoolAndUnchanged_1" ] ∀ (a b : Bool), (a && b) ===> ∀ (a b : Bool), true = (a && b)
+#testOptimize [ "BoolAndUnchanged_1", proof ] ∀ (a b : Bool), (a && b) ===> ∀ (a b : Bool), true = (a && b)
 
 -- (a && c) && (b || d) ===> (a && c) && (b || d)
-#testOptimize [ "BoolAndUnchanged_2" ] ∀ (a b c d : Bool), (a && c) && (b || d) ===>
+#testOptimize [ "BoolAndUnchanged_2", proof ] ∀ (a b c d : Bool), (a && c) && (b || d) ===>
                                        ∀ (a b c d : Bool), true = ((a && c) && (b || d))
 
 

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
@@ -10,34 +10,34 @@ namespace Test.OptimizeBoolAnd
 /-! Test cases for `reduceApp` rule on ``and. -/
 
 -- true && false ===> false
-#testOptimize [ "BoolAndCst_1" ] true && false ===> false
+#testOptimize [ "BoolAndCst_1", proof ] true && false ===> false
 
 -- false && true ===> false
-#testOptimize [ "BoolAndCst_2" ] false && true ===> false
+#testOptimize [ "BoolAndCst_2", proof ] false && true ===> false
 
 -- true && true ===> true
-#testOptimize [ "BoolAndCst_3" ] true && true ===> true
+#testOptimize [ "BoolAndCst_3", proof ] true && true ===> true
 
 -- false && false ===> false
-#testOptimize [ "BoolAndCst_4" ] false && false ===> false
+#testOptimize [ "BoolAndCst_4", proof ] false && false ===> false
 
 -- ! true && false ===> false
-#testOptimize [ "BoolAndCst_5" ] !true && false ===> false
+#testOptimize [ "BoolAndCst_5", proof ] !true && false ===> false
 
 -- ! false && true ===> true
-#testOptimize [ "BoolAndCst_6" ] ! false && true ===> true
+#testOptimize [ "BoolAndCst_6", proof ] ! false && true ===> true
 
 
 /-! Test cases for simplification rule `false && e ==> false`. -/
 
 -- (a && false) = false ===> True
-#testOptimize [ "BoolAndFalse_1" ] ∀ (a : Bool), (a && false) = false ===> True
+#testOptimize [ "BoolAndFalse_1", proof ] ∀ (a : Bool), (a && false) = false ===> True
 
 -- (a && false) ===> False
 #testOptimize [ "BoolAndFalse_2" ] ∀ (a : Bool), a && false ===> False
 
 -- (false && a) = false ===> True
-#testOptimize [ "BoolAndFalse_3" ] ∀ (a : Bool), (false && a) = false ===> True
+#testOptimize [ "BoolAndFalse_3", proof ] ∀ (a : Bool), (false && a) = false ===> True
 
 -- false && a ===> False
 #testOptimize [ "BoolAndFalse_4" ] ∀ (a : Bool), false && a ===> False
@@ -63,25 +63,25 @@ namespace Test.OptimizeBoolAnd
 /-! Test cases for simplification rule `true && e ==> e`. -/
 
 -- (a && true) = a ===> True
-#testOptimize [ "BoolAndTrue_1" ] ∀ (a : Bool), (a && true) = a ===> True
+#testOptimize [ "BoolAndTrue_1", proof ] ∀ (a : Bool), (a && true) = a ===> True
 
 -- (a && true) ===> a (i.e., true = a)
 #testOptimize [ "BoolAndTrue_2" ] ∀ (a : Bool), a && true ===> ∀ (a : Bool), true = a
 
 -- (true && a) = a ===> True
-#testOptimize [ "BoolAndTrue_3" ] ∀ (a : Bool), (true && a) = a ===> True
+#testOptimize [ "BoolAndTrue_3", proof ] ∀ (a : Bool), (true && a) = a ===> True
 
 -- (true && (a || b)) = (a || b) ===> True
-#testOptimize [ "BoolAndTrue_4" ] ∀ (a b : Bool), (true && (a || b)) = (a || b) ===> True
+#testOptimize [ "BoolAndTrue_4", proof ] ∀ (a b : Bool), (true && (a || b)) = (a || b) ===> True
 
 -- ((a && b) && true) = (a && b) ===> True
-#testOptimize [ "BoolAndTrue_5" ] ∀ (a b : Bool), ((a && b) && true) = (a && b) ===> True
+#testOptimize [ "BoolAndTrue_5", proof ] ∀ (a b : Bool), ((a && b) && true) = (a && b) ===> True
 
 -- ((a && true) && b) = (a && b) ===> True
-#testOptimize [ "BoolAndTrue_6" ] ∀ (a b : Bool), ((a && true) && b) = (a && b) ===> True
+#testOptimize [ "BoolAndTrue_6", proof ] ∀ (a b : Bool), ((a && true) && b) = (a && b) ===> True
 
 -- ((true && a) && b) = (a && b) ===> True
-#testOptimize [ "BoolAndTrue_7" ] ∀ (a b : Bool), ((true && a) && b) = (a && b) ===> True
+#testOptimize [ "BoolAndTrue_7", proof ] ∀ (a b : Bool), ((true && a) && b) = (a && b) ===> True
 
 -- let x := a && a
 -- let y := a || !x
@@ -155,7 +155,7 @@ namespace Test.OptimizeBoolAnd
 /-! Test cases for simplification rule `e1 && e2 ==> e1 (if e1 =ₚₜᵣ e2)`. -/
 
 -- (a && a) = a ===> True
-#testOptimize [ "BoolAndSubsumption_1" ] ∀ (a : Bool), (a && a) = a ===> True
+#testOptimize [ "BoolAndSubsumption_1", proof ] ∀ (a : Bool), (a && a) = a ===> True
 
 -- (a && a) ===> a
 #testOptimize [ "BoolAndSubsumption_2" ] ∀ (a : Bool), a && a ===> ∀ (a : Bool), true = a

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolNot.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolNot.lean
@@ -9,24 +9,24 @@ namespace Tests.OptimizeBoolNot
 /-! Test cases for `reduceApp` rule on ``not. -/
 
 -- not false ===> true
-#testOptimize [ "BoolNotCst_1" ] not false ===> true
+#testOptimize [ "BoolNotCst_1", proof ] not false ===> true
 
 -- ! false ===> true
-#testOptimize [ "BoolNotCst_2" ] ! false ===> true
+#testOptimize [ "BoolNotCst_2", proof ] ! false ===> true
 
 -- not true ===> false
-#testOptimize [ "BoolNotCst_3" ] not true ===> false
+#testOptimize [ "BoolNotCst_3", proof ] not true ===> false
 
 -- ! true ===> false
-#testOptimize [ "BoolNotCst_4" ] ! true ===> false
+#testOptimize [ "BoolNotCst_4", proof ] ! true ===> false
 
 /-! Test cases for simplification rule `! (! e) ==> e`. -/
 
 -- not (not a) = a ===> True
-#testOptimize [ "BoolNot_1" ] ∀ (a : Bool), not (not a) = a ===> True
+#testOptimize [ "BoolNot_1", proof ] ∀ (a : Bool), not (not a) = a ===> True
 
 -- not (not a) ===> a
-#testOptimize [ "BoolNot_2" ] ∀ (a : Bool), not (not a) ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolNot_2", proof ] ∀ (a : Bool), not (not a) ===> ∀ (a : Bool), true = a
 
 -- not (not (not a)) = not a ===> True
 #testOptimize [ "BoolNot_3" ] ∀ (a : Bool), not (not (not a)) = not a ===> True
@@ -35,10 +35,10 @@ namespace Tests.OptimizeBoolNot
 #testOptimize [ "BoolNot_4" ] ∀ (a : Bool), not (not (not (not a))) = a ===> True
 
 -- ! (! a) = a ==> True
-#testOptimize [ "BoolNot_5" ] ∀ (a : Bool), (! (! a)) = a ===> True
+#testOptimize [ "BoolNot_5", proof ] ∀ (a : Bool), (! (! a)) = a ===> True
 
 -- ! (! a) ===> a
-#testOptimize [ "BoolNot_6" ] ∀ (a : Bool), (! (! a)) ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolNot_6", proof ] ∀ (a : Bool), (! (! a)) ===> ∀ (a : Bool), true = a
 
 -- ! (! (! a)) = ! a ===> True
 #testOptimize [ "BoolNot_7" ] ∀ (a : Bool), (! (! (! a))) = (! a) ===> True

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
@@ -11,46 +11,46 @@ namespace Tests.OptimizeBoolOr
 /-! Test cases for `reduceApp` rule on ``or. -/
 
 -- true || false ===> true
-#testOptimize [ "BoolOrCst_1" ] true || false ===> true
+#testOptimize [ "BoolOrCst_1", proof ] true || false ===> true
 
 -- false || true ===> true
-#testOptimize [ "BoolOrCst_2" ] false || true ===> true
+#testOptimize [ "BoolOrCst_2", proof ] false || true ===> true
 
 -- true || true ===> true
-#testOptimize [ "BoolOrCst_3" ] true || true ===> true
+#testOptimize [ "BoolOrCst_3", proof ] true || true ===> true
 
 -- false || false ===> false
-#testOptimize [ "BoolOrCst_4" ] false || false ===> false
+#testOptimize [ "BoolOrCst_4", proof ] false || false ===> false
 
 -- ! true || false ===> false
-#testOptimize [ "BoolOrCst_5" ] !true || false ===> false
+#testOptimize [ "BoolOrCst_5", proof ] !true || false ===> false
 
 -- ! false || false ===> true
-#testOptimize [ "BoolOrCst_6" ] !false || false ===> true
+#testOptimize [ "BoolOrCst_6", proof ] !false || false ===> true
 
 
 /-! Test cases for simplification rule `false || e ==> e`. -/
 
 -- (a || false) = a ===> True
-#testOptimize [ "BoolOrFalse_1" ] ∀ (a : Bool), (a || false) = a ===> True
+#testOptimize [ "BoolOrFalse_1", proof ] ∀ (a : Bool), (a || false) = a ===> True
 
 -- a || false ===> a (i.e., true = a)
 #testOptimize [ "BoolOrFalse_2" ] ∀ (a : Bool), (a || false) ===> ∀ (a : Bool), true = a
 
 -- (false || a) = a ===> True
-#testOptimize [ "BoolOrFalse_3" ] ∀ (a : Bool), (false || a) = a ===> True
+#testOptimize [ "BoolOrFalse_3", proof ] ∀ (a : Bool), (false || a) = a ===> True
 
 -- (false || (a && b)) = a && b ===> True
-#testOptimize [ "BoolOrFalse_4" ] ∀ (a b : Bool), (false || (a && b)) = (a && b) ===> True
+#testOptimize [ "BoolOrFalse_4", proof ] ∀ (a b : Bool), (false || (a && b)) = (a && b) ===> True
 
 -- ((a || b) || false) = a || b ===> True
-#testOptimize [ "BoolOrFalse_5" ] ∀ (a b : Bool), ((a || b) || false) = (a || b) ===> True
+#testOptimize [ "BoolOrFalse_5", proof ] ∀ (a b : Bool), ((a || b) || false) = (a || b) ===> True
 
 -- ((a || false) || b) = a || b ===> True
-#testOptimize [ "BoolOrFalse_6" ] ∀ (a b : Bool), ((a || false) || b) = (a || b) ===> True
+#testOptimize [ "BoolOrFalse_6", proof ] ∀ (a b : Bool), ((a || false) || b) = (a || b) ===> True
 
 -- ((false || a) || b) = a || b ===> True
-#testOptimize [ "BoolOrFalse_7" ] ∀ (a b : Bool), ((false || a) || b) = (a || b) ===> True
+#testOptimize [ "BoolOrFalse_7", proof ] ∀ (a b : Bool), ((false || a) || b) = (a || b) ===> True
 
 -- let x := a || a
 -- let y := a && !x

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
@@ -94,13 +94,13 @@ namespace Tests.OptimizeBoolOr
 /-! Test cases for simplification rule `e || not e ==> true`. -/
 
 -- (a || not a) = true ===> True
-#testOptimize [ "BoolOrNot_1" ] ∀ (a : Bool), (a || not a) = true ===> True
+#testOptimize [ "BoolOrNot_1", proof ] ∀ (a : Bool), (a || not a) = true ===> True
 
 -- a || not a ===> True
-#testOptimize [ "BoolOrNot_2" ] ∀ (a : Bool), (a || not a) ===> True
+#testOptimize [ "BoolOrNot_2", proof ] ∀ (a : Bool), (a || not a) ===> True
 
 -- a || !a ===> True
-#testOptimize [ "BoolOrNot_3" ] ∀ (a : Bool), (a || !a) ===> True
+#testOptimize [ "BoolOrNot_3", proof ] ∀ (a : Bool), (a || !a) ===> True
 
 -- (a && b) || !(b && a) ===> True
 #testOptimize [ "BoolOrNot_4" ] ∀ (a b : Bool), (a && b) || !(b && a) ===> True

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
@@ -35,7 +35,7 @@ namespace Tests.OptimizeBoolOr
 #testOptimize [ "BoolOrFalse_1", proof ] ∀ (a : Bool), (a || false) = a ===> True
 
 -- a || false ===> a (i.e., true = a)
-#testOptimize [ "BoolOrFalse_2" ] ∀ (a : Bool), (a || false) ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolOrFalse_2", proof ] ∀ (a : Bool), (a || false) ===> ∀ (a : Bool), true = a
 
 -- (false || a) = a ===> True
 #testOptimize [ "BoolOrFalse_3", proof ] ∀ (a : Bool), (false || a) = a ===> True
@@ -62,28 +62,28 @@ namespace Tests.OptimizeBoolOr
 /-! Test cases for simplification rule `true || e ==> true`. -/
 
 -- (a || true) = true ===> True
-#testOptimize [ "BoolOrTrue_1" ] ∀ (a : Bool), (a || true) = true ===> True
+#testOptimize [ "BoolOrTrue_1", proof ] ∀ (a : Bool), (a || true) = true ===> True
 
 -- (a || true) ====> True
-#testOptimize [ "BoolOrTrue_2" ] ∀ (a : Bool), (a || true) ===> True
+#testOptimize [ "BoolOrTrue_2", proof ] ∀ (a : Bool), (a || true) ===> True
 
 -- (true || a) = true ===> True
-#testOptimize [ "BoolOrTrue_3" ] ∀ (a : Bool), (true || a) = true ===> True
+#testOptimize [ "BoolOrTrue_3" , proof] ∀ (a : Bool), (true || a) = true ===> True
 
 -- true || a ===> True
-#testOptimize [ "BoolOrTrue_4" ] ∀ (a : Bool), true || a ===> True
+#testOptimize [ "BoolOrTrue_4" , proof] ∀ (a : Bool), true || a ===> True
 
 -- true || (a && b) ===> True
-#testOptimize [ "BoolOrTrue_5" ] ∀ (a b : Bool), true || (a && b) ===> True
+#testOptimize [ "BoolOrTrue_5", proof] ∀ (a b : Bool), true || (a && b) ===> True
 
 -- (a || b) || true ===> True
-#testOptimize [ "BoolOrTrue_6" ] ∀ (a b : Bool), (a || b) || true ===> True
+#testOptimize [ "BoolOrTrue_6", proof ] ∀ (a b : Bool), (a || b) || true ===> True
 
 -- (a || true) || b ===> True
-#testOptimize [ "BoolOrTrue_7" ] ∀ (a b : Bool), (a || true) || b ===> True
+#testOptimize [ "BoolOrTrue_7", proof ] ∀ (a b : Bool), (a || true) || b ===> True
 
 -- (true || a) || b ===> True
-#testOptimize [ "BoolOrTrue_8" ] ∀ (a b : Bool), (true || a) || b ===> True
+#testOptimize [ "BoolOrTrue_8", proof ] ∀ (a b : Bool), (true || a) || b ===> True
 
 -- let x := a && a
 -- let y := a || !x
@@ -159,10 +159,10 @@ namespace Tests.OptimizeBoolOr
 /-! Test cases for simplification rule `e1 || e2 ==> e1 (if e1 =ₚₜᵣ e2)`. -/
 
 -- a || a = a ===> True
-#testOptimize [ "BoolOrSubsumption_1" ] ∀ (a : Bool), (a || a) = a ===> True
+#testOptimize [ "BoolOrSubsumption_1", proof ] ∀ (a : Bool), (a || a) = a ===> True
 
 -- a || a ===> a
-#testOptimize [ "BoolOrSubsumption_2" ] ∀ (a : Bool), a || a ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolOrSubsumption_2", proof ] ∀ (a : Bool), a || a ===> ∀ (a : Bool), true = a
 
 -- (a && b) || (b && a) ===> (a && b)
 #testOptimize [ "BoolOrSubsumption_3" ] ∀ (a b : Bool), (a && b) || (b && a) ===>
@@ -184,10 +184,10 @@ namespace Tests.OptimizeBoolOr
 -/
 
 -- a || b ===> a || b
-#testOptimize [ "BoolOrUnchanged_1" ] ∀ (a b : Bool), (a || b) ===> ∀ (a b : Bool), true = (a || b)
+#testOptimize [ "BoolOrUnchanged_1", proof ] ∀ (a b : Bool), (a || b) ===> ∀ (a b : Bool), true = (a || b)
 
 -- (a && c) || (b || d) ===> (a && c) || (b || d)
-#testOptimize [ "BoolOrUnchanged_2" ] ∀ (a b c d : Bool), (a && c) || (b || d) ===>
+#testOptimize [ "BoolOrUnchanged_2", proof ] ∀ (a b c d : Bool), (a && c) || (b || d) ===>
                                       ∀ (a b c d : Bool), true = ((a && c) || (b || d))
 
 

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolOr.lean
@@ -32,10 +32,10 @@ namespace Tests.OptimizeBoolOr
 /-! Test cases for simplification rule `false || e ==> e`. -/
 
 -- (a || false) = a ===> True
-#testOptimize [ "BoolOrFalse_1", proof ] ∀ (a : Bool), (a || false) = a ===> True
+#testOptimize [ "BoolOrFalse_1" ] ∀ (a : Bool), (a || false) = a ===> True
 
 -- a || false ===> a (i.e., true = a)
-#testOptimize [ "BoolOrFalse_2", proof ] ∀ (a : Bool), (a || false) ===> ∀ (a : Bool), true = a
+#testOptimize [ "BoolOrFalse_2" ] ∀ (a : Bool), (a || false) ===> ∀ (a : Bool), true = a
 
 -- (false || a) = a ===> True
 #testOptimize [ "BoolOrFalse_3", proof ] ∀ (a : Bool), (false || a) = a ===> True
@@ -44,10 +44,10 @@ namespace Tests.OptimizeBoolOr
 #testOptimize [ "BoolOrFalse_4", proof ] ∀ (a b : Bool), (false || (a && b)) = (a && b) ===> True
 
 -- ((a || b) || false) = a || b ===> True
-#testOptimize [ "BoolOrFalse_5", proof ] ∀ (a b : Bool), ((a || b) || false) = (a || b) ===> True
+#testOptimize [ "BoolOrFalse_5"] ∀ (a b : Bool), ((a || b) || false) = (a || b) ===> True
 
 -- ((a || false) || b) = a || b ===> True
-#testOptimize [ "BoolOrFalse_6", proof ] ∀ (a b : Bool), ((a || false) || b) = (a || b) ===> True
+#testOptimize [ "BoolOrFalse_6" ] ∀ (a b : Bool), ((a || false) || b) = (a || b) ===> True
 
 -- ((false || a) || b) = a || b ===> True
 #testOptimize [ "BoolOrFalse_7", proof ] ∀ (a b : Bool), ((false || a) || b) = (a || b) ===> True
@@ -62,10 +62,10 @@ namespace Tests.OptimizeBoolOr
 /-! Test cases for simplification rule `true || e ==> true`. -/
 
 -- (a || true) = true ===> True
-#testOptimize [ "BoolOrTrue_1", proof ] ∀ (a : Bool), (a || true) = true ===> True
+#testOptimize [ "BoolOrTrue_1" ] ∀ (a : Bool), (a || true) = true ===> True
 
 -- (a || true) ====> True
-#testOptimize [ "BoolOrTrue_2", proof ] ∀ (a : Bool), (a || true) ===> True
+#testOptimize [ "BoolOrTrue_2" ] ∀ (a : Bool), (a || true) ===> True
 
 -- (true || a) = true ===> True
 #testOptimize [ "BoolOrTrue_3" , proof] ∀ (a : Bool), (true || a) = true ===> True
@@ -77,10 +77,10 @@ namespace Tests.OptimizeBoolOr
 #testOptimize [ "BoolOrTrue_5", proof] ∀ (a b : Bool), true || (a && b) ===> True
 
 -- (a || b) || true ===> True
-#testOptimize [ "BoolOrTrue_6", proof ] ∀ (a b : Bool), (a || b) || true ===> True
+#testOptimize [ "BoolOrTrue_6" ] ∀ (a b : Bool), (a || b) || true ===> True
 
 -- (a || true) || b ===> True
-#testOptimize [ "BoolOrTrue_7", proof ] ∀ (a b : Bool), (a || true) || b ===> True
+#testOptimize [ "BoolOrTrue_7" ] ∀ (a b : Bool), (a || true) || b ===> True
 
 -- (true || a) || b ===> True
 #testOptimize [ "BoolOrTrue_8", proof ] ∀ (a b : Bool), (true || a) || b ===> True

--- a/Tests/Optimize/OptimizeDecide/DecideBoolAnd.lean
+++ b/Tests/Optimize/OptimizeDecide/DecideBoolAnd.lean
@@ -233,4 +233,22 @@ variable (b : Bool)
                                        (z ≠ x ∧ ((y ≠ x) ∧ n > m) ∧ z = m) ===> True
 
 
+/-! ## Proof-reconstruction tests for the `decide'` regrouping on Boolean `and`. -/
+
+variable (p : Prop)
+variable (q : Prop)
+
+-- (decide' p && decide' q) ===> decide' (p ∧ q)
+#testOptimize [ "DecideAndDecideProof", proof ]
+  (Blaster.decide' p && Blaster.decide' q) = Blaster.decide' (p ∧ q) ===> True
+
+-- (b && decide' p) ===> decide' (p ∧ true = b)
+#testOptimize [ "DecideAndBoolProof_1", proof ]
+  (b && Blaster.decide' p) = Blaster.decide' (p ∧ (true = b)) ===> True
+
+-- (decide' p && !b) ===> decide' (p ∧ true = !b)
+#testOptimize [ "DecideAndBoolProof_2", proof ]
+  (Blaster.decide' p && !b) = Blaster.decide' (p ∧ (true = !b)) ===> True
+
+
 end Test.DecideBoolAnd

--- a/Tests/Optimize/OptimizeDecide/DecideBoolOr.lean
+++ b/Tests/Optimize/OptimizeDecide/DecideBoolOr.lean
@@ -235,4 +235,22 @@ variable (b : Bool)
                                        (z ≠ x ∨ ((y ≠ x) ∨ n > m) ∨ z = m) ===> True
 
 
+/-! ## Proof-reconstruction tests for the `decide'` regrouping on Boolean `or`. -/
+
+variable (p : Prop)
+variable (q : Prop)
+
+-- (decide' p || decide' q) ===> decide' (p ∨ q)
+#testOptimize [ "DecideOrDecideProof", proof ]
+  (Blaster.decide' p || Blaster.decide' q) = Blaster.decide' (p ∨ q) ===> True
+
+-- (b || decide' p) ===> decide' (p ∨ true = b)
+#testOptimize [ "DecideOrBoolProof_1", proof ]
+  (b || Blaster.decide' p) = Blaster.decide' (p ∨ (true = b)) ===> True
+
+-- (decide' p || !b) ===> decide' (p ∨ true = !b)
+#testOptimize [ "DecideOrBoolProof_2", proof ]
+  (Blaster.decide' p || !b) = Blaster.decide' (p ∨ (true = !b)) ===> True
+
+
 end Test.DecideBoolOr

--- a/Tests/Optimize/OptimizeDecide/NominalDecide.lean
+++ b/Tests/Optimize/OptimizeDecide/NominalDecide.lean
@@ -281,4 +281,18 @@ variable (q : Bool)
 #testOptimize [ "DecideUnchanged_11" ] decide (q = !(!(!(!p)))) ===> Blaster.decide' (p = q)
 
 
+/-! Proof reconstruction tests for the eliminative decide' cases -/
+
+-- Blaster.decide' False ===> false
+#testOptimize [ "Decide'False_1", proof ] Blaster.decide' False ===> false
+
+-- Blaster.decide' True ===> true
+#testOptimize [ "Decide'True_1", proof ] Blaster.decide' True ===> true
+
+-- Blaster.decide' (true = p) ===> p
+#testOptimize [ "Decide'EqTrue_1", proof ] Blaster.decide' (true = q) ===> q
+
+-- Blaster.decide' (false = p) ===> !p
+#testOptimize [ "Decide'EqFalse_1", proof ] Blaster.decide' (false = q) ===> !q
+
 end Test.NominalDecide

--- a/Tests/Optimize/OptimizeInt.lean
+++ b/Tests/Optimize/OptimizeInt.lean
@@ -1,3 +1,5 @@
 import Tests.Optimize.OptimizeInt.OptimizeIntAdd
 import Tests.Optimize.OptimizeInt.OptimizeIntMul
 import Tests.Optimize.OptimizeInt.OptimizeIntNeg
+import Tests.Optimize.OptimizeInt.OptimizeIntDiv
+import Tests.Optimize.OptimizeInt.OptimizeIntMod

--- a/Tests/Optimize/OptimizeInt.lean
+++ b/Tests/Optimize/OptimizeInt.lean
@@ -1,0 +1,1 @@
+import Tests.Optimize.OptimizeInt.OptimizeIntAdd

--- a/Tests/Optimize/OptimizeInt.lean
+++ b/Tests/Optimize/OptimizeInt.lean
@@ -3,3 +3,5 @@ import Tests.Optimize.OptimizeInt.OptimizeIntMul
 import Tests.Optimize.OptimizeInt.OptimizeIntNeg
 import Tests.Optimize.OptimizeInt.OptimizeIntDiv
 import Tests.Optimize.OptimizeInt.OptimizeIntMod
+import Tests.Optimize.OptimizeInt.OptimizeIntEDiv
+import Tests.Optimize.OptimizeInt.OptimizeIntEMod

--- a/Tests/Optimize/OptimizeInt.lean
+++ b/Tests/Optimize/OptimizeInt.lean
@@ -1,1 +1,2 @@
 import Tests.Optimize.OptimizeInt.OptimizeIntAdd
+import Tests.Optimize.OptimizeInt.OptimizeIntMul

--- a/Tests/Optimize/OptimizeInt.lean
+++ b/Tests/Optimize/OptimizeInt.lean
@@ -1,2 +1,3 @@
 import Tests.Optimize.OptimizeInt.OptimizeIntAdd
 import Tests.Optimize.OptimizeInt.OptimizeIntMul
+import Tests.Optimize.OptimizeInt.OptimizeIntNeg

--- a/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
@@ -23,3 +23,21 @@ elab "intAddCst_1" : term => return intAddCst_1
 #testOptimize ["IntAddZero_1", proof] ∀ (m n: Int), 0 + m = n ===> ∀ (m n: Int), m = n
 
 #testOptimize ["IntAddZero_2", proof] ∀ (n : Int), 0 + n = n ===> True
+
+/-! Test cases for simplification rule `N1 + (N2 + n) ==> (N1 "+" N2) + n` -/
+
+#testOptimize ["IntAddAssoc_1", proof] ∀ (n : Int), 1 + (2 + n) = 3 + n ===> True
+
+-- nested operand carries a core `Int.add`, exercising `toElabForm`'s Int branch
+#testOptimize ["IntAddAssoc_2", proof] ∀ (a b : Int), 1 + (2 + (a + b)) = 3 + (a + b) ===> True
+
+/-! Test cases for simplification rule `N1 + -(N2 + n) ==> (N1 "-" N2) + -n` -/
+
+#testOptimize ["IntAddNegAdd_1", proof] ∀ (n : Int), 5 + -(2 + n) = 3 + -n ===> True
+
+/-! Test cases for the commutative reorder `n1 + n2 ==> n2 + n1` -/
+
+#testOptimize ["IntAddComm_1", proof] ∀ (n : Int), n + 3 = 3 + n ===> True
+
+-- reorder `n + 0 ==> 0 + n`, closed with `Int.add_zero`
+#testOptimize ["IntAddComm_2", proof] ∀ (n : Int), n + 0 = n ===> True

--- a/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
@@ -16,7 +16,7 @@ def intAddCst_1 : Expr := Lean.Expr.app
 
 elab "intAddCst_1" : term => return intAddCst_1
 
-#testOptimize [ "intAddCst_1", proof] (0 : Int) + 1 ===> intAddCst_1
+#testOptimize [ "IntAddCst_1", proof] (0 : Int) + 1 ===> intAddCst_1
 
 /-! Test cases for simplification rule `0 + n ===> n` -/
 

--- a/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
@@ -1,0 +1,28 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Tests.OptimizeIntAdd
+
+/-! ## Test objectives to validate normalization and simplification rules on ``Int.add -/
+
+/-! Test cases for `reduceApp` rule on ``Int.add -/
+
+-- 0 + 1 ===> 1
+def intAddCst_1 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 1))
+
+elab "intAddCst_1" : term => return intAddCst_1
+
+#testOptimize [ "intAddCst_1", proof] (0 : Int) + 1 ===> intAddCst_1
+
+-- 0 - 2 ===> -2
+def intAddCst_2 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.negSucc [])
+  (Lean.Expr.lit (Lean.Literal.natVal 1))
+
+elab "intAddCst_2" : term => return intAddCst_2
+
+#testOptimize [ "intAddCst_2", proof] (0 : Int) - 2 ===> intAddCst_2

--- a/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
@@ -18,11 +18,8 @@ elab "intAddCst_1" : term => return intAddCst_1
 
 #testOptimize [ "intAddCst_1", proof] (0 : Int) + 1 ===> intAddCst_1
 
--- 0 - 2 ===> -2
-def intAddCst_2 : Expr := Lean.Expr.app
-  (Lean.Expr.const `Int.negSucc [])
-  (Lean.Expr.lit (Lean.Literal.natVal 1))
+/-! Test cases for simplification rule `0 + n ===> n` -/
 
-elab "intAddCst_2" : term => return intAddCst_2
+#testOptimize ["IntAddZero_1", proof] ∀ (m n: Int), 0 + m = n ===> ∀ (m n: Int), m = n
 
-#testOptimize [ "intAddCst_2", proof] (0 : Int) - 2 ===> intAddCst_2
+#testOptimize ["IntAddZero_2", proof] ∀ (n : Int), 0 + n = n ===> True

--- a/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntAdd.lean
@@ -41,3 +41,11 @@ elab "intAddCst_1" : term => return intAddCst_1
 
 -- reorder `n + 0 ==> 0 + n`, closed with `Int.add_zero`
 #testOptimize ["IntAddComm_2", proof] ∀ (n : Int), n + 0 = n ===> True
+
+
+/-! Test cases for the simplification rule `n1 + (-n2) ==> 0 (if n1 =ₚₜᵣ n2)` -/
+
+-- n + (-n) = 0 ==> True
+#testOptimize ["IntAddNeg_1", proof] ∀ (n : Int), n + (-n) = 0 ===> True
+
+end Tests.OptimizeIntAdd

--- a/Tests/Optimize/OptimizeInt/OptimizeIntDiv.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntDiv.lean
@@ -84,3 +84,5 @@ elab "intDivCst_2" : term => return intDivCst_2
 #testOptimize[ "IntFdivGcd_1", proof] ∀ (x : Int), Int.fdiv (6 * x) 4 = Int.fdiv (3 * x) 2 ===> True
 
 #testOptimize[ "IntTdivGcd_1", proof] ∀ (x : Int), Int.tdiv (6 * x) 4 = Int.tdiv (3 * x) 2 ===> True
+
+end Tests.OptimizeIntDiv

--- a/Tests/Optimize/OptimizeInt/OptimizeIntDiv.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntDiv.lean
@@ -1,0 +1,75 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Tests.OptimizeIntDiv
+
+/-! ## Test objectives to validate normalization and simplification rules on ``Int.ediv, ``Int.tdiv and ``Int.fdiv -/
+
+/-! Test cases for `reduceApp` rule on ``Int.ediv, ``Int.tdiv and ``Int.fdiv -/
+
+
+def intDivCst_1 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 5))
+
+elab "intDivCst_1" : term => return intDivCst_1
+
+def intDivCst_2 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 0))
+
+elab "intDivCst_2" : term => return intDivCst_2
+
+-- 5 / 1 ===> 5
+#testOptimize [ "IntDivCst_1", proof] (5 : Int) / 1 ===> intDivCst_1
+
+#testOptimize [ "IntFdivCst_1", proof] Int.fdiv 5 1 ===> intDivCst_1
+
+#testOptimize [ "IntTdivCst_1", proof] Int.tdiv 5 1 ===> intDivCst_1
+
+-- 0 / 5 ===> 0
+#testOptimize [ "IntDivCst_2", proof] (0 : Int) / 5 ===> intDivCst_2
+
+#testOptimize [ "IntFdivCst_2", proof] Int.fdiv 0 5 ===> intDivCst_2
+
+#testOptimize [ "IntTdivCst_2", proof] Int.tdiv 0 5 ===> intDivCst_2
+
+-- 5 / 0 ===> 0
+#testOptimize [ "IntDivCst_3", proof] (5 : Int) / 0 ===> intDivCst_2
+
+#testOptimize [ "IntFdivCst_3", proof] Int.fdiv 5 0 ===> intDivCst_2
+
+#testOptimize [ "IntTdivCst_3", proof] Int.tdiv 5 0 ===> intDivCst_2
+
+/-! Test cases for simplification rule n / 1 ===> n -/
+
+#testOptimize[ "IntDivOne_1", proof] ∀ (n : Int), n / 1 = n ===> True
+
+#testOptimize[ "IntFdivOne_1", proof] ∀ (n : Int), Int.fdiv n 1 = n ===> True
+
+#testOptimize[ "IntTdivOne_1", proof] ∀ (n : Int), Int.tdiv n 1 = n ===> True
+
+#testOptimize[ "IntDivOne_2", proof] ∀ (n m : Int), n / 1 = m ===> ∀ (n m : Int), n = m
+
+#testOptimize[ "IntFdivOne_2", proof] ∀ (n m : Int), Int.fdiv n 1 = m ===> ∀ (n m : Int), n = m
+
+#testOptimize[ "IntTdivOne_2", proof] ∀ (n m : Int), Int.tdiv n 1 = m ===> ∀ (n m : Int), n = m
+
+/-! Test cases for simplification rule n / 0 ===> 0 -/
+
+#testOptimize[ "IntDivZero_1", proof] ∀ (n : Int), n / 0 = 0 ===> True
+
+#testOptimize[ "IntFdivZero_1", proof] ∀ (n : Int), Int.fdiv n 0 = 0 ===> True
+
+#testOptimize[ "IntTdivZero_1", proof] ∀ (n : Int), Int.tdiv n 0 = 0 ===> True
+
+
+/-! Test cases for simplification rule 0 / n ===> 0 -/
+
+#testOptimize[ "IntDivZero_2", proof] ∀ (n : Int), 0 / n = 0 ===> True
+
+#testOptimize[ "IntFdivZero_2", proof] ∀ (n : Int), Int.fdiv 0 n = 0 ===> True
+
+#testOptimize[ "IntTdivZero_2", proof] ∀ (n : Int), Int.tdiv 0 n = 0 ===> True

--- a/Tests/Optimize/OptimizeInt/OptimizeIntDiv.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntDiv.lean
@@ -73,3 +73,14 @@ elab "intDivCst_2" : term => return intDivCst_2
 #testOptimize[ "IntFdivZero_2", proof] ∀ (n : Int), Int.fdiv 0 n = 0 ===> True
 
 #testOptimize[ "IntTdivZero_2", proof] ∀ (n : Int), Int.tdiv 0 n = 0 ===> True
+
+
+/-! Test cases for the gcd normalization `(N1 * n) / N2 ==> ((N1 "/" gcd) * n) / (N2 "/" gcd)`. -/
+
+#testOptimize[ "IntEDivGcd_1", proof] ∀ (x : Int), (6 * x) / 4 = (3 * x) / 2 ===> True
+
+#testOptimize[ "IntEDivGcd_2", proof] ∀ (x : Int), (6 * x) / (-4) = (3 * x) / (-2) ===> True
+
+#testOptimize[ "IntFdivGcd_1", proof] ∀ (x : Int), Int.fdiv (6 * x) 4 = Int.fdiv (3 * x) 2 ===> True
+
+#testOptimize[ "IntTdivGcd_1", proof] ∀ (x : Int), Int.tdiv (6 * x) 4 = Int.tdiv (3 * x) 2 ===> True

--- a/Tests/Optimize/OptimizeInt/OptimizeIntEDiv.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntEDiv.lean
@@ -1,0 +1,48 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Test.OptimizeIntEDiv
+
+/-! ## Tests for the div cancellation proof steps on `Int.ediv`.
+    Cases: `n / n ==> 1` and `(m * n) / m | (n * m) / m ==> n`, each under a
+    hypothesis ensuring the divisor is nonzero (`0 < n`, `n < 0`, or `0 ≠ n`). -/
+
+/-! `n / n ==> 1`. -/
+
+-- x / x = 1  (with 0 < x)
+#testOptimize [ "IntEDivSelf_1", proof ]
+  ∀ (x : Int), 0 < x → x / x = 1 ===> True
+
+-- x / x = 1  (with 0 ≠ x)
+#testOptimize [ "IntEDivSelf_2", proof ]
+  ∀ (x : Int), 0 ≠ x → x / x = 1 ===> True
+
+-- x / x = 1  (with x < 0)
+#testOptimize [ "IntEDivSelf_3", proof ]
+  ∀ (x : Int), x < 0 → x / x = 1 ===> True
+
+-- (x + 0) / (x + 0) = 1  (operands reduced to the same fvar)
+#testOptimize [ "IntEDivSelf_4", proof ]
+  ∀ (x : Int), 0 < x → (x + 0) / (x + 0) = 1 ===> True
+
+/-! `(m * n) / m ==> n` and `(n * m) / m ==> n`. -/
+
+-- (x * y) / y = x  (with 0 < y)
+#testOptimize [ "IntMulEDivCancel_1", proof ]
+  ∀ (x y : Int), 0 < y → (x * y) / y = x ===> True
+
+-- (y * x) / y = x  (with 0 < y)
+#testOptimize [ "IntMulEDivCancel_2", proof ]
+  ∀ (x y : Int), 0 < y → (y * x) / y = x ===> True
+
+-- (x * y) / y = x  (with 0 ≠ y)
+#testOptimize [ "IntMulEDivCancel_3", proof ]
+  ∀ (x y : Int), 0 ≠ y → (x * y) / y = x ===> True
+
+-- (y * x) / y = x  (with y < 0)
+#testOptimize [ "IntMulEDivCancel_4", proof ]
+  ∀ (x y : Int), y < 0 → (y * x) / y = x ===> True
+
+end Test.OptimizeIntEDiv

--- a/Tests/Optimize/OptimizeInt/OptimizeIntEMod.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntEMod.lean
@@ -1,0 +1,32 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Test.OptimizeIntEMod
+
+/-! ## Tests for the mod cancellation proof steps on `Int.emod`.
+    Cases: `n % n ==> 0` and `(m * n) % m | (n * m) % m ==> 0`. These hold
+    unconditionally, so no hypothesis is required. -/
+
+/-! `n % n ==> 0`. -/
+
+-- x % x = 0
+#testOptimize [ "IntEModSelf_1", proof ]
+  ∀ (x : Int), x % x = 0 ===> True
+
+-- (x + 0) % (x + 0) = 0  (operands reduced to the same fvar)
+#testOptimize [ "IntEModSelf_2", proof ]
+  ∀ (x : Int), (x + 0) % (x + 0) = 0 ===> True
+
+/-! `(m * n) % m ==> 0` and `(n * m) % m ==> 0`. -/
+
+-- (x * y) % x = 0
+#testOptimize [ "IntMulEModCancel_1", proof ]
+  ∀ (x y : Int), (x * y) % x = 0 ===> True
+
+-- (x * y) % y = 0
+#testOptimize [ "IntMulEModCancel_2", proof ]
+  ∀ (x y : Int), (x * y) % y = 0 ===> True
+
+end Test.OptimizeIntEMod

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMod.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMod.lean
@@ -76,3 +76,5 @@ elab "intModCst_2" : term => return intModCst_2
 #testOptimize ["IntFmodGcd_1", proof] ∀ (x : Int), Int.fmod (6 * x) 3 = 0 ===> True
 
 #testOptimize ["IntTmodGcd_1", proof] ∀ (x : Int), Int.tmod (6 * x) 3 = 0 ===> True
+
+end Tests.OptimizeIntMod

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMod.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMod.lean
@@ -1,0 +1,67 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Tests.OptimizeIntMod
+
+/-! ## Test objectives to validate normalization and simplification rules on ``Int.emod, ``Int.tmod and ``Int.fmod -/
+/-! Test cases for `reduceApp` rule on ``Int.emod, ``Int.tmod and ``Int.fmod -/
+
+def intModCst_1 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 0))
+elab "intModCst_1" : term => return intModCst_1
+
+def intModCst_2 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 5))
+elab "intModCst_2" : term => return intModCst_2
+
+-- 0 % 5 ===> 0
+#testOptimize [ "IntModCst_1", proof] (0 : Int) % 5 ===> intModCst_1
+
+#testOptimize [ "IntFmodCst_1", proof] Int.fmod 0 5 ===> intModCst_1
+
+#testOptimize [ "IntTmodCst_1", proof] Int.tmod 0 5 ===> intModCst_1
+
+-- 5 % 1 ===> 0
+#testOptimize [ "IntModCst_2", proof] (5 : Int) % 1 ===> intModCst_1
+
+#testOptimize [ "IntFmodCst_2", proof] Int.fmod 5 1 ===> intModCst_1
+
+#testOptimize [ "IntTmodCst_2", proof] Int.tmod 5 1 ===> intModCst_1
+
+-- 5 % 0 ===> 5
+#testOptimize [ "IntModCst_3", proof] (5 : Int) % 0 ===> intModCst_2
+
+#testOptimize [ "IntFmodCst_3", proof] Int.fmod 5 0 ===> intModCst_2
+
+#testOptimize [ "IntTmodCst_3", proof] Int.tmod 5 0 ===> intModCst_2
+
+/-! Test cases for simplification rule 0 % n ===> 0 -/
+#testOptimize ["IntModZero_1", proof] ∀ (n : Int), 0 % n = 0 ===> True
+
+#testOptimize ["IntFmodZero_1", proof] ∀ (n : Int), Int.fmod 0 n = 0 ===> True
+
+#testOptimize ["IntTmodZero_1", proof] ∀ (n : Int), Int.tmod 0 n = 0 ===> True
+
+/- Test cases for simplification rule n % 1 ===> 0 -/
+#testOptimize ["IntModOne_1", proof] ∀ (n : Int), n % 1 = 0 ===> True
+
+#testOptimize ["IntFmodOne_1", proof] ∀ (n : Int), Int.fmod n 1 = 0 ===> True
+
+#testOptimize ["IntTmodOne_1", proof] ∀ (n : Int), Int.tmod n 1 = 0 ===> True
+
+/- Test cases for simplification rule n % 0 ===> n -/
+#testOptimize ["IntModZero_2", proof] ∀ (n : Int), n % 0 = n ===> True
+
+#testOptimize ["IntFmodZero_2", proof] ∀ (n : Int), Int.fmod n 0 = n ===> True
+
+#testOptimize ["IntTmodZero_2", proof] ∀ (n : Int), Int.tmod n 0 = n ===> True
+
+#testOptimize ["IntModZero_3", proof] ∀ (n m : Int), n % 0 = m ===> ∀ (n m : Int), n = m
+
+#testOptimize ["IntFmodZero_3", proof] ∀ (n m : Int), Int.fmod n 0 = m ===> ∀ (n m : Int), n = m
+
+#testOptimize ["IntTmodZero_3", proof] ∀ (n m : Int), Int.tmod n 0 = m ===> ∀ (n m : Int), n = m

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMod.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMod.lean
@@ -65,3 +65,14 @@ elab "intModCst_2" : term => return intModCst_2
 #testOptimize ["IntFmodZero_3", proof] ∀ (n m : Int), Int.fmod n 0 = m ===> ∀ (n m : Int), n = m
 
 #testOptimize ["IntTmodZero_3", proof] ∀ (n m : Int), Int.tmod n 0 = m ===> ∀ (n m : Int), n = m
+
+
+/-! Test cases for the gcd normalization `(N1 * n) % N2 ==> 0 (if N1 % N2 = 0)`. -/
+
+#testOptimize ["IntEModGcd_1", proof] ∀ (x : Int), (6 * x) % 3 = 0 ===> True
+
+#testOptimize ["IntEModGcd_2", proof] ∀ (x : Int), (6 * x) % (-3) = 0 ===> True
+
+#testOptimize ["IntFmodGcd_1", proof] ∀ (x : Int), Int.fmod (6 * x) 3 = 0 ===> True
+
+#testOptimize ["IntTmodGcd_1", proof] ∀ (x : Int), Int.tmod (6 * x) 3 = 0 ===> True

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
@@ -1,0 +1,40 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Tests.OptimizeIntMul
+
+/-! ## Test objectives to validate normalization and simplification rules on ``Int.Mul -/
+
+/-! Test cases for `reduceApp` rule on ``Int.Mul-/
+
+-- 0 * 5 ===> 0
+def intMulCst_1 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 0))
+
+elab "intMulCst_1" : term => return intMulCst_1
+
+#testOptimize [ "intMulCst_1", proof] (0 : Int) * 5 ===> intMulCst_1
+
+
+-- 1 * 5 ===> 5
+def intMulCst_2 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 5))
+elab "intMulCst_2" : term => return intMulCst_2
+
+#testOptimize [ "IntMulCst_2", proof] (1: Int) * 5 ===> intMulCst_2
+
+/-! Tests cases for simplification rule 0 * n = 0 -/
+#testOptimize ["IntMulZero_1", proof] ∀ (n : Int), 0 * n = 0 ===> True
+
+variable (x : Int)
+#testOptimize ["IntMulZero_2", proof] (0 : Int) * x ===> intMulCst_1
+
+
+/-! Tests cases for simplification rule 1 * n = n-/
+#testOptimize ["IntMulOne_1", proof] ∀ (x : Int), 1 * x = x ===> True
+
+#testOptimize ["IntMulOne_2", proof] ∀ (x y : Int), 1 * x = y ===> ∀ (x y : Int), x = y

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
@@ -5,9 +5,9 @@ open Lean Elab Command Term
 
 namespace Tests.OptimizeIntMul
 
-/-! ## Test objectives to validate normalization and simplification rules on ``Int.Mul -/
+/-! ## Test objectives to validate normalization and simplification rules on ``Int.mul -/
 
-/-! Test cases for `reduceApp` rule on ``Int.Mul-/
+/-! Test cases for `reduceApp` rule on ``Int.mul -/
 
 -- 0 * 5 ===> 0
 def intMulCst_1 : Expr := Lean.Expr.app
@@ -16,7 +16,7 @@ def intMulCst_1 : Expr := Lean.Expr.app
 
 elab "intMulCst_1" : term => return intMulCst_1
 
-#testOptimize [ "intMulCst_1", proof] (0 : Int) * 5 ===> intMulCst_1
+#testOptimize [ "IntMulCst_1", proof] (0 : Int) * 5 ===> intMulCst_1
 
 
 -- 1 * 5 ===> 5

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
@@ -38,3 +38,21 @@ variable (x : Int)
 #testOptimize ["IntMulOne_1", proof] ∀ (x : Int), 1 * x = x ===> True
 
 #testOptimize ["IntMulOne_2", proof] ∀ (x y : Int), 1 * x = y ===> ∀ (x y : Int), x = y
+
+/-! Tests cases for simplification rule `-1 * n ==> -n` -/
+#testOptimize ["IntMulNegOne_1", proof] ∀ (n : Int), -1 * n = -n ===> True
+
+/-! Tests cases for simplification rule `N1 * (N2 * n) ==> (N1 "*" N2) * n` -/
+#testOptimize ["IntMulAssoc_1", proof] ∀ (n : Int), 2 * (3 * n) = 6 * n ===> True
+
+-- nested operand carries a core `Int.mul`, exercising `toElabForm`'s Int branch
+#testOptimize ["IntMulAssoc_2", proof] ∀ (a b : Int), 2 * (3 * (a * b)) = 6 * (a * b) ===> True
+
+/-! Tests cases for the commutative reorder `n1 * n2 ==> n2 * n1` -/
+#testOptimize ["IntMulComm_1", proof] ∀ (n : Int), n * 3 = 3 * n ===> True
+
+-- reorder `n * 0 ==> 0 * n`, closed with `Int.mul_zero`
+#testOptimize ["IntMulComm_2", proof] ∀ (n : Int), n * 0 = 0 ===> True
+
+-- reorder `n * 1 ==> 1 * n`, closed with `Int.mul_one`
+#testOptimize ["IntMulComm_3", proof] ∀ (n : Int), n * 1 = n ===> True

--- a/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntMul.lean
@@ -56,3 +56,5 @@ variable (x : Int)
 
 -- reorder `n * 1 ==> 1 * n`, closed with `Int.mul_one`
 #testOptimize ["IntMulComm_3", proof] ∀ (n : Int), n * 1 = n ===> True
+
+end Tests.OptimizeIntMul

--- a/Tests/Optimize/OptimizeInt/OptimizeIntNeg.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntNeg.lean
@@ -27,3 +27,5 @@ elab "intNegCst_1" : term => return intNegCst_1
 #testOptimize ["IntNegNeg_2", proof] ∀ (x y : Int), -(-x) = y ===> ∀ (x y : Int), x = y
 
 #testOptimize ["IntNegNeg_3", proof] ∀ (x : Int), -(-(-x)) = -x ===> True
+
+end Tests.OptimizeIntNeg

--- a/Tests/Optimize/OptimizeInt/OptimizeIntNeg.lean
+++ b/Tests/Optimize/OptimizeInt/OptimizeIntNeg.lean
@@ -1,0 +1,29 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Tests.OptimizeIntNeg
+
+/-! ## Test objectives to validate normalization and simplification rules on ``Int.neg -/
+
+/-! Tests cases for `reduceApp` rule on ``Int.neg -/
+
+-- - (-5) ===> 5
+def intNegCst_1 : Expr := Lean.Expr.app
+  (Lean.Expr.const `Int.ofNat [])
+  (Lean.Expr.lit (Lean.Literal.natVal 5))
+
+elab "intNegCst_1" : term => return intNegCst_1
+
+#testOptimize [ "IntNegCst_1", proof] -( - (5 : Int)) ===> intNegCst_1
+
+#testOptimize [ "IntNegCst_2", proof] -(- 5 : Int) ===> intNegCst_1
+
+/-! Test cases for simplification rule -(-n) = n -/
+
+#testOptimize ["IntNegNeg_1", proof] ∀ (n : Int), -(-n) = n ===> True
+
+#testOptimize ["IntNegNeg_2", proof] ∀ (x y : Int), -(-x) = y ===> ∀ (x y : Int), x = y
+
+#testOptimize ["IntNegNeg_3", proof] ∀ (x : Int), -(-(-x)) = -x ===> True

--- a/Tests/Optimize/OptimizeNat.lean
+++ b/Tests/Optimize/OptimizeNat.lean
@@ -5,3 +5,4 @@ import Tests.Optimize.OptimizeNat.OptimizeNatMul
 import Tests.Optimize.OptimizeNat.OptimizeNatPred
 import Tests.Optimize.OptimizeNat.OptimizeNatSub
 import Tests.Optimize.OptimizeNat.OptimizeNatSucc
+import Tests.Optimize.OptimizeNat.OptimizeNatPow

--- a/Tests/Optimize/OptimizeNat.lean
+++ b/Tests/Optimize/OptimizeNat.lean
@@ -1,4 +1,3 @@
-
 import Tests.Optimize.OptimizeNat.OptimizeNatAdd
 import Tests.Optimize.OptimizeNat.OptimizeNatDiv
 import Tests.Optimize.OptimizeNat.OptimizeNatMod

--- a/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
@@ -31,22 +31,22 @@ elab "natAddCst_3" : term => return natAddCst_3
 /-! Test cases for simplification rule `0 + n ===> n`. -/
 
 -- x + 0 ===> x
-#testOptimize [ "NatAddZero_1" ] ∀ (x y : Nat), x + 0 ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatAddZero_1", proof ] ∀ (x y : Nat), x + 0 ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- 0 + x ===> x
-#testOptimize [ "NatAddZero_2" ] ∀ (x y : Nat), 0 + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatAddZero_2", proof ] ∀ (x y : Nat), 0 + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- x + Nat.zero ===> x
-#testOptimize [ "NatAddZero_3" ] ∀ (x y : Nat), x + Nat.zero ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatAddZero_3", proof ] ∀ (x y : Nat), x + Nat.zero ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- Nat.zero + x ===> x
-#testOptimize [ "NatAddZero_4" ] ∀ (x y : Nat), Nat.zero + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatAddZero_4", proof ] ∀ (x y : Nat), Nat.zero + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- (10 - 10) + x ===> x
-#testOptimize [ "NatAddZero_5" ] ∀ (x y : Nat), (10 - 10) + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatAddZero_5", proof ] ∀ (x y : Nat), (10 - 10) + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- x + (10 - 123) ===> x
-#testOptimize [ "NatAddZero_6" ] ∀ (x y : Nat), x + (10 - 123) ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatAddZero_6", proof ] ∀ (x y : Nat), x + (10 - 123) ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 
 /-! Test cases to ensure that simplification rules `0 + n ===> n` is not wrongly applied. -/
@@ -71,13 +71,13 @@ def natAddZeroUnchanged_1 : Expr :=
 
 elab "natAddZeroUnchanged_1" : term => return natAddZeroUnchanged_1
 
-#testOptimize [ "NatAddZeroUnchanged_1" ] ∀ (x y : Nat), (1 + x) < y ===> natAddZeroUnchanged_1
+#testOptimize [ "NatAddZeroUnchanged_1", proof ] ∀ (x y : Nat), (1 + x) < y ===> natAddZeroUnchanged_1
 
 -- (27 - 26) + x ===> 1 + x
-#testOptimize [ "NatAddZeroUnchanged_2" ] ∀ (x y : Nat), (27 - 26) + x < y ===> natAddZeroUnchanged_1
+#testOptimize [ "NatAddZeroUnchanged_2", proof ] ∀ (x y : Nat), (27 - 26) + x < y ===> natAddZeroUnchanged_1
 
 -- (Nat.zero + 1) + x ===> 1 + x
-#testOptimize [ "NatAddZeroUnchanged_3" ] ∀ (x y : Nat), (Nat.zero + 1) + x < y ===> natAddZeroUnchanged_1
+#testOptimize [ "NatAddZeroUnchanged_3", proof ] ∀ (x y : Nat), (Nat.zero + 1) + x < y ===> natAddZeroUnchanged_1
 
 -- (127 + 40) + x ===> 167 + x
 def natAddZeroUnchanged_4 : Expr :=
@@ -99,7 +99,7 @@ def natAddZeroUnchanged_4 : Expr :=
 
 elab "natAddZeroUnchanged_4" : term => return natAddZeroUnchanged_4
 
-#testOptimize [ "NatAddZeroUnchanged_4" ] ∀ (x y : Nat), (127 + 40) + x < y ===> natAddZeroUnchanged_4
+#testOptimize [ "NatAddZeroUnchanged_4", proof ] ∀ (x y : Nat), (127 + 40) + x < y ===> natAddZeroUnchanged_4
 
 
 /-! Test cases for simplification rule `N1 + (N2 + n) ===> (N1 "+" N2) + n`. -/
@@ -136,7 +136,7 @@ def natAddCstProp_5 : Expr :=
 
 elab "natAddCstProp_5" : term => return natAddCstProp_5
 
-#testOptimize [ "NatAddCstProp_5" ] ∀ (x y : Nat), 10 + (20 + x) < y ===> natAddCstProp_5
+#testOptimize [ "NatAddCstProp_5", proof ] ∀ (x y : Nat), 10 + (20 + x) < y ===> natAddCstProp_5
 
 -- 10 + (20 + (40 + x)) = 70 + x ===> True
 #testOptimize [ "NatAddCstProp_6", proof ] ∀ (x : Nat), 10 + (20 + (40 + x)) = 70 + x ===> True
@@ -151,7 +151,7 @@ elab "natAddCstProp_5" : term => return natAddCstProp_5
 #testOptimize [ "NatAddCstProp_9", proof ] ∀ (x : Nat), 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
 
 -- 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
-#testOptimize [ "NatAddCstProp_10" ] ∀ (x : Nat), 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
+#testOptimize [ "NatAddCstProp_10", proof ] ∀ (x : Nat), 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
 
 -- 100 + ((180 - (x + 40)) - 150) = 100
 #testOptimize [ "NatAddCstProp_11", proof ] ∀ (x : Nat), 100 + ((180 - (x + 40)) - 150) = 100 ===> True
@@ -185,7 +185,7 @@ def natAddCstPropUnchanged_1 : Expr :=
 
 elab "natAddCstPropUnchanged_1" : term => return natAddCstPropUnchanged_1
 
-#testOptimize [ "NatAddCstPropUnchanged_1" ] ∀ (x y : Nat), 40 + (x + y) < y ===> natAddCstPropUnchanged_1
+#testOptimize [ "NatAddCstPropUnchanged_1", proof ] ∀ (x y : Nat), 40 + (x + y) < y ===> natAddCstPropUnchanged_1
 
 
 -- 40 + (x - y) ===> 40 + (x - y)
@@ -212,7 +212,7 @@ def natAddCstPropUnchanged_2 : Expr :=
 
 elab "natAddCstPropUnchanged_2" : term => return natAddCstPropUnchanged_2
 
-#testOptimize [ "NatAddCstPropUnchanged_2" ] ∀ (x y : Nat), 40 + (x - y) < y ===> natAddCstPropUnchanged_2
+#testOptimize [ "NatAddCstPropUnchanged_2", proof ] ∀ (x y : Nat), 40 + (x - y) < y ===> natAddCstPropUnchanged_2
 
 
 -- 40 + (x * y) ===> 40 + (x * y)
@@ -239,7 +239,7 @@ def natAddCstPropUnchanged_3 : Expr :=
 
 elab "natAddCstPropUnchanged_3" : term => return natAddCstPropUnchanged_3
 
-#testOptimize [ "NatAddCstPropUnchanged_3" ] ∀ (x y : Nat), 40 + (x * y) < y ===> natAddCstPropUnchanged_3
+#testOptimize [ "NatAddCstPropUnchanged_3", proof ] ∀ (x y : Nat), 40 + (x * y) < y ===> natAddCstPropUnchanged_3
 
 
 /-! Test cases for normalization rule `n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)`. -/
@@ -254,7 +254,7 @@ elab "natAddCstPropUnchanged_3" : term => return natAddCstPropUnchanged_3
 #testOptimize [ "NatAddCommut_3", proof ] ∀ (x : Nat), x + 10 = 10 + x ===> True
 
 -- y + x ===> x + y (with `x` declared first)
-#testOptimize [ "NatAddCommut_4" ] ∀ (x y z : Nat), z < y + x ===> ∀ (x y z : Nat), z < Nat.add x y
+#testOptimize [ "NatAddCommut_4", proof ] ∀ (x y z : Nat), z < y + x ===> ∀ (x y z : Nat), z < Nat.add x y
 
 -- x + 40 ===> 40 + x
 def natAddCommut_5 : Expr :=
@@ -276,13 +276,13 @@ def natAddCommut_5 : Expr :=
 
 elab "natAddCommut_5" : term => return natAddCommut_5
 
-#testOptimize [ "NatAddCommut_5" ] ∀ (x y : Nat), y < x + 40 ===> natAddCommut_5
+#testOptimize [ "NatAddCommut_5", proof ] ∀ (x y : Nat), y < x + 40 ===> natAddCommut_5
 
 -- (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
 #testOptimize [ "NatAddCommut_6", proof ] ∀ (x y z : Nat), (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
 
 --- (x - y) + (p + q) ===> (p + q) + (x - y)
-#testOptimize [ "NatAddCommut_7" ] ∀ (x y z p q : Nat), (x - y) + (p + q) < z ===>
+#testOptimize [ "NatAddCommut_7", proof ] ∀ (x y z p q : Nat), (x - y) + (p + q) < z ===>
                                    ∀ (x y z p q : Nat), Nat.add (Nat.add p q) (Nat.sub x y) < z
 
 --- (x - y) + (p + q) = (p + q) + (x - y) ===> True
@@ -320,7 +320,7 @@ def natAddVar_4 : Expr :=
 
 elab "natAddVar_4" : term => return natAddVar_4
 
-#testOptimize [ "NatAddVar_4" ] ∀ (x y : Nat), x + y < 10 ===> natAddVar_4
+#testOptimize [ "NatAddVar_4", proof ] ∀ (x y : Nat), x + y < 10 ===> natAddVar_4
 
 
 /-! Test cases to ensure that constant propagation is properly performed

--- a/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
@@ -13,19 +13,19 @@ namespace Test.OptimizeNatAdd
 def natAddCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 10)
 elab "natAddCst_1" : term => return natAddCst_1
 
-#testOptimize [ "NatAddCst_1" ] (0 : Nat) + 10 ===> natAddCst_1
+#testOptimize [ "NatAddCst_1", proof ] (0 : Nat) + 10 ===> natAddCst_1
 
 -- 12 + 0 ===> 12
 def natAddCst_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 12)
 elab "natAddCst_2" : term => return natAddCst_2
 
-#testOptimize [ "NatAddCst_2" ] (12 : Nat) + 0 ===> natAddCst_2
+#testOptimize [ "NatAddCst_2", proof ] (12 : Nat) + 0 ===> natAddCst_2
 
 -- 123 + 50 ===> 173
 def natAddCst_3 : Expr := Lean.Expr.lit (Lean.Literal.natVal 173)
 elab "natAddCst_3" : term => return natAddCst_3
 
-#testOptimize [ "NatAddCst_3" ] (123 : Nat) + 50 ===> natAddCst_3
+#testOptimize [ "NatAddCst_3", proof ] (123 : Nat) + 50 ===> natAddCst_3
 
 
 /-! Test cases for simplification rule `0 + n ===> n`. -/
@@ -105,16 +105,16 @@ elab "natAddZeroUnchanged_4" : term => return natAddZeroUnchanged_4
 /-! Test cases for simplification rule `N1 + (N2 + n) ===> (N1 "+" N2) + n`. -/
 
 -- 10 + (20 + x) = 30 + x ===> True
-#testOptimize [ "NatAddCstProp_1" ] ∀ (x : Nat), 10 + (20 + x) = 30 + x ===> True
+#testOptimize [ "NatAddCstProp_1", proof ] ∀ (x : Nat), 10 + (20 + x) = 30 + x ===> True
 
 -- 10 + (x + 20) = x + 30 ===> True
-#testOptimize [ "NatAddCstProp_2" ] ∀ (x : Nat), 10 + (x + 20) = x + 30 ===> True
+#testOptimize [ "NatAddCstProp_2", proof ] ∀ (x : Nat), 10 + (x + 20) = x + 30 ===> True
 
 -- (x + 20) + 10 = 30 + x ===> True
-#testOptimize [ "NatAddCstProp_3" ] ∀ (x : Nat), (x + 20) + 10 = 30 + x ===> True
+#testOptimize [ "NatAddCstProp_3", proof ] ∀ (x : Nat), (x + 20) + 10 = 30 + x ===> True
 
 -- (20 + x) + 10 = x + 30 ===> True
-#testOptimize [ "NatAddCstProp_4" ] ∀ (x : Nat), (20 + x) + 10 = x + 30 ===> True
+#testOptimize [ "NatAddCstProp_4", proof ] ∀ (x : Nat), (20 + x) + 10 = x + 30 ===> True
 
 -- 10 + (20 + x) ===> (30 + x)
 def natAddCstProp_5 : Expr :=
@@ -139,22 +139,22 @@ elab "natAddCstProp_5" : term => return natAddCstProp_5
 #testOptimize [ "NatAddCstProp_5" ] ∀ (x y : Nat), 10 + (20 + x) < y ===> natAddCstProp_5
 
 -- 10 + (20 + (40 + x)) = 70 + x ===> True
-#testOptimize [ "NatAddCstProp_6" ] ∀ (x : Nat), 10 + (20 + (40 + x)) = 70 + x ===> True
+#testOptimize [ "NatAddCstProp_6", proof ] ∀ (x : Nat), 10 + (20 + (40 + x)) = 70 + x ===> True
 
 -- 10 + (20 + (x + 40)) = 70 + x ===> True
-#testOptimize [ "NatAddCstProp_7" ] ∀ (x : Nat), 10 + (20 + (x + 40)) = 70 + x ===> True
+#testOptimize [ "NatAddCstProp_7", proof ] ∀ (x : Nat), 10 + (20 + (x + 40)) = 70 + x ===> True
 
 -- 10 + ((x + 20) - 10) = 20 + x ===> True
 #testOptimize [ "NatAddCstProp_8" ] ∀ (x : Nat), 10 + ((x + 20) - 10) = 20 + x ===> True
 
 -- 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
-#testOptimize [ "NatAddCstProp_9" ] ∀ (x : Nat), 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
+#testOptimize [ "NatAddCstProp_9", proof ] ∀ (x : Nat), 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
 
 -- 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
 #testOptimize [ "NatAddCstProp_10" ] ∀ (x : Nat), 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
 
 -- 100 + ((180 - (x + 40)) - 150) = 100
-#testOptimize [ "NatAddCstProp_11" ] ∀ (x : Nat), 100 + ((180 - (x + 40)) - 150) = 100 ===> True
+#testOptimize [ "NatAddCstProp_11", proof ] ∀ (x : Nat), 100 + ((180 - (x + 40)) - 150) = 100 ===> True
 
 
 /-! Test cases to ensure that simplification rule `N1 + (N2 + n) ===> (N1 "+" N2) + n`
@@ -245,13 +245,13 @@ elab "natAddCstPropUnchanged_3" : term => return natAddCstPropUnchanged_3
 /-! Test cases for normalization rule `n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)`. -/
 
 -- x + y = x + y ===> True
-#testOptimize [ "NatAddCommut_1" ] ∀ (x y : Nat), x + y = x + y ===> True
+#testOptimize [ "NatAddCommut_1", proof ] ∀ (x y : Nat), x + y = x + y ===> True
 
 -- x + y = y + x ===> True
-#testOptimize [ "NatAddCommut_2" ] ∀ (x y : Nat), x + y = y + x ===> True
+#testOptimize [ "NatAddCommut_2", proof ] ∀ (x y : Nat), x + y = y + x ===> True
 
 -- x + 10 = 10 + x ===> True
-#testOptimize [ "NatAddCommut_3" ] ∀ (x : Nat), x + 10 = 10 + x ===> True
+#testOptimize [ "NatAddCommut_3", proof ] ∀ (x : Nat), x + 10 = 10 + x ===> True
 
 -- y + x ===> x + y (with `x` declared first)
 #testOptimize [ "NatAddCommut_4" ] ∀ (x y z : Nat), z < y + x ===> ∀ (x y z : Nat), z < Nat.add x y
@@ -279,26 +279,26 @@ elab "natAddCommut_5" : term => return natAddCommut_5
 #testOptimize [ "NatAddCommut_5" ] ∀ (x y : Nat), y < x + 40 ===> natAddCommut_5
 
 -- (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
-#testOptimize [ "NatAddCommut_6" ] ∀ (x y z : Nat), (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
+#testOptimize [ "NatAddCommut_6", proof ] ∀ (x y z : Nat), (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
 
 --- (x - y) + (p + q) ===> (p + q) + (x - y)
 #testOptimize [ "NatAddCommut_7" ] ∀ (x y z p q : Nat), (x - y) + (p + q) < z ===>
                                    ∀ (x y z p q : Nat), Nat.add (Nat.add p q) (Nat.sub x y) < z
 
 --- (x - y) + (p + q) = (p + q) + (x - y) ===> True
-#testOptimize [ "NatAddCommut_8" ] ∀ (x y p q : Nat), (x - y) + (p + q) = (p + q) + (x - y) ===> True
+#testOptimize [ "NatAddCommut_8", proof ] ∀ (x y p q : Nat), (x - y) + (p + q) = (p + q) + (x - y) ===> True
 
 
 /-! Test cases to ensure that `Nat.add` is preserved when expected. -/
 
 -- x + (y + 0) = y + x ===> True
-#testOptimize [ "NatAddVar_1" ] ∀ (x y : Nat), x + (y + 0) = y + x ===> True
+#testOptimize [ "NatAddVar_1", proof ] ∀ (x y : Nat), x + (y + 0) = y + x ===> True
 
 -- (x + 0) + y = y + x ===> True
-#testOptimize [ "NatAddVar_2" ] ∀ (x y : Nat), (x + 0) + y = y + x ===> True
+#testOptimize [ "NatAddVar_2", proof ] ∀ (x y : Nat), (x + 0) + y = y + x ===> True
 
 -- (x + 0) + (y + 0) = y + x ===> True
-#testOptimize [ "NatAddVar_3" ] ∀ (x y : Nat), (x + 0) + (y + 0) = y + x ===> True
+#testOptimize [ "NatAddVar_3", proof ] ∀ (x y : Nat), (x + 0) + (y + 0) = y + x ===> True
 
 -- x + y < 10 ===> x + y < 10
 def natAddVar_4 : Expr :=
@@ -334,12 +334,12 @@ variable (y : Nat)
 def natAddReduce_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 100)
 elab "natAddReduce_1" : term => return natAddReduce_1
 
-#testOptimize [ "NatAddReduce_1" ] (100 + ((180 - (x + 40)) - 150)) + ((200 - y) - 320) ===> natAddReduce_1
+#testOptimize [ "NatAddReduce_1", proof ] (100 + ((180 - (x + 40)) - 150)) + ((200 - y) - 320) ===> natAddReduce_1
 
 def natAddReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 124)
 elab "natAddReduce_2" : term => return natAddReduce_2
 
 -- (100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24) ===> 124
-#testOptimize [ "NatAddReduce_2" ] (100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24)  ===> natAddReduce_2
+#testOptimize [ "NatAddReduce_2", proof ] (100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24)  ===> natAddReduce_2
 
 end Test.OptimizeNatAdd

--- a/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
@@ -71,13 +71,16 @@ def natAddZeroUnchanged_1 : Expr :=
 
 elab "natAddZeroUnchanged_1" : term => return natAddZeroUnchanged_1
 
-#testOptimize [ "NatAddZeroUnchanged_1", proof ] ∀ (x y : Nat), (1 + x) < y ===> natAddZeroUnchanged_1
+#testOptimize [ "NatAddZeroUnchanged_1", proof ]
+  ∀ (x y : Nat), (1 + x) < y ===> natAddZeroUnchanged_1
 
 -- (27 - 26) + x ===> 1 + x
-#testOptimize [ "NatAddZeroUnchanged_2", proof ] ∀ (x y : Nat), (27 - 26) + x < y ===> natAddZeroUnchanged_1
+#testOptimize [ "NatAddZeroUnchanged_2", proof ]
+  ∀ (x y : Nat), (27 - 26) + x < y ===> natAddZeroUnchanged_1
 
 -- (Nat.zero + 1) + x ===> 1 + x
-#testOptimize [ "NatAddZeroUnchanged_3", proof ] ∀ (x y : Nat), (Nat.zero + 1) + x < y ===> natAddZeroUnchanged_1
+#testOptimize [ "NatAddZeroUnchanged_3", proof ]
+  ∀ (x y : Nat), (Nat.zero + 1) + x < y ===> natAddZeroUnchanged_1
 
 -- (127 + 40) + x ===> 167 + x
 def natAddZeroUnchanged_4 : Expr :=
@@ -99,7 +102,8 @@ def natAddZeroUnchanged_4 : Expr :=
 
 elab "natAddZeroUnchanged_4" : term => return natAddZeroUnchanged_4
 
-#testOptimize [ "NatAddZeroUnchanged_4", proof ] ∀ (x y : Nat), (127 + 40) + x < y ===> natAddZeroUnchanged_4
+#testOptimize [ "NatAddZeroUnchanged_4", proof ]
+  ∀ (x y : Nat), (127 + 40) + x < y ===> natAddZeroUnchanged_4
 
 
 /-! Test cases for simplification rule `N1 + (N2 + n) ===> (N1 "+" N2) + n`. -/
@@ -145,16 +149,19 @@ elab "natAddCstProp_5" : term => return natAddCstProp_5
 #testOptimize [ "NatAddCstProp_7", proof ] ∀ (x : Nat), 10 + (20 + (x + 40)) = 70 + x ===> True
 
 -- 10 + ((x + 20) - 10) = 20 + x ===> True
-#testOptimize [ "NatAddCstProp_8" ] ∀ (x : Nat), 10 + ((x + 20) - 10) = 20 + x ===> True
+#testOptimize [ "NatAddCstProp_8", proof ] ∀ (x : Nat), 10 + ((x + 20) - 10) = 20 + x ===> True
 
 -- 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
-#testOptimize [ "NatAddCstProp_9", proof ] ∀ (x : Nat), 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
+#testOptimize [ "NatAddCstProp_9", proof ]
+  ∀ (x : Nat), 10 + (20 + (15 + (x + 25))) = 70 + x ===> True
 
 -- 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
-#testOptimize [ "NatAddCstProp_10", proof ] ∀ (x : Nat), 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
+#testOptimize [ "NatAddCstProp_10", proof ]
+  ∀ (x : Nat), 10 + (20 + ((x + 10) - 7)) = 33 + x ===> True
 
 -- 100 + ((180 - (x + 40)) - 150) = 100
-#testOptimize [ "NatAddCstProp_11", proof ] ∀ (x : Nat), 100 + ((180 - (x + 40)) - 150) = 100 ===> True
+#testOptimize [ "NatAddCstProp_11", proof ]
+  ∀ (x : Nat), 100 + ((180 - (x + 40)) - 150) = 100 ===> True
 
 
 /-! Test cases to ensure that simplification rule `N1 + (N2 + n) ===> (N1 "+" N2) + n`
@@ -185,7 +192,8 @@ def natAddCstPropUnchanged_1 : Expr :=
 
 elab "natAddCstPropUnchanged_1" : term => return natAddCstPropUnchanged_1
 
-#testOptimize [ "NatAddCstPropUnchanged_1", proof ] ∀ (x y : Nat), 40 + (x + y) < y ===> natAddCstPropUnchanged_1
+#testOptimize [ "NatAddCstPropUnchanged_1", proof ]
+  ∀ (x y : Nat), 40 + (x + y) < y ===> natAddCstPropUnchanged_1
 
 
 -- 40 + (x - y) ===> 40 + (x - y)
@@ -212,7 +220,8 @@ def natAddCstPropUnchanged_2 : Expr :=
 
 elab "natAddCstPropUnchanged_2" : term => return natAddCstPropUnchanged_2
 
-#testOptimize [ "NatAddCstPropUnchanged_2", proof ] ∀ (x y : Nat), 40 + (x - y) < y ===> natAddCstPropUnchanged_2
+#testOptimize [ "NatAddCstPropUnchanged_2", proof ]
+  ∀ (x y : Nat), 40 + (x - y) < y ===> natAddCstPropUnchanged_2
 
 
 -- 40 + (x * y) ===> 40 + (x * y)
@@ -239,7 +248,8 @@ def natAddCstPropUnchanged_3 : Expr :=
 
 elab "natAddCstPropUnchanged_3" : term => return natAddCstPropUnchanged_3
 
-#testOptimize [ "NatAddCstPropUnchanged_3", proof ] ∀ (x y : Nat), 40 + (x * y) < y ===> natAddCstPropUnchanged_3
+#testOptimize [ "NatAddCstPropUnchanged_3", proof ]
+  ∀ (x y : Nat), 40 + (x * y) < y ===> natAddCstPropUnchanged_3
 
 
 /-! Test cases for normalization rule `n1 + n2 ==> n2 + n1 (if n2 <ₒ n1)`. -/
@@ -254,7 +264,8 @@ elab "natAddCstPropUnchanged_3" : term => return natAddCstPropUnchanged_3
 #testOptimize [ "NatAddCommut_3", proof ] ∀ (x : Nat), x + 10 = 10 + x ===> True
 
 -- y + x ===> x + y (with `x` declared first)
-#testOptimize [ "NatAddCommut_4", proof ] ∀ (x y z : Nat), z < y + x ===> ∀ (x y z : Nat), z < Nat.add x y
+#testOptimize [ "NatAddCommut_4", proof ]
+  ∀ (x y z : Nat), z < y + x ===> ∀ (x y z : Nat), z < Nat.add x y
 
 -- x + 40 ===> 40 + x
 def natAddCommut_5 : Expr :=
@@ -279,14 +290,17 @@ elab "natAddCommut_5" : term => return natAddCommut_5
 #testOptimize [ "NatAddCommut_5", proof ] ∀ (x y : Nat), y < x + 40 ===> natAddCommut_5
 
 -- (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
-#testOptimize [ "NatAddCommut_6", proof ] ∀ (x y z : Nat), (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
+#testOptimize [ "NatAddCommut_6", proof ]
+  ∀ (x y z : Nat), (x + (y + 20)) + z = z + ((y + 20) + x) ===> True
 
 --- (x - y) + (p + q) ===> (p + q) + (x - y)
-#testOptimize [ "NatAddCommut_7", proof ] ∀ (x y z p q : Nat), (x - y) + (p + q) < z ===>
-                                   ∀ (x y z p q : Nat), Nat.add (Nat.add p q) (Nat.sub x y) < z
+#testOptimize [ "NatAddCommut_7", proof ]
+  ∀ (x y z p q : Nat), (x - y) + (p + q) < z ===>
+  ∀ (x y z p q : Nat), Nat.add (Nat.add p q) (Nat.sub x y) < z
 
 --- (x - y) + (p + q) = (p + q) + (x - y) ===> True
-#testOptimize [ "NatAddCommut_8", proof ] ∀ (x y p q : Nat), (x - y) + (p + q) = (p + q) + (x - y) ===> True
+#testOptimize [ "NatAddCommut_8", proof ]
+  ∀ (x y p q : Nat), (x - y) + (p + q) = (p + q) + (x - y) ===> True
 
 
 /-! Test cases to ensure that `Nat.add` is preserved when expected. -/
@@ -298,6 +312,7 @@ elab "natAddCommut_5" : term => return natAddCommut_5
 #testOptimize [ "NatAddVar_2", proof ] ∀ (x y : Nat), (x + 0) + y = y + x ===> True
 
 -- (x + 0) + (y + 0) = y + x ===> True
+set_option trace.Optimize.expr true in
 #testOptimize [ "NatAddVar_3", proof ] ∀ (x y : Nat), (x + 0) + (y + 0) = y + x ===> True
 
 -- x + y < 10 ===> x + y < 10
@@ -334,12 +349,14 @@ variable (y : Nat)
 def natAddReduce_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 100)
 elab "natAddReduce_1" : term => return natAddReduce_1
 
-#testOptimize [ "NatAddReduce_1", proof ] (100 + ((180 - (x + 40)) - 150)) + ((200 - y) - 320) ===> natAddReduce_1
+#testOptimize [ "NatAddReduce_1", proof ]
+  (100 + ((180 - (x + 40)) - 150)) + ((200 - y) - 320) ===> natAddReduce_1
 
 def natAddReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 124)
 elab "natAddReduce_2" : term => return natAddReduce_2
 
 -- (100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24) ===> 124
-#testOptimize [ "NatAddReduce_2", proof ] (100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24)  ===> natAddReduce_2
+#testOptimize [ "NatAddReduce_2", proof ]
+  (100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24)  ===> natAddReduce_2
 
 end Test.OptimizeNatAdd

--- a/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatAdd.lean
@@ -312,7 +312,6 @@ elab "natAddCommut_5" : term => return natAddCommut_5
 #testOptimize [ "NatAddVar_2", proof ] ∀ (x y : Nat), (x + 0) + y = y + x ===> True
 
 -- (x + 0) + (y + 0) = y + x ===> True
-set_option trace.Optimize.expr true in
 #testOptimize [ "NatAddVar_3", proof ] ∀ (x y : Nat), (x + 0) + (y + 0) = y + x ===> True
 
 -- x + y < 10 ===> x + y < 10

--- a/Tests/Optimize/OptimizeNat/OptimizeNatDiv.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatDiv.lean
@@ -13,37 +13,37 @@ namespace Test.OptimizeNatDiv
 def natDivCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 0)
 elab "natDivCst_1" : term => return natDivCst_1
 
-#testOptimize [ "NatDivCst_1" ] (0 : Nat) / 432 ===> natDivCst_1
+#testOptimize [ "NatDivCst_1", proof ] (0 : Nat) / 432 ===> natDivCst_1
 
 -- 432 / 0 ===> 0
 -- NOTE: divison by zero not triggered
-#testOptimize [ "NatDivCst_2" ] (432 : Nat) / 0 ===> natDivCst_1
+#testOptimize [ "NatDivCst_2", proof ] (432 : Nat) / 0 ===> natDivCst_1
 
 -- 132 / 1 ===> 132
 def natDivCst_3 : Expr := Lean.Expr.lit (Lean.Literal.natVal 132)
 elab "natDivCst_3" : term => return natDivCst_3
 
-#testOptimize [ "NatDivCst_3" ] (132 : Nat) / 1 ===> natDivCst_3
+#testOptimize [ "NatDivCst_3", proof ] (132 : Nat) / 1 ===> natDivCst_3
 
 -- 7 / 3 ===> 2
 def natDivCst_4 : Expr := Lean.Expr.lit (Lean.Literal.natVal 2)
 elab "natDivCst_4" : term => return natDivCst_4
 
-#testOptimize [ "NatDivCst_4" ] (7 : Nat) / 3 ===> natDivCst_4
+#testOptimize [ "NatDivCst_4", proof ] (7 : Nat) / 3 ===> natDivCst_4
 
 -- 18 / 3 ===> 6
 def natDivCst_5 : Expr := Lean.Expr.lit (Lean.Literal.natVal 6)
 elab "natDivCst_5" : term => return natDivCst_5
 
-#testOptimize [ "NatDivCst_5" ] (18 : Nat) / 3 ===> natDivCst_5
+#testOptimize [ "NatDivCst_5", proof ] (18 : Nat) / 3 ===> natDivCst_5
 
 -- 8 / 3 ===> 2
-#testOptimize [ "NatDivCst_6" ] (8 : Nat) / 3 ===> natDivCst_4
+#testOptimize [ "NatDivCst_6", proof ] (8 : Nat) / 3 ===> natDivCst_4
 
 -- 0 / 0 ===> 0
 -- NOTE: test case showing that n1/n2 ===> 1 (if n1=ₚₜᵣ n2)
 -- cannot be considered.
-#testOptimize [ "NatDivCst_7" ] (0 : Nat) / 0 ===> natDivCst_1
+#testOptimize [ "NatDivCst_7", proof ] (0 : Nat) / 0 ===> natDivCst_1
 
 
 /-! Test cases for simplification rule `n / 0 ==> 0`. -/
@@ -62,37 +62,38 @@ def natDivZero_1 : Expr :=
   (Lean.BinderInfo.default))
 elab "natDivZero_1" : term => return natDivZero_1
 
-#testOptimize [ "NatDivZero_1" ] ∀ (x y : Nat), x / 0 < y ===> natDivZero_1
+#testOptimize [ "NatDivZero_1", proof ] ∀ (x y : Nat), x / 0 < y ===> natDivZero_1
 
 -- x / 0 = 0 ===> True
-#testOptimize [ "NatDivZero_2" ] ∀ (x : Nat), x / 0 = 0 ===> True
+#testOptimize [ "NatDivZero_2", proof ] ∀ (x : Nat), x / 0 = 0 ===> True
 
 -- x / Nat.zero ===> 0
-#testOptimize [ "NatDivZero_3" ] ∀ (x y : Nat), x / Nat.zero < y ===> natDivZero_1
+#testOptimize [ "NatDivZero_3", proof ] ∀ (x y : Nat), x / Nat.zero < y ===> natDivZero_1
 
 -- x / Nat.zero = 0 ===> True
-#testOptimize [ "NatDivZero_4" ] ∀ (x : Nat), x / Nat.zero = 0 ===> True
+#testOptimize [ "NatDivZero_4", proof ] ∀ (x : Nat), x / Nat.zero = 0 ===> True
 
 -- ∀ (x y : Nat), (x / y - y) = 0 ===> True
-#testOptimize [ "NatDivZero_5" ] ∀ (x y : Nat), x / (y - y) = 0 ===> True
+#testOptimize [ "NatDivZero_5", proof ] ∀ (x y : Nat), x / (y - y) = 0 ===> True
 
 -- ∀ (x y : Nat), (x / ((1 * y) - y)) = 0 ===> True
-#testOptimize [ "NatDivZero_6" ] ∀ (x y : Nat), x / ((1 * y) - y) = 0 ===> True
+#testOptimize [ "NatDivZero_6", proof ] ∀ (x y : Nat), x / ((1 * y) - y) = 0 ===> True
 
 
 /-! Test cases for simplification rule `n / 1 ==> n`. -/
 
 -- x / 1 ===> x
-#testOptimize [ "NatDivOne_1" ] ∀ (x y : Nat), x / 1 < y ===> ∀ (x y : Nat), x < y
+#testOptimize [ "NatDivOne_1", proof ] ∀ (x y : Nat), x / 1 < y ===> ∀ (x y : Nat), x < y
 
 -- x / 1 = x ===> True
-#testOptimize [ "NatDivOne_2" ] ∀ (x : Nat), x / 1 = x ===> True
+#testOptimize [ "NatDivOne_2", proof ] ∀ (x : Nat), x / 1 = x ===> True
 
 -- ∀ (x y : Nat), (x / ((((Nat.succ y) - 1) - y) + 1) = x ===> True
-#testOptimize [ "NatDivOne_3" ] ∀ (x y : Nat), x / ((((Nat.succ y) - 1) - y) + 1) = x ===> True
+#testOptimize [ "NatDivOne_3", proof ]
+  ∀ (x y : Nat), x / ((((Nat.succ y) - 1) - y) + 1) = x ===> True
 
 -- ∀ (x y : Nat), (x / (((100 - y) -230) + 1) = x ===> True
-#testOptimize [ "NatDivOne_4" ] ∀ (x y : Nat), x / (((100 - y) -230) + 1) = x ===> True
+#testOptimize [ "NatDivOne_4", proof ] ∀ (x y : Nat), x / (((100 - y) -230) + 1) = x ===> True
 
 
 /-! Test cases to ensure that the following simplification rules are not wrongly applied:
@@ -120,37 +121,39 @@ def natDivCstUnchanged_1 : Expr :=
 
 elab "natDivCstUnchanged_1" : term => return natDivCstUnchanged_1
 
-#testOptimize [ "NatDivCstUnchanged_1" ] ∀ (x y : Nat), x / 10 < y ===> natDivCstUnchanged_1
+#testOptimize [ "NatDivCstUnchanged_1", proof ] ∀ (x y : Nat), x / 10 < y ===> natDivCstUnchanged_1
 
 -- x / (100 - 90) ===> x / 10
-#testOptimize [ "NatDivCstUnchanged_2" ] ∀ (x y : Nat), x / (100 - 90) < y ===> natDivCstUnchanged_1
+#testOptimize [ "NatDivCstUnchanged_2", proof ]
+  ∀ (x y : Nat), x / (100 - 90) < y ===> natDivCstUnchanged_1
 
 
 -- ∀ (x y z : Nat), (x / y - x) < z ==> ∀ (x y z : Nat), Nat.div x (Nat.sub y x) < z
-#testOptimize [ "NatDivCstUnchanged_3" ] ∀ (x y z : Nat), x / (y - x) < z ===>
-                                         ∀ (x y z : Nat), Nat.div x (Nat.sub y x) < z
+#testOptimize [ "NatDivCstUnchanged_3", proof ]
+  ∀ (x y z : Nat), x / (y - x) < z ===>
+  ∀ (x y z : Nat), Nat.div x (Nat.sub y x) < z
 
 
 /-! Test cases for simplification rule `0 / n ==> 0`. -/
 
 -- 0 / x ===> 0
-#testOptimize [ "NatZeroDiv_1" ] ∀ (x y : Nat), 0 / x < y ===> natDivZero_1
+#testOptimize [ "NatZeroDiv_1", proof ] ∀ (x y : Nat), 0 / x < y ===> natDivZero_1
 
 -- 0 / x = 0 ===> True
-#testOptimize [ "NatZeroDiv_2" ] ∀ (x : Nat), 0 / x = 0 ===> True
+#testOptimize [ "NatZeroDiv_2", proof ] ∀ (x : Nat), 0 / x = 0 ===> True
 
 -- Nat.zero / x ===> 0
-#testOptimize [ "NatZeroDiv_3" ] ∀ (x y : Nat), Nat.zero / x < y ===> natDivZero_1
+#testOptimize [ "NatZeroDiv_3", proof ] ∀ (x y : Nat), Nat.zero / x < y ===> natDivZero_1
 
 -- Nat.zero / x = 0 ===> True
-#testOptimize [ "NatZeroDiv_4" ] ∀ (x : Nat), Nat.zero / x = 0 ===> True
+#testOptimize [ "NatZeroDiv_4", proof ] ∀ (x : Nat), Nat.zero / x = 0 ===> True
 
 
 -- ∀ (x y : Nat), (y - y) / x = 0 ===> True
-#testOptimize [ "NatZeroDiv_5" ] ∀ (x y : Nat), (y - y) / x  = 0 ===> True
+#testOptimize [ "NatZeroDiv_5", proof ] ∀ (x y : Nat), (y - y) / x  = 0 ===> True
 
 -- ∀ (x y : Nat), ((100 - y) - 120) / x = 0 ===> True
-#testOptimize [ "NatZeroDiv_6" ] ∀ (x y : Nat), ((100 - y) - 120) / x = 0 ===> True
+#testOptimize [ "NatZeroDiv_6", proof ] ∀ (x y : Nat), ((100 - y) - 120) / x = 0 ===> True
 
 
 
@@ -176,15 +179,17 @@ def natCstDivUnchanged_1 : Expr :=
 
 elab "natCstDivUnchanged_1" : term => return natCstDivUnchanged_1
 
-#testOptimize [ "NatCstDivUnchanged_1" ] ∀ (x y : Nat), 10 / x < y ===> natCstDivUnchanged_1
+#testOptimize [ "NatCstDivUnchanged_1", proof ] ∀ (x y : Nat), 10 / x < y ===> natCstDivUnchanged_1
 
 -- (100 - 90) / x ===> 10 / x
-#testOptimize [ "NatCstDivUnchanged_2" ] ∀ (x y : Nat), (100 - 90) / x < y ===> natCstDivUnchanged_1
+#testOptimize [ "NatCstDivUnchanged_2", proof ]
+  ∀ (x y : Nat), (100 - 90) / x < y ===> natCstDivUnchanged_1
 
 
 -- ∀ (x y z : Nat), (x / y - x) < z ==> ∀ (x y z : Nat), Nat.div x (Nat.sub y x) < z
-#testOptimize [ "NatCstDivUnchanged_3" ] ∀ (x y z : Nat), (y - x) / x < z ===>
-                                         ∀ (x y z : Nat), Nat.div (Nat.sub y x) x < z
+#testOptimize [ "NatCstDivUnchanged_3", proof ]
+  ∀ (x y z : Nat), (y - x) / x < z ===>
+  ∀ (x y z : Nat), Nat.div (Nat.sub y x) x < z
 
 
 /-! Test cases for simplification rule `(n / N1) / N2 ==> n / (N1 "*" N2) (if N1 > 0 ∧ N2 > 0)`. -/
@@ -209,28 +214,35 @@ def natDivDivCstProp_1 : Expr :=
 
 elab "natDivDivCstProp_1" : term => return natDivDivCstProp_1
 
-#testOptimize [ "NatDivDivCstProp_1" ] ∀ (x y : Nat), (x / 10) / 20 < y ===> natDivDivCstProp_1
+#testOptimize [ "NatDivDivCstProp_1", proof ]
+  ∀ (x y : Nat), (x / 10) / 20 < y ===> natDivDivCstProp_1
 
 -- (x / 10) / 20 = x / 200 ===> True
-#testOptimize [ "NatDivDivCstProp_2" ] ∀ (x : Nat), (x / 10) / 20 = (x / 200) ===> True
+#testOptimize [ "NatDivDivCstProp_2", proof ]
+  ∀ (x : Nat), (x / 10) / 20 = (x / 200) ===> True
 
 -- (x / 0) / 20 = 0 ===> True
-#testOptimize [ "NatDivDivCstProp_3" ] ∀ (x : Nat), (x / 0) / 20 = 0 ===> True
+#testOptimize [ "NatDivDivCstProp_3", proof ]
+  ∀ (x : Nat), (x / 0) / 20 = 0 ===> True
 
 -- (x / 10) / 0 = 0 ===> True
-#testOptimize [ "NatDivDivCstProp_4" ] ∀ (x : Nat), (x / 10) / 0 = 0 ===> True
+#testOptimize [ "NatDivDivCstProp_4", proof ]
+  ∀ (x : Nat), (x / 10) / 0 = 0 ===> True
 
 -- (x / 10) / 0 = 0 ===> True
-#testOptimize [ "NatDivDivCstProp_5" ] ∀ (x : Nat), (x / 10) / 0 = 0 ===> True
+#testOptimize [ "NatDivDivCstProp_5", proof ] ∀ (x : Nat), (x / 10) / 0 = 0 ===> True
 
 -- (x / 10) / ((20 - (50 + x)) + 10) = x / 100 ===> True
-#testOptimize [ "NatDivDivCstProp_6" ] ∀ (x : Nat), (x / 10) / ((20 - (50 + x)) + 10) = x / 100 ===> True
+#testOptimize [ "NatDivDivCstProp_6", proof ]
+  ∀ (x : Nat), (x / 10) / ((20 - (50 + x)) + 10) = x / 100 ===> True
 
 -- (((x / 10) / 3) / 40) = x / 1200 ===> True
-#testOptimize [ "NatDivDivCstProp_7" ] ∀ (x : Nat), (((x / 10) / 3) / 40) = x / 1200 ===> True
+#testOptimize [ "NatDivDivCstProp_7", proof ]
+  ∀ (x : Nat), (((x / 10) / 3) / 40) = x / 1200 ===> True
 
 -- (((x / 100 + ((120 - x) - 150)) / 3) / 14) = x / 4200 ===> True
-#testOptimize [ "NatDivDivCstProp_8" ] ∀ (x : Nat), (((x / 100 + ((120 - x) - 150)) / 3) / 14) = x / 4200 ===> True
+#testOptimize [ "NatDivDivCstProp_8", proof ]
+  ∀ (x : Nat), (((x / 100 + ((120 - x) - 150)) / 3) / 14) = x / 4200 ===> True
 
 
 /-! Test cases to ensure that simplification rule `(n / N1) / N2 ==> n / (N1 "*" N2) (if N1 > 0 ∧ N2 > 0)`
@@ -263,10 +275,12 @@ def natDivDivCstUnchanged_1 : Expr :=
   (Lean.BinderInfo.default)
 elab "natDivDivCstUnchanged_1" : term => return natDivDivCstUnchanged_1
 
-#testOptimize [ "NatDivDivCstUnchanged_1" ] ∀ (x y z : Nat), (x / 10) / y < z ===>  natDivDivCstUnchanged_1
+#testOptimize [ "NatDivDivCstUnchanged_1", proof ]
+  ∀ (x y z : Nat), (x / 10) / y < z ===>  natDivDivCstUnchanged_1
 
 -- (x / 10) / y = (x / 10) / y ===> True
-#testOptimize [ "NatDivDivCstUnchanged_2" ] ∀ (x y : Nat), (x / 10) / y = (x / 10) / y ===> True
+#testOptimize [ "NatDivDivCstUnchanged_2", proof ]
+  ∀ (x y : Nat), (x / 10) / y = (x / 10) / y ===> True
 
 -- (x / y) / 20 ===> (x / y) / 20
 def natDivDivCstUnchanged_3 : Expr :=
@@ -292,10 +306,12 @@ Lean.Expr.forallE `x
   (Lean.BinderInfo.default)
 elab "natDivDivCstUnchanged_3" : term => return natDivDivCstUnchanged_3
 
-#testOptimize [ "NatDivDivCstUnchanged_3" ] ∀ (x y z : Nat), (x / y) / 20 < z ===> natDivDivCstUnchanged_3
+#testOptimize [ "NatDivDivCstUnchanged_3", proof ]
+  ∀ (x y z : Nat), (x / y) / 20 < z ===> natDivDivCstUnchanged_3
 
 -- (x / y) / 20 = (x / y) / 20 ===> True
-#testOptimize [ "NatDivDivCstUnchanged_4" ] ∀ (x y : Nat), (x / y) / 20 = (x / y) / 20 ===> True
+#testOptimize [ "NatDivDivCstUnchanged_4", proof ]
+  ∀ (x y : Nat), (x / y) / 20 = (x / y) / 20 ===> True
 
 
 
@@ -322,7 +338,8 @@ def natMulDivCstProp_1 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulDivCstProp_1" : term => return natMulDivCstProp_1
 
-#testOptimize [ "NatMulDivCstProp_1" ] ∀ (x y : Nat), (10 * x) / 5 < y ===> natMulDivCstProp_1
+#testOptimize [ "NatMulDivCstProp_1", proof ]
+  ∀ (x y : Nat), (10 * x) / 5 < y ===> natMulDivCstProp_1
 
 def natMulDivCstProp_2 : Expr :=
  Lean.Expr.forallE `x
@@ -347,7 +364,8 @@ def natMulDivCstProp_2 : Expr :=
 elab "natMulDivCstProp_2" : term => return natMulDivCstProp_2
 
 -- (10 * x) / 15 ===> (2 * x) / 3
-#testOptimize [ "NatMulDivCstProp_2" ] ∀ (x y : Nat), (10 * x) / 15 < y ===> natMulDivCstProp_2
+#testOptimize [ "NatMulDivCstProp_2", proof ]
+  ∀ (x y : Nat), (10 * x) / 15 < y ===> natMulDivCstProp_2
 
 def natMulDivCstProp_3 : Expr :=
  Lean.Expr.forallE `x
@@ -372,7 +390,8 @@ def natMulDivCstProp_3 : Expr :=
 elab "natMulDivCstProp_3" : term => return natMulDivCstProp_3
 
 -- (10 * x) / 13 ===> (10 * x) / 13
-#testOptimize [ "NatMulDivCstProp_3" ] ∀ (x y : Nat), (10 * x) / 13 < y ===> natMulDivCstProp_3
+#testOptimize [ "NatMulDivCstProp_3", proof ]
+  ∀ (x y : Nat), (10 * x) / 13 < y ===> natMulDivCstProp_3
 
 
 -- (6 * x) / 120 ===> x / 20
@@ -394,10 +413,12 @@ def natMulDivCstProp_4 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulDivCstProp_4" : term => return natMulDivCstProp_4
 
-#testOptimize [ "NatMulDivCstProp_4" ] ∀ (x y : Nat), (6 * x) / 120 < y ===> natMulDivCstProp_4
+#testOptimize [ "NatMulDivCstProp_4", proof ]
+  ∀ (x y : Nat), (6 * x) / 120 < y ===> natMulDivCstProp_4
 
 -- (16 * x) / 16 ===> x
-#testOptimize [ "NatMulDivCstProp_5" ] ∀ (x y : Nat), (16 * x) / 16 < y ===> ∀ (x y : Nat), x < y
+#testOptimize [ "NatMulDivCstProp_5", proof ]
+  ∀ (x y : Nat), (16 * x) / 16 < y ===> ∀ (x y : Nat), x < y
 
 
 /-! Test cases to ensure that simplification rule
@@ -419,7 +440,8 @@ def natMulDivCstUnchanged_1 : Expr :=
    (Lean.BinderInfo.default))
 elab "natMulDivCstUnchanged_1" : term => return natMulDivCstUnchanged_1
 
-#testOptimize [ "NatMulDivCstUnchanged_1" ] ∀ (x y : Nat), (10 * x) / 0 < y ===> natMulDivCstUnchanged_1
+#testOptimize [ "NatMulDivCstUnchanged_1", proof ]
+  ∀ (x y : Nat), (10 * x) / 0 < y ===> natMulDivCstUnchanged_1
 
 -- (10 * x) / y ===> (10 * x) / y
 def natMulDivCstUnchanged_2 : Expr :=
@@ -444,7 +466,8 @@ def natMulDivCstUnchanged_2 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulDivCstUnchanged_2" : term => return natMulDivCstUnchanged_2
 
-#testOptimize [ "NatMulDivCstUnchanged_2" ] ∀ (x y : Nat), (10 * x) / y < y ===> natMulDivCstUnchanged_2
+#testOptimize [ "NatMulDivCstUnchanged_2", proof ]
+  ∀ (x y : Nat), (10 * x) / y < y ===> natMulDivCstUnchanged_2
 
 def natMulDivCstUnchanged_3 : Expr :=
  Lean.Expr.forallE `x
@@ -467,7 +490,8 @@ def natMulDivCstUnchanged_3 : Expr :=
 elab "natMulDivCstUnchanged_3" : term => return natMulDivCstUnchanged_3
 
 -- (x * y) / 13 ===> (x * y) / 13
-#testOptimize [ "NatMulDivCstUnchanged_3" ] ∀ (x y : Nat), (x * y) / 13 < y ===> natMulDivCstUnchanged_3
+#testOptimize [ "NatMulDivCstUnchanged_3", proof ]
+  ∀ (x y : Nat), (x * y) / 13 < y ===> natMulDivCstUnchanged_3
 
 
 -- (6 - x) / 120 ===> (6 - x) / 20
@@ -493,7 +517,8 @@ def natMulDivCstUnchanged_4 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulDivCstUnchanged_4" : term => return natMulDivCstUnchanged_4
 
-#testOptimize [ "NatMulDivCstUnchanged_4" ] ∀ (x y : Nat), (6 - x) / 120 < y ===> natMulDivCstUnchanged_4
+#testOptimize [ "NatMulDivCstUnchanged_4", proof ]
+  ∀ (x y : Nat), (6 - x) / 120 < y ===> natMulDivCstUnchanged_4
 
 -- (16 + x) / 16 ===> (16 + x) / 16
 def natMulDivCstUnchanged_5 : Expr :=
@@ -518,7 +543,8 @@ def natMulDivCstUnchanged_5 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulDivCstUnchanged_5" : term => return natMulDivCstUnchanged_5
 
-#testOptimize [ "NatMulDivCstUnchanged_5" ] ∀ (x y : Nat), (16 + x) / 16 < y ===> natMulDivCstUnchanged_5
+#testOptimize [ "NatMulDivCstUnchanged_5", proof ]
+  ∀ (x y : Nat), (16 + x) / 16 < y ===> natMulDivCstUnchanged_5
 
 
 
@@ -528,31 +554,31 @@ elab "natMulDivCstUnchanged_5" : term => return natMulDivCstUnchanged_5
 -/
 
 -- (x * y) / y ===> x
-#testOptimize [ "NatMulDivReduce_1" ] (norm-result: 1)
+#testOptimize [ "NatMulDivReduce_1", proof ] (norm-result: 1)
   ∀ (x y z : Nat), 0 < y → (x * y) / y < z ===> ∀ (x y z : Nat), 0 < y → x < z
 
 -- (x * y) / y = x ===> True
-#testOptimize [ "NatMulDivReduce_2" ] (norm-result: 1)
+#testOptimize [ "NatMulDivReduce_2", proof ] (norm-result: 1)
   ∀ (x y : Nat), 0 ≠ y → (x * y) / y = x ===> True
 
 -- (y * x) / y ===> x
-#testOptimize [ "NatMulDivReduce_3" ] (norm-result: 1)
+#testOptimize [ "NatMulDivReduce_3", proof ] (norm-result: 1)
   ∀ (y x z : Nat), 0 < y → (y * x) / y < z ===> ∀ (y x z : Nat), 0 < y → x < z
 
 -- (y * x) / y = x ===> True
-#testOptimize [ "NatMulDivReduce_4" ]
+#testOptimize [ "NatMulDivReduce_4", proof ]
   ∀ (y x : Nat), 0 < y → (y * x) / y = x ===> True
 
 -- (y * x) / (y + 0) = x ===> True
-#testOptimize [ "NatMulDivReduce_5" ]
+#testOptimize [ "NatMulDivReduce_5", proof ]
   ∀ (y x : Nat), 0 < y → (y * x) / (y + 0) = x ===> True
 
 -- (y * x) / (y + (z - z)) = x ===> True
-#testOptimize [ "NatMulDivReduce_6" ]
+#testOptimize [ "NatMulDivReduce_6", proof ]
   ∀ (y x z : Nat), 0 ≠ y → (y * x) / (y + (z - z)) = x ===> True
 
 -- ((y + 0) * x) / (y + (z - z)) = x ===> True
-#testOptimize [ "NatMulDivReduce_7" ]
+#testOptimize [ "NatMulDivReduce_7", proof ]
   ∀ (y x z : Nat), 0 < y → ((y + 0) * x) / (y + (z - z)) = x ===> True
 
 
@@ -562,37 +588,47 @@ elab "natMulDivCstUnchanged_5" : term => return natMulDivCstUnchanged_5
 -/
 
 -- (x * y) / z ===> (x * y) / z
-#testOptimize [ "NatMulDivReduceUnchanged_1" ] ∀ (x y z : Nat), (x * y) / z < z ===>
-                                               ∀ (x y z : Nat), Nat.div (Nat.mul x y) z < z
+#testOptimize [ "NatMulDivReduceUnchanged_1", proof ]
+  ∀ (x y z : Nat), (x * y) / z < z ===>
+  ∀ (x y z : Nat), Nat.div (Nat.mul x y) z < z
 
 -- (y * x) / z ===> (y * x) / z
-#testOptimize [ "NatMulDivReduceUnchanged_2" ] ∀ (y x z : Nat), (y * x) / z < z ===>
-                                               ∀ (y x z : Nat), Nat.div (Nat.mul y x) z < z
+#testOptimize [ "NatMulDivReduceUnchanged_2", proof ]
+  ∀ (y x z : Nat), (y * x) / z < z ===>
+  ∀ (y x z : Nat), Nat.div (Nat.mul y x) z < z
 
 -- (y * x) / (y + z) ===> Nat.div (Nat.mul x y) (Nat.add y z)
-#testOptimize [ "NatMulDivReduceUnchanged_3" ] ∀ (x y z : Nat), (y * x) / (y + z) < z ===>
-                                               ∀ (x y z : Nat), Nat.div (Nat.mul x y) (Nat.add y z) < z
+#testOptimize [ "NatMulDivReduceUnchanged_3", proof ]
+  ∀ (x y z : Nat), (y * x) / (y + z) < z ===>
+  ∀ (x y z : Nat), Nat.div (Nat.mul x y) (Nat.add y z) < z
 
 
 
 /-! Test cases to ensure that `Nat.div` is preserved when expected and is not a commutative operator. -/
 -- x / y ===> x / y
-#testOptimize [ "NatDivVar_1" ] ∀ (x y z : Nat), x / y < z ===> ∀ (x y z : Nat), Nat.div x y < z
+#testOptimize [ "NatDivVar_1", proof ]
+  ∀ (x y z : Nat), x / y < z ===>
+  ∀ (x y z : Nat), Nat.div x y < z
 
 -- x / y = x / y ===> True
-#testOptimize [ "NatDivVar_2" ] ∀ (x y : Nat), x / y = x / y ===> True
+#testOptimize [ "NatDivVar_2", proof ]
+  ∀ (x y : Nat), x / y = x / y ===> True
 
 -- x / (y / 1) ===> x / y
-#testOptimize [ "NatDivVar_3" ] ∀ (x y z : Nat), x / (y / 1) < z ===> ∀ (x y z : Nat), Nat.div x y < z
+#testOptimize [ "NatDivVar_3", proof ]
+  ∀ (x y z : Nat), x / (y / 1) < z ===>
+  ∀ (x y z : Nat), Nat.div x y < z
 
 -- (x / 1) / y ===> x / y
-#testOptimize [ "NatDivVar_4" ] ∀ (x y z : Nat), (x / 1) / y < z ===> ∀ (x y z : Nat), Nat.div x y < z
+#testOptimize [ "NatDivVar_4", proof ]
+  ∀ (x y z : Nat), (x / 1) / y < z ===>
+  ∀ (x y z : Nat), Nat.div x y < z
 
 -- (x / 1) / (y / y) = x / (y / y) ===> True
-#testOptimize [ "NatDivVar_5" ] ∀ (x y : Nat), (x / 1) / (y / y) = x / (y / y) ===> True
+#testOptimize [ "NatDivVar_5", proof ] ∀ (x y : Nat), (x / 1) / (y / y) = x / (y / y) ===> True
 
 -- (x / 10) / y = (x / (15 - 5)) / y ===> True
-#testOptimize [ "NatDivVar_6" ] ∀ (x y : Nat), (x / 10) / y = (x / (15 - 5)) / y ===> True
+#testOptimize [ "NatDivVar_6", proof ] ∀ (x y : Nat), (x / 10) / y = (x / (15 - 5)) / y ===> True
 
 -- (x / 10) / y ===> (x / 10) / y
 def natDivVar_7 : Expr :=
@@ -621,7 +657,7 @@ def natDivVar_7 : Expr :=
 
 elab "natDivVar_7" : term => return natDivVar_7
 
-#testOptimize [ "NatDivVar_7" ] ∀ (x y z : Nat), (x / 10) / y < z ===> natDivVar_7
+#testOptimize [ "NatDivVar_7", proof ] ∀ (x y z : Nat), (x / 10) / y < z ===> natDivVar_7
 
 
 /-! Test cases to ensure that constant propagation is properly performed
@@ -633,7 +669,7 @@ variable (y : Nat)
 variable (z : Nat)
 
 -- (((x * y) / y) - x) / z ===> 0
-#testOptimize [ "NatDivReduce_1" ] (norm-result: 1)
+#testOptimize [ "NatDivReduce_1", proof ] (norm-result: 1)
   ∀ (_h : 0 < y), (((x * y) / y) - x) / z < z ===>
   ∀ (_h : 0 < y), 0 < z
 
@@ -641,7 +677,21 @@ variable (z : Nat)
 def natDivReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 3)
 elab "natDivReduce_2" : term => return natDivReduce_2
 
-#testOptimize [ "NatDivReduce_2" ]  (30 + (0 / x)) / ((((((120 * x) / 12) / 10) - x)) + 10) ===> natDivReduce_2
+#testOptimize [ "NatDivReduce_2", proof ]
+  (30 + (0 / x)) / ((((((120 * x) / 12) / 10) - x)) + 10) ===> natDivReduce_2
 
+/-! Test cases for simplification rule `n / n ==> 1 (if 0 < n ∨ 0 ≠ n in hypotheses)`. -/
+
+-- x / x ===> 1 (with 0 < x)
+#testOptimize [ "NatDivSelf_1", proof ] (norm-result: 1)
+  ∀ (x : Nat), 0 < x → x / x = 1 ===> True
+
+-- x / x ===> 1 (with 0 ≠ x)
+#testOptimize [ "NatDivSelf_2", proof ] (norm-result: 1)
+  ∀ (x : Nat), 0 ≠ x → x / x = 1 ===> True
+
+-- (x + 0) / (x + 0) ===> 1 (operands reduced to same fvar)
+#testOptimize [ "NatDivSelf_3", proof ] (norm-result: 1)
+  ∀ (x : Nat), 0 < x → (x + 0) / (x + 0) = 1 ===> True
 
 end Test.OptimizeNatDiv

--- a/Tests/Optimize/OptimizeNat/OptimizeNatMod.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatMod.lean
@@ -13,47 +13,47 @@ namespace Test.OptimizeNatMod
 def natModCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 0)
 elab "natModCst_1" : term => return natModCst_1
 
-#testOptimize [ "NatModCst_1" ] (0 : Nat) % 432 ===> natModCst_1
+#testOptimize [ "NatModCst_1", proof ] (0 : Nat) % 432 ===> natModCst_1
 
 -- 432  % 0 ===> 432
 -- NOTE: divison by zero not triggered
 def natModCst_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 432)
 elab "natModCst_2" : term => return natModCst_2
 
-#testOptimize [ "NatModCst_2" ] (432 : Nat) % 0 ===> natModCst_2
+#testOptimize [ "NatModCst_2", proof ] (432 : Nat) % 0 ===> natModCst_2
 
 -- 121 % 1 ==> 0
-#testOptimize [ "NatModCst_3" ] (121 : Nat) % 1 ===> natModCst_1
+#testOptimize [ "NatModCst_3", proof ] (121 : Nat) % 1 ===> natModCst_1
 
 -- 7 % 3 ===> 1
 def natModCst_4 : Expr := Lean.Expr.lit (Lean.Literal.natVal 1)
 elab "natModCst_4" : term => return natModCst_4
 
-#testOptimize [ "NatModCst_4" ] (7 : Nat) % 3 ===> natModCst_4
+#testOptimize [ "NatModCst_4", proof ] (7 : Nat) % 3 ===> natModCst_4
 
 -- 18 % 3 ===> 0
-#testOptimize [ "NatModCst_5" ] (18 : Nat) % 3 ===> natModCst_1
+#testOptimize [ "NatModCst_5", proof ] (18 : Nat) % 3 ===> natModCst_1
 
 
 /-! Test cases for simplification rule `n % 0 ==> n`. -/
 
 -- x % 0 ===> x
-#testOptimize [ "NatModZero_1" ] ∀ (x y : Nat), x % 0 < y ===> ∀ (x y : Nat), x < y
+#testOptimize [ "NatModZero_1", proof ] ∀ (x y : Nat), x % 0 < y ===> ∀ (x y : Nat), x < y
 
 -- x % 0 = x ===> True
-#testOptimize [ "NatModZero_2" ] ∀ (x : Nat), x % 0 = x ===> True
+#testOptimize [ "NatModZero_2", proof ] ∀ (x : Nat), x % 0 = x ===> True
 
 -- x % Nat.zero ===> x
-#testOptimize [ "NatModZero_3" ] ∀ (x y : Nat), x % Nat.zero < y ===> ∀ (x y : Nat), x < y
+#testOptimize [ "NatModZero_3", proof ] ∀ (x y : Nat), x % Nat.zero < y ===> ∀ (x y : Nat), x < y
 
 -- x % Nat.zero = x ===> True
-#testOptimize [ "NatModZero_4" ] ∀ (x : Nat), x % Nat.zero = x ===> True
+#testOptimize [ "NatModZero_4", proof ] ∀ (x : Nat), x % Nat.zero = x ===> True
 
 -- ∀ (x y : Nat), (x % y - y) = x ===> True
-#testOptimize [ "NatModZero_5" ] ∀ (x y : Nat), x % (y - y) = x ===> True
+#testOptimize [ "NatModZero_5", proof ] ∀ (x y : Nat), x % (y - y) = x ===> True
 
 -- ∀ (x y : Nat), (x % ((1 * y) - y)) = x ===> True
-#testOptimize [ "NatModZero_6" ] ∀ (x y : Nat), x % ((1 * y) - y) = x ===> True
+#testOptimize [ "NatModZero_6", proof ] ∀ (x y : Nat), x % ((1 * y) - y) = x ===> True
 
 
 /-! Test cases for simplification rule `n % 1 ==> 0`. -/
@@ -73,16 +73,18 @@ def natModOne_1 : Expr :=
 
 elab "natModOne_1" : term => return natModOne_1
 
-#testOptimize [ "NatModOne_1" ] ∀ (x y : Nat), x % 1 < y ===> natModOne_1
+#testOptimize [ "NatModOne_1", proof ] ∀ (x y : Nat), x % 1 < y ===> natModOne_1
 
 -- x % 1 = 0 ===> True
-#testOptimize [ "NatModOne_2" ] ∀ (x : Nat), x % 1 = 0 ===> True
+#testOptimize [ "NatModOne_2", proof ] ∀ (x : Nat), x % 1 = 0 ===> True
 
 -- ∀ (x y : Nat), (x % ((((Nat.succ y) - 1) - y) + 1) = 0 ===> True
-#testOptimize [ "NatModOne_3" ] ∀ (x y : Nat), x % ((((Nat.succ y) - 1) - y) + 1) = 0 ===> True
+#testOptimize [ "NatModOne_3", proof ]
+  ∀ (x y : Nat), x % ((((Nat.succ y) - 1) - y) + 1) = 0 ===> True
 
 -- ∀ (x y : Nat), (x % (((100 - y) -230) + 1) = 0 ===> True
-#testOptimize [ "NatModOne_4" ] ∀ (x y : Nat), x % (((100 - y) -230) + 1) = 0 ===> True
+#testOptimize [ "NatModOne_4", proof ]
+  ∀ (x y : Nat), x % (((100 - y) -230) + 1) = 0 ===> True
 
 
 /-! Test cases to ensure that the following simplification rules are not wrongly applied:
@@ -110,37 +112,39 @@ def natModCstUnchanged_1 : Expr :=
 
 elab "natModCstUnchanged_1" : term => return natModCstUnchanged_1
 
-#testOptimize [ "NatModCstUnchanged_1" ] ∀ (x y : Nat), x % 10 < y ===> natModCstUnchanged_1
+#testOptimize [ "NatModCstUnchanged_1", proof ] ∀ (x y : Nat), x % 10 < y ===> natModCstUnchanged_1
 
 -- x % (100 - 90) ===> x % 10
-#testOptimize [ "NatModCstUnchanged_2" ] ∀ (x y : Nat), x % (100 - 90) < y ===> natModCstUnchanged_1
+#testOptimize [ "NatModCstUnchanged_2", proof ]
+  ∀ (x y : Nat), x % (100 - 90) < y ===> natModCstUnchanged_1
 
 
 -- ∀ (x y z : Nat), (x % y - x) < z ==> ∀ (x y z : Nat), Nat.div x (Nat.sub y x) < z
-#testOptimize [ "NatModCstUnchanged_3" ] ∀ (x y z : Nat), x % (y - x) < z ===>
-                                         ∀ (x y z : Nat), Nat.mod x (Nat.sub y x) < z
+#testOptimize [ "NatModCstUnchanged_3", proof ]
+  ∀ (x y z : Nat), x % (y - x) < z ===>
+  ∀ (x y z : Nat), Nat.mod x (Nat.sub y x) < z
 
 
 /-! Test cases for simplification rule `0 % n ==> 0`. -/
 
 -- 0 % x ===> 0
-#testOptimize [ "NatZeroMod_1" ] ∀ (x y : Nat), 0 % x < y ===> natModOne_1
+#testOptimize [ "NatZeroMod_1", proof ] ∀ (x y : Nat), 0 % x < y ===> natModOne_1
 
 -- 0 % x = 0 ===> True
-#testOptimize [ "NatZeroMod_2" ] ∀ (x : Nat), 0 % x = 0 ===> True
+#testOptimize [ "NatZeroMod_2", proof ] ∀ (x : Nat), 0 % x = 0 ===> True
 
 -- Nat.zero % x ===> 0
-#testOptimize [ "NatZeroMod_3" ] ∀ (x y : Nat), Nat.zero % x < y ===> natModOne_1
+#testOptimize [ "NatZeroMod_3", proof ] ∀ (x y : Nat), Nat.zero % x < y ===> natModOne_1
 
 -- Nat.zero % x = 0 ===> True
-#testOptimize [ "NatZeroMod_4" ] ∀ (x : Nat), Nat.zero % x = 0 ===> True
+#testOptimize [ "NatZeroMod_4", proof ] ∀ (x : Nat), Nat.zero % x = 0 ===> True
 
 
 -- ∀ (x y : Nat), (y - y) % x = 0 ===> True
-#testOptimize [ "NatZeroMod_5" ] ∀ (x y : Nat), (y - y) % x  = 0 ===> True
+#testOptimize [ "NatZeroMod_5", proof ] ∀ (x y : Nat), (y - y) % x  = 0 ===> True
 
 -- ∀ (x y : Nat), ((100 - y) - 120) % x = 0 ===> True
-#testOptimize [ "NatZeroMod_6" ] ∀ (x y : Nat), ((100 - y) - 120) % x = 0 ===> True
+#testOptimize [ "NatZeroMod_6", proof ] ∀ (x y : Nat), ((100 - y) - 120) % x = 0 ===> True
 
 
 
@@ -165,15 +169,17 @@ def natCstModUnchanged_1 : Expr :=
   (Lean.BinderInfo.default)
 elab "natCstModUnchanged_1" : term => return natCstModUnchanged_1
 
-#testOptimize [ "NatCstModUnchanged_1" ] ∀ (x y : Nat), 10 % x < y ===> natCstModUnchanged_1
+#testOptimize [ "NatCstModUnchanged_1", proof ] ∀ (x y : Nat), 10 % x < y ===> natCstModUnchanged_1
 
 -- (100 - 90) % x ===> 10 % x
-#testOptimize [ "NatCstModUnchanged_2" ] ∀ (x y : Nat), (100 - 90) % x < y ===> natCstModUnchanged_1
+#testOptimize [ "NatCstModUnchanged_2", proof ]
+  ∀ (x y : Nat), (100 - 90) % x < y ===> natCstModUnchanged_1
 
 
 -- ∀ (x y z : Nat), (x % y - x) < z ==> ∀ (x y z : Nat), Nat.mod x (Nat.sub y x) < z
-#testOptimize [ "NatCstModUnchanged_3" ] ∀ (x y z : Nat), (y - x) % x < z ===>
-                                         ∀ (x y z : Nat), Nat.mod (Nat.sub y x) x < z
+#testOptimize [ "NatCstModUnchanged_3", proof ]
+  ∀ (x y z : Nat), (y - x) % x < z ===>
+  ∀ (x y z : Nat), Nat.mod (Nat.sub y x) x < z
 
 
 
@@ -196,16 +202,19 @@ def natMulModCstProp_1 : Expr :=
     (Lean.BinderInfo.default))
 elab "natMulModCstProp_1" : term => return natMulModCstProp_1
 
-#testOptimize [ "NatMulModCstProp_1" ] ∀ (x y : Nat), (124 * x) % 4 < y ===> natMulModCstProp_1
+#testOptimize [ "NatMulModCstProp_1", proof ]
+  ∀ (x y : Nat), (124 * x) % 4 < y ===> natMulModCstProp_1
 
 -- (2197 * x) % 13 ===> 0
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatMulModCstProp_2" ] ∀ (x y : Nat), (2197 * x) % 13 < y ===> natMulModCstProp_1
+#testOptimize [ "NatMulModCstProp_2", proof ]
+  ∀ (x y : Nat), (2197 * x) % 13 < y ===> natMulModCstProp_1
 
 
 -- ((169 - (200 - (x + 259))) * x) % 13 ===> 0
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatMulModCstProp_3" ] ∀ (x y : Nat), ((169 - (200 - (x + 259))) * x) % 13 < y ===> natMulModCstProp_1
+#testOptimize [ "NatMulModCstProp_3", proof ]
+  ∀ (x y : Nat), ((169 - (200 - (x + 259))) * x) % 13 < y ===> natMulModCstProp_1
 
 
 
@@ -236,7 +245,8 @@ def natMulModCstUnchanged_1 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulModCstUnchanged_1" : term => return natMulModCstUnchanged_1
 
-#testOptimize [ "NatMulModCstUnchanged_1" ] ∀ (x y : Nat), (124 * x) % 9 < y ===> natMulModCstUnchanged_1
+#testOptimize [ "NatMulModCstUnchanged_1", proof ]
+  ∀ (x y : Nat), (124 * x) % 9 < y ===> natMulModCstUnchanged_1
 
 -- (2197 * x) % 14 ===> (2197 * x) % 14
 def natMulModCstUnchanged_2 : Expr :=
@@ -261,7 +271,8 @@ def natMulModCstUnchanged_2 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulModCstUnchanged_2" : term => return natMulModCstUnchanged_2
 
-#testOptimize [ "NatMulModCstUnchanged_2" ] ∀ (x y : Nat), (2197 * x) % 14 < y ===> natMulModCstUnchanged_2
+#testOptimize [ "NatMulModCstUnchanged_2", proof ]
+  ∀ (x y : Nat), (2197 * x) % 14 < y ===> natMulModCstUnchanged_2
 
 
 -- ((169 - (200 - (x + 259))) * x) % 14 ===> (169 * x)% 14
@@ -287,7 +298,8 @@ def natMulModCstUnchanged_3 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulModCstUnchanged_3" : term => return natMulModCstUnchanged_3
 
-#testOptimize [ "NatMulModCstUnchanged_3" ] ∀ (x y : Nat), ((169 - (200 - (x + 259))) * x) % 14 < y ===> natMulModCstUnchanged_3
+#testOptimize [ "NatMulModCstUnchanged_3", proof ]
+  ∀ (x y : Nat), ((169 - (200 - (x + 259))) * x) % 14 < y ===> natMulModCstUnchanged_3
 
 
 /-! Test cases for simplification rule `n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)` -/
@@ -307,7 +319,7 @@ def natModIdentity_1 : Expr :=
     (Lean.BinderInfo.default))
 elab "natModIdentity_1" : term => return natModIdentity_1
 
-#testOptimize [ "NatModIdentity_1" ] ∀ (x y : Nat), x % x < y ===> natModIdentity_1
+#testOptimize [ "NatModIdentity_1", proof ] ∀ (x y : Nat), x % x < y ===> natModIdentity_1
 
 
 -- (m * n) % (n * m) ===> 0
@@ -325,16 +337,19 @@ def natModIdentity_2 : Expr :=
   (Lean.BinderInfo.default))
 elab "natModIdentity_2" : term => return natModIdentity_2
 
-#testOptimize [ "NatModIdentity_2" ] ∀ (m n y : Nat), (m * n) % (n * m) < y ===> natModIdentity_2
+#testOptimize [ "NatModIdentity_2", proof ]
+  ∀ (m n y : Nat), (m * n) % (n * m) < y ===> natModIdentity_2
 
 -- (x + (100 - (y + 250))) % x ===> 0
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatModIdentity_3" ] ∀ (x y : Nat), (x + (100 - (y + 250))) % x < y ===> natModIdentity_1
+#testOptimize [ "NatModIdentity_3", proof ]
+  ∀ (x y : Nat), (x + (100 - (y + 250))) % x < y ===> natModIdentity_1
 
 
 -- x % (x + ((298 - (x + 350)) % y)) ===> 0
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatModIdentity_4" ] ∀ (x y : Nat), x % (x + ((298 - (x + 350)) % y)) < y ===> natModIdentity_1
+#testOptimize [ "NatModIdentity_4", proof ]
+  ∀ (x y : Nat), x % (x + ((298 - (x + 350)) % y)) < y ===> natModIdentity_1
 
 
 
@@ -342,20 +357,24 @@ elab "natModIdentity_2" : term => return natModIdentity_2
     is not wrongly applied.
 -/
 -- x % y ===> Nat.mod x y
-#testOptimize [ "NatModIdentityUnchanged_1" ] ∀ (x y z : Nat), x % y < z ===>
-                                              ∀ (x y z : Nat), Nat.mod x y < z
+#testOptimize [ "NatModIdentityUnchanged_1", proof ]
+  ∀ (x y z : Nat), x % y < z ===>
+  ∀ (x y z : Nat), Nat.mod x y < z
 
 -- (m * n) % (n * x) ===> Nat.mod (Nat.mul m n) (Nat.mul n x)
-#testOptimize [ "NatModIdentityUnchanged_2" ] ∀ (m n x y : Nat), (m * n) % (n * x) < y ===>
-                                              ∀ (m n x y : Nat), Nat.mod (Nat.mul m n) (Nat.mul n x) < y
+#testOptimize [ "NatModIdentityUnchanged_2", proof ]
+  ∀ (m n x y : Nat), (m * n) % (n * x) < y ===>
+  ∀ (m n x y : Nat), Nat.mod (Nat.mul m n) (Nat.mul n x) < y
 
 -- (y + (100 - (y + 250))) % x ===> Nat.mod y x
-#testOptimize [ "NatModIdentityUnchanged_3" ] ∀ (x y z : Nat), (y + (100 - (y + 250))) % x < z ===>
-                                              ∀ (x y z : Nat), Nat.mod y x < z
+#testOptimize [ "NatModIdentityUnchanged_3", proof ]
+  ∀ (x y z : Nat), (y + (100 - (y + 250))) % x < z ===>
+  ∀ (x y z : Nat), Nat.mod y x < z
 
 -- x % (y + ((298 - (x + 350)) % x)) ===> Nat.mod x y
-#testOptimize [ "NatModIdentityUnchanged_4" ] ∀ (x y z : Nat), x % (y + ((298 - (x + 350)) % x)) < z ===>
-                                              ∀ (x y z : Nat), Nat.mod x y < z
+#testOptimize [ "NatModIdentityUnchanged_4", proof ]
+  ∀ (x y z : Nat), x % (y + ((298 - (x + 350)) % x)) < z ===>
+  ∀ (x y z : Nat), Nat.mod x y < z
 
 
 /-! Test cases for the following simplification rules:
@@ -378,26 +397,27 @@ def natMulModReduce_1 : Expr :=
    (Lean.BinderInfo.default))
 elab "natMulModReduce_1" : term => return natMulModReduce_1
 
-#testOptimize [ "NatMulModReduce_1" ] ∀ (x y z : Nat), (x * y) % y < z ===> natMulModReduce_1
+#testOptimize [ "NatMulModReduce_1", proof ] ∀ (x y z : Nat), (x * y) % y < z ===> natMulModReduce_1
 
 -- (x * y) % y = 0 ===> True
-#testOptimize [ "NatMulModReduce_2" ] ∀ (x y : Nat), (x * y) % y = 0 ===> True
+#testOptimize [ "NatMulModReduce_2", proof ] ∀ (x y : Nat), (x * y) % y = 0 ===> True
 
 -- (y * x) % y ===> 0
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatMulModReduce_3" ] ∀ (y x z : Nat), (y * x) % y < z ===> natMulModReduce_1
+#testOptimize [ "NatMulModReduce_3", proof ] ∀ (y x z : Nat), (y * x) % y < z ===> natMulModReduce_1
 
 -- (y * x) % y = 0 ===> True
-#testOptimize [ "NatMulModReduce_4" ] ∀ (y x : Nat), (y * x) % y = 0 ===> True
+#testOptimize [ "NatMulModReduce_4", proof ] ∀ (y x : Nat), (y * x) % y = 0 ===> True
 
 -- (y * x) % (y + 0) = 0 ===> True
-#testOptimize [ "NatMulModReduce_5" ] ∀ (y x : Nat), (y * x) % (y + 0) = 0 ===> True
+#testOptimize [ "NatMulModReduce_5", proof ] ∀ (y x : Nat), (y * x) % (y + 0) = 0 ===> True
 
 -- (y * x) % (y + (z - z)) = 0 ===> True
-#testOptimize [ "NatMulModReduce_6" ] ∀ (y x z : Nat), (y * x) % (y + (z - z)) = 0 ===> True
+#testOptimize [ "NatMulModReduce_6", proof ] ∀ (y x z : Nat), (y * x) % (y + (z - z)) = 0 ===> True
 
 -- ((y + 0) * x) % (y + (z - z)) = 0 ===> True
-#testOptimize [ "NatMulModReduce_7" ] ∀ (y x z : Nat), ((y + 0) * x) % (y + (z - z)) = 0 ===> True
+#testOptimize [ "NatMulModReduce_7", proof ]
+  ∀ (y x z : Nat), ((y + 0) * x) % (y + (z - z)) = 0 ===> True
 
 
 
@@ -407,37 +427,44 @@ elab "natMulModReduce_1" : term => return natMulModReduce_1
 -/
 
 -- (x * y) % z ===> (x * y) % z
-#testOptimize [ "NatMulModReduceUnchanged_1" ] ∀ (x y z : Nat), (x * y) % z < z ===>
-                                               ∀ (x y z : Nat), Nat.mod (Nat.mul x y) z < z
+#testOptimize [ "NatMulModReduceUnchanged_1", proof ]
+  ∀ (x y z : Nat), (x * y) % z < z ===>
+  ∀ (x y z : Nat), Nat.mod (Nat.mul x y) z < z
 
 -- (y * x) % z ===> (y * x) % z
-#testOptimize [ "NatMulModReduceUnchanged_2" ] ∀ (y x z : Nat), (y * x) % z < z ===>
-                                               ∀ (y x z : Nat), Nat.mod (Nat.mul y x) z < z
+#testOptimize [ "NatMulModReduceUnchanged_2", proof ]
+  ∀ (y x z : Nat), (y * x) % z < z ===>
+  ∀ (y x z : Nat), Nat.mod (Nat.mul y x) z < z
 
 -- (y * x) % (y + z) ===> Nat.div (Nat.mul x y) (Nat.add y z)
-#testOptimize [ "NatMulModReduceUnchanged_3" ] ∀ (x y z : Nat), (y * x) % (y + z) < z ===>
-                                               ∀ (x y z : Nat), Nat.mod (Nat.mul x y) (Nat.add y z) < z
+#testOptimize [ "NatMulModReduceUnchanged_3", proof ]
+  ∀ (x y z : Nat), (y * x) % (y + z) < z ===>
+  ∀ (x y z : Nat), Nat.mod (Nat.mul x y) (Nat.add y z) < z
 
 
 
 /-! Test cases to ensure that `Nat.div` is preserved when expected and is not a commutative operator. -/
 -- x % y ===> x % y
-#testOptimize [ "NatModVar_1" ] ∀ (x y z : Nat), x % y < z ===> ∀ (x y z : Nat), Nat.mod x y < z
+#testOptimize [ "NatModVar_1", proof ]
+  ∀ (x y z : Nat), x % y < z ===> ∀ (x y z : Nat), Nat.mod x y < z
 
 -- x % y = x % y ===> True
-#testOptimize [ "NatModVar_2" ] ∀ (x y : Nat), x % y = x % y ===> True
+#testOptimize [ "NatModVar_2", proof ]
+  ∀ (x y : Nat), x % y = x % y ===> True
 
 -- x % (y % 0) ===> x % y
-#testOptimize [ "NatModVar_3" ] ∀ (x y z : Nat), x % (y % 0) < z ===> ∀ (x y z : Nat), Nat.mod x y < z
+#testOptimize [ "NatModVar_3", proof ]
+  ∀ (x y z : Nat), x % (y % 0) < z ===> ∀ (x y z : Nat), Nat.mod x y < z
 
 -- (x % 0) % y ===> x % y
-#testOptimize [ "NatModVar_4" ] ∀ (x y z : Nat), (x % 0) % y < z ===> ∀ (x y z : Nat), Nat.mod x y < z
+#testOptimize [ "NatModVar_4", proof ]
+  ∀ (x y z : Nat), (x % 0) % y < z ===> ∀ (x y z : Nat), Nat.mod x y < z
 
 -- (x % 0) % (y % y) = x % (y % y) ===> True
-#testOptimize [ "NatModVar_5" ] ∀ (x y : Nat), (x % 0) % (y % y) = x % (y % y) ===> True
+#testOptimize [ "NatModVar_5", proof ] ∀ (x y : Nat), (x % 0) % (y % y) = x % (y % y) ===> True
 
 -- (x % 10) % y = (x % (15 - 5)) % y ===> True
-#testOptimize [ "NatModVar_6" ] ∀ (x y : Nat), (x % 10) % y = (x % (15 - 5)) % y ===> True
+#testOptimize [ "NatModVar_6", proof ] ∀ (x y : Nat), (x % 10) % y = (x % (15 - 5)) % y ===> True
 
 -- (x % 10) % y ===> (x % 10) % y
 def natModVar_7 : Expr :=
@@ -466,7 +493,7 @@ def natModVar_7 : Expr :=
 
 elab "natModVar_7" : term => return natModVar_7
 
-#testOptimize [ "NatModVar_7" ] ∀ (x y z : Nat), (x % 10) % y < z ===> natModVar_7
+#testOptimize [ "NatModVar_7", proof ] ∀ (x y z : Nat), (x % 10) % y < z ===> natModVar_7
 
 
 /-! Test cases to ensure that constant propagation is properly performed
@@ -480,13 +507,14 @@ variable (z : Nat)
 def natModReduce_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 0)
 elab "natModReduce_1" : term => return natModReduce_1
 
-#testOptimize [ "NatModReduce_1" ] (((x * y) % y) - x) % z ===>  natModReduce_1
+#testOptimize [ "NatModReduce_1", proof ] (((x * y) % y) - x) % z ===>  natModReduce_1
 
 
 -- (30 + (x % 1)) % ((((120 * x) % 12) % 10) - x) ===> 30
 def natModReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 30)
 elab "natModReduce_2" : term => return natModReduce_2
 
-#testOptimize [ "NatModReduce_2" ]  (30 + (x % 1)) % ((((120 * x) % 12) % 10) - x) ===> natModReduce_2
+#testOptimize [ "NatModReduce_2", proof ]
+  (30 + (x % 1)) % ((((120 * x) % 12) % 10) - x) ===> natModReduce_2
 
 end Test.OptimizeNatMod

--- a/Tests/Optimize/OptimizeNat/OptimizeNatMul.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatMul.lean
@@ -13,38 +13,38 @@ namespace Test.OptimizeNatMul
 def natMulCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 0)
 elab "natMulCst_1" : term => return natMulCst_1
 
-#testOptimize [ "NatMulCst_1" ] (0 : Nat) * 432 ===> natMulCst_1
+#testOptimize [ "NatMulCst_1", proof ] (0 : Nat) * 432 ===> natMulCst_1
 
 -- 432 * 0 ===> 0
-#testOptimize [ "NatMulCst_2" ] 432 * (0 : Nat) ===> natMulCst_1
+#testOptimize [ "NatMulCst_2", proof ] 432 * (0 : Nat) ===> natMulCst_1
 
 def natMulCst_3 : Expr := Lean.Expr.lit (Lean.Literal.natVal 432)
 elab "natMulCst_3" : term => return natMulCst_3
 
 -- 432 * 1 ===> 32
-#testOptimize [ "NatMulCst_3" ] 432 * (1 : Nat) ===> natMulCst_3
+#testOptimize [ "NatMulCst_3", proof ] 432 * (1 : Nat) ===> natMulCst_3
 
 -- 1 * 432 ===> 32
-#testOptimize [ "NatMulCst_4" ] 1 * (432 : Nat) ===> natMulCst_3
+#testOptimize [ "NatMulCst_4", proof ] 1 * (432 : Nat) ===> natMulCst_3
 
 -- 34 * 432 ===> 14688
 def natMulCst_5 : Expr := Lean.Expr.lit (Lean.Literal.natVal 14688)
 elab "natMulCst_5" : term => return natMulCst_5
 
-#testOptimize [ "NatMulCst_5" ] (34 : Nat) * 432 ===> natMulCst_5
+#testOptimize [ "NatMulCst_5", proof ] (34 : Nat) * 432 ===> natMulCst_5
 
 
 /-! Test cases for simplification rule `0 * n ==> 0`. -/
 
 variable (x : Nat)
 -- x * 0 ===> 0
-#testOptimize [ "NatMulZero_1" ] x * 0 ===> natMulCst_1
+#testOptimize [ "NatMulZero_1", proof ] x * 0 ===> natMulCst_1
 
 -- 0 * x ===> 0
-#testOptimize [ "NatMulZero_2" ] 0 * x ===> natMulCst_1
+#testOptimize [ "NatMulZero_2", proof ] 0 * x ===> natMulCst_1
 
 -- 0 * x = 0 ===> True
-#testOptimize [ "NatMulZero_3" ] ∀ (x : Nat), 0 * x = 0 ===> True
+#testOptimize [ "NatMulZero_3", proof ] ∀ (x : Nat), 0 * x = 0 ===> True
 
 -- x * Nat.zero ===> 0
 #testOptimize [ "NatMulZero_4" ] ∀ (x y : Nat), x * Nat.zero ≤ y ===> True
@@ -53,7 +53,7 @@ variable (x : Nat)
 #testOptimize [ "NatMulZero_5" ] ∀ (x y : Nat), Nat.zero * x ≤ y ===> True
 
 -- Nat.zero * x = 0 ===> True
-#testOptimize [ "NatMulZero_6" ] ∀ (x : Nat), Nat.zero * x = 0 ===> True
+#testOptimize [ "NatMulZero_6", proof ] ∀ (x : Nat), Nat.zero * x = 0 ===> True
 
 -- (10 - 10) * x ===> 0
 #testOptimize [ "NatMulZero_7" ] ∀ (x y : Nat), (10 - 10) * x ≤ y ===> True
@@ -62,22 +62,22 @@ variable (x : Nat)
 #testOptimize [ "NatMulZero_8" ] ∀ (x y : Nat), x * (10 - 123) ≤ y ===> True
 
 -- x * (y - y) = 0 ===> True
-#testOptimize [ "NatMulZero_9" ] ∀ (x y : Nat), x * (y - y) = 0 ===> True
+#testOptimize [ "NatMulZero_9", proof ] ∀ (x y : Nat), x * (y - y) = 0 ===> True
 
 
 /-! Test cases for simplification rule `1 * n ==> n`. -/
 
 -- 1 * n ===> n
-#testOptimize [ "NatMulOne_1" ] ∀ (x y : Nat), x * 1 ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatMulOne_1", proof ] ∀ (x y : Nat), x * 1 ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- n * 1 ===> n
-#testOptimize [ "NatMulOne_2" ] ∀ (x y : Nat), 1 * x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatMulOne_2", proof ] ∀ (x y : Nat), 1 * x ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- 1 * x = x ===> True
-#testOptimize [ "NatMulOne_3" ] ∀ (x : Nat), 1 * x = x ===> True
+#testOptimize [ "NatMulOne_3", proof ] ∀ (x : Nat), 1 * x = x ===> True
 
 -- (10 - 9) * x ===> x
-#testOptimize [ "NatMulOne_4" ] ∀ (x y : Nat), (10 - 9) * x < y ===> ∀ (x y : Nat), x < y
+#testOptimize [ "NatMulOne_4", proof ] ∀ (x y : Nat), (10 - 9) * x < y ===> ∀ (x y : Nat), x < y
 
 -- ((((Nat.succ y) - 1) - y) + 1) * x ===> x
 #testOptimize [ "NatMulOne_5" ] ∀ (x y z : Nat), ((((Nat.succ y) - 1) - y) + 1) * x < z ===>
@@ -112,30 +112,30 @@ def natMulCstUnchanged_1 : Expr :=
   (Lean.BinderInfo.default)
 elab "natMulCstUnchanged_1" : term => return natMulCstUnchanged_1
 
-#testOptimize [ "NatMulCstUnchanged_1" ] ∀ (x y : Nat), x * 10 ≤ y ===> natMulCstUnchanged_1
+#testOptimize [ "NatMulCstUnchanged_1", proof ] ∀ (x y : Nat), x * 10 ≤ y ===> natMulCstUnchanged_1
 
 -- (100 - 90) * x ===> 10 * x
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatMulCstUnchanged_2" ] ∀ (x y : Nat), (100 - 90) * x ≤ y ===> natMulCstUnchanged_1
+#testOptimize [ "NatMulCstUnchanged_2", proof ] ∀ (x y : Nat), (100 - 90) * x ≤ y ===> natMulCstUnchanged_1
 
 -- x * (y - z) ===> Nat.mul x (Nat.sub y z)
-#testOptimize [ "NatMulCstUnchanged_3" ] ∀ (x y z m : Nat), x * (y - z) < m ===>
+#testOptimize [ "NatMulCstUnchanged_3", proof ] ∀ (x y z m : Nat), x * (y - z) < m ===>
                                          ∀ (x y z m : Nat), Nat.mul x (Nat.sub y z) < m
 
 
 /-! Test cases for simplification rule `N1 * (N2 * n) ===> (N1 "*" N2) * n`. -/
 
 -- 10 * (20 * x) = 200 * x ===> True
-#testOptimize [ "NatMulCstProp_1" ] ∀ (x : Nat), 10 * (20 * x) = 200 * x ===> True
+#testOptimize [ "NatMulCstProp_1", proof ] ∀ (x : Nat), 10 * (20 * x) = 200 * x ===> True
 
 -- 10 * (x * 20) = x * 200 ===> True
-#testOptimize [ "NatMulCstProp_2" ] ∀ (x : Nat), 10 * (x * 20) = x * 200 ===> True
+#testOptimize [ "NatMulCstProp_2", proof ] ∀ (x : Nat), 10 * (x * 20) = x * 200 ===> True
 
 -- (x * 20) * 10 = 30 * x ===> True
-#testOptimize [ "NatMulCstProp_3" ] ∀ (x : Nat), (x * 20) * 10 = 200 * x ===> True
+#testOptimize [ "NatMulCstProp_3", proof ] ∀ (x : Nat), (x * 20) * 10 = 200 * x ===> True
 
 -- (20 * x) * 10 = x * 30 ===> True
-#testOptimize [ "NatMulCstProp_4" ] ∀ (x : Nat), (20 * x) * 10 = x * 200 ===> True
+#testOptimize [ "NatMulCstProp_4", proof ] ∀ (x : Nat), (20 * x) * 10 = x * 200 ===> True
 
 -- 10 * (20 * x) ===> (200 * x)
 def natAddCstProp_5 : Expr :=
@@ -157,28 +157,28 @@ def natAddCstProp_5 : Expr :=
 
 elab "natAddCstProp_5" : term => return natAddCstProp_5
 
-#testOptimize [ "NatMulCstProp_5" ] ∀ (x y : Nat), 10 * (20 * x) < y ===> natAddCstProp_5
+#testOptimize [ "NatMulCstProp_5", proof ] ∀ (x y : Nat), 10 * (20 * x) < y ===> natAddCstProp_5
 
 -- 10 * (2 * (40 * x)) = 800 * x ===> True
-#testOptimize [ "NatMulCstProp_6" ] ∀ (x : Nat), 10 * (2 * (40 * x)) = 800 * x ===> True
+#testOptimize [ "NatMulCstProp_6", proof ] ∀ (x : Nat), 10 * (2 * (40 * x)) = 800 * x ===> True
 
 -- 10 * (2 * (x * 40)) = 800 * x ===> True
-#testOptimize [ "NatMulCstProp_7" ] ∀ (x : Nat), 10 * (2 * (x * 40)) = 800 * x ===> True
+#testOptimize [ "NatMulCstProp_7", proof ] ∀ (x : Nat), 10 * (2 * (x * 40)) = 800 * x ===> True
 
 -- 10 * (20 * (x - 10)) = 200 * (x - 10) ===> True
-#testOptimize [ "NatMulCstProp_8" ] ∀ (x : Nat), 10 * (20 * (x - 10)) = 200 * (x - 10)===> True
+#testOptimize [ "NatMulCstProp_8", proof ] ∀ (x : Nat), 10 * (20 * (x - 10)) = 200 * (x - 10)===> True
 
 -- 10 * (20 * (10 - x)) = 200 * (10 - x) ===> True
-#testOptimize [ "NatMulCstProp_9" ] ∀ (x : Nat), 10 * (20 * (10 - x)) = 200 * (10 - x) ===> True
+#testOptimize [ "NatMulCstProp_9", proof ] ∀ (x : Nat), 10 * (20 * (10 - x)) = 200 * (10 - x) ===> True
 
 -- 10 * (2 * (5 * (x * 25))) = 2500 * x ===> True
-#testOptimize [ "NatMulCstProp_10" ] ∀ (x : Nat), 10 * (2 * (5 * (x * 25))) = 2500 * x ===> True
+#testOptimize [ "NatMulCstProp_10", proof ] ∀ (x : Nat), 10 * (2 * (5 * (x * 25))) = 2500 * x ===> True
 
 -- 10 * (20 * ((x - 3) - 7)) = 200 * (x - 10) ===> True
-#testOptimize [ "NatMulCstProp_11" ] ∀ (x : Nat), 10 * (20 * ((x - 3) - 7)) = 200 * (x - 10) ===> True
+#testOptimize [ "NatMulCstProp_11", proof ] ∀ (x : Nat), 10 * (20 * ((x - 3) - 7)) = 200 * (x - 10) ===> True
 
 -- 10 * (20 * (100 - (x + 190))) = 0 ===> True
-#testOptimize [ "NatMulCstProp_12" ] ∀ (x : Nat), 10 * (20 * (100 - (x + 190))) = 0 ===> True
+#testOptimize [ "NatMulCstProp_12", proof ] ∀ (x : Nat), 10 * (20 * (100 - (x + 190))) = 0 ===> True
 
 
 /-! Test cases to ensure that simplification rule `N1 * (N2 * n) ===> (N1 "*" N2) * n` is not
@@ -209,7 +209,7 @@ def natMulCstPropUnchanged_1 : Expr :=
 
 elab "natMulCstPropUnchanged_1" : term => return natMulCstPropUnchanged_1
 
-#testOptimize [ "NatMulCstPropUnchanged_1" ] ∀ (x y : Nat), 40 * (x * y) < y ===> natMulCstPropUnchanged_1
+#testOptimize [ "NatMulCstPropUnchanged_1", proof ] ∀ (x y : Nat), 40 * (x * y) < y ===> natMulCstPropUnchanged_1
 
 
 -- 40 * (x - y) ===> 40 * (x - y)
@@ -236,7 +236,7 @@ def natMulCstPropUnchanged_2 : Expr :=
 
 elab "natMulCstPropUnchanged_2" : term => return natMulCstPropUnchanged_2
 
-#testOptimize [ "NatMulCstPropUnchanged_2" ] ∀ (x y : Nat), 40 * (x - y) < y ===> natMulCstPropUnchanged_2
+#testOptimize [ "NatMulCstPropUnchanged_2", proof ] ∀ (x y : Nat), 40 * (x - y) < y ===> natMulCstPropUnchanged_2
 
 
 -- 40 * (x + y) ===> 40 * (x + y)
@@ -263,23 +263,23 @@ def natMulCstPropUnchanged_3 : Expr :=
 
 elab "natMulCstPropUnchanged_3" : term => return natMulCstPropUnchanged_3
 
-#testOptimize [ "NatMulCstPropUnchanged_3" ] ∀ (x y : Nat), 40 * (x + y) < y ===> natMulCstPropUnchanged_3
+#testOptimize [ "NatMulCstPropUnchanged_3", proof ] ∀ (x y : Nat), 40 * (x + y) < y ===> natMulCstPropUnchanged_3
 
 
 
 /-! Test cases for normalization rule `n1 * n2 ==> n2 * n1 (if n2 <ₒ n1)`. -/
 
 -- x * y = x * y ===> True
-#testOptimize [ "NatMulCommut_1" ] ∀ (x y : Nat), x * y = x * y ===> True
+#testOptimize [ "NatMulCommut_1", proof ] ∀ (x y : Nat), x * y = x * y ===> True
 
 -- x * y = y * x ===> True
-#testOptimize [ "NatMulCommut_2" ] ∀ (x y : Nat), x * y = y * x ===> True
+#testOptimize [ "NatMulCommut_2", proof ] ∀ (x y : Nat), x * y = y * x ===> True
 
 -- x * 10 = 10 * x ===> True
-#testOptimize [ "NatMulCommut_3" ] ∀ (x : Nat), x * 10 = 10 * x ===> True
+#testOptimize [ "NatMulCommut_3", proof ] ∀ (x : Nat), x * 10 = 10 * x ===> True
 
 -- y * x ===> x * y (with `x` declared first)
-#testOptimize [ "NatMulCommut_4" ] ∀ (x y z : Nat), z < y * x ===> ∀ (x y z : Nat), z < Nat.mul x y
+#testOptimize [ "NatMulCommut_4", proof ] ∀ (x y z : Nat), z < y * x ===> ∀ (x y z : Nat), z < Nat.mul x y
 
 -- x * 40 ===> 40 * x
 def natMulCommut_5 : Expr :=
@@ -301,29 +301,29 @@ def natMulCommut_5 : Expr :=
 
 elab "natMulCommut_5" : term => return natMulCommut_5
 
-#testOptimize [ "NatMulCommut_5" ] ∀ (x y : Nat), y < x * 40 ===> natMulCommut_5
+#testOptimize [ "NatMulCommut_5", proof ] ∀ (x y : Nat), y < x * 40 ===> natMulCommut_5
 
 -- (x * (y * 20)) * z = z * ((y * 20) * x) ===> True
-#testOptimize [ "NatMulCommut_6" ] ∀ (x y z : Nat), (x * (y * 20)) * z = z * ((y * 20) * x) ===> True
+#testOptimize [ "NatMulCommut_6", proof ] ∀ (x y z : Nat), (x * (y * 20)) * z = z * ((y * 20) * x) ===> True
 
 --- (x - y) * (p + q) ===> (p + q) * (x - y)
-#testOptimize [ "NatMulCommut_7" ] ∀ (x y z p q : Nat), (x - y) * (p + q) < z ===>
+#testOptimize [ "NatMulCommut_7", proof ] ∀ (x y z p q : Nat), (x - y) * (p + q) < z ===>
                                    ∀ (x y z p q : Nat), Nat.mul (Nat.add p q) (Nat.sub x y) < z
 
 --- (x - y) * (p + q) = (p + q) * (x - y) ===> True
-#testOptimize [ "NatMulCommut_8" ] ∀ (x y p q : Nat), (x - y) * (p + q) = (p + q) * (x - y) ===> True
+#testOptimize [ "NatMulCommut_8", proof ] ∀ (x y p q : Nat), (x - y) * (p + q) = (p + q) * (x - y) ===> True
 
 
 /-! Test cases to ensure that `Nat.mul` is preserved when expected. -/
 
 -- x * (y * 1) = x * y ===> True
-#testOptimize [ "NatMulVar_1" ] ∀ (x y : Nat), x * (y * 1) = x * y ===> True
+#testOptimize [ "NatMulVar_1", proof ] ∀ (x y : Nat), x * (y * 1) = x * y ===> True
 
 -- (x * 1) * y = x * y ===> True
-#testOptimize [ "NatMulVar_2" ] ∀ (x y : Nat), (x * 1) * y = x * y ===> True
+#testOptimize [ "NatMulVar_2", proof ] ∀ (x y : Nat), (x * 1) * y = x * y ===> True
 
 -- (x * 1) * (y * 1) = y * x ===> True
-#testOptimize [ "NatMulVar_3" ] ∀ (x y : Nat), (x * 1) * (y * 1) = y * x ===> True
+#testOptimize [ "NatMulVar_3", proof ] ∀ (x y : Nat), (x * 1) * (y * 1) = y * x ===> True
 
 -- x * y < 10 ===> x * y < 10
 def natAddVar_4 : Expr :=
@@ -345,7 +345,7 @@ def natAddVar_4 : Expr :=
 
 elab "natAddVar_4" : term => return natAddVar_4
 
-#testOptimize [ "NatMulVar_4" ] ∀ (x y : Nat), x * y < 10 ===> natAddVar_4
+#testOptimize [ "NatMulVar_4", proof ] ∀ (x y : Nat), x * y < 10 ===> natAddVar_4
 
 
 /-! Test cases to ensure that constant propagation is properly performed
@@ -356,13 +356,13 @@ variable (x : Nat)
 variable (y : Nat)
 
 -- (100 * (30 - ((180 - (x * 1)) - 150))) * ((320 - (y + 400)) - y) ===> 0
-#testOptimize [ "NatMulReduce_1" ] (100 * (30 - ((180 - (x * 1)) - 150))) * ((320 - (y + 400)) - y) ===> natMulCst_1
+#testOptimize [ "NatMulReduce_1", proof ] (100 * (30 - ((180 - (x * 1)) - 150))) * ((320 - (y + 400)) - y) ===> natMulCst_1
 
 -- (100 * (((180 - (x * 40)) - 150) - 30)) * ((((20 - y) - 50) * 24) + 1) ===> 100
 def natMulReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 100)
 elab "natMulReduce_2" : term => return natMulReduce_2
 
-#testOptimize [ "NatMulReduce_2" ] (100 + (((180 - (x * 40)) - 150) - 30)) * ((((20 - y) - 50) * 24) + 1) ===> natMulReduce_2
+#testOptimize [ "NatMulReduce_2", proof ] (100 + (((180 - (x * 40)) - 150) - 30)) * ((((20 - y) - 50) * 24) + 1) ===> natMulReduce_2
 
 
 end Test.OptimizeNatMul

--- a/Tests/Optimize/OptimizeNat/OptimizeNatMul.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatMul.lean
@@ -47,19 +47,19 @@ variable (x : Nat)
 #testOptimize [ "NatMulZero_3", proof ] ∀ (x : Nat), 0 * x = 0 ===> True
 
 -- x * Nat.zero ===> 0
-#testOptimize [ "NatMulZero_4" ] ∀ (x y : Nat), x * Nat.zero ≤ y ===> True
+#testOptimize [ "NatMulZero_4", proof ] ∀ (x y : Nat), x * Nat.zero ≤ y ===> True
 
 -- Nat.zero * x ===> 0
-#testOptimize [ "NatMulZero_5" ] ∀ (x y : Nat), Nat.zero * x ≤ y ===> True
+#testOptimize [ "NatMulZero_5", proof ] ∀ (x y : Nat), Nat.zero * x ≤ y ===> True
 
 -- Nat.zero * x = 0 ===> True
 #testOptimize [ "NatMulZero_6", proof ] ∀ (x : Nat), Nat.zero * x = 0 ===> True
 
 -- (10 - 10) * x ===> 0
-#testOptimize [ "NatMulZero_7" ] ∀ (x y : Nat), (10 - 10) * x ≤ y ===> True
+#testOptimize [ "NatMulZero_7", proof ] ∀ (x y : Nat), (10 - 10) * x ≤ y ===> True
 
 -- x * (10 - 123) ===> 0
-#testOptimize [ "NatMulZero_8" ] ∀ (x y : Nat), x * (10 - 123) ≤ y ===> True
+#testOptimize [ "NatMulZero_8", proof ] ∀ (x y : Nat), x * (10 - 123) ≤ y ===> True
 
 -- x * (y - y) = 0 ===> True
 #testOptimize [ "NatMulZero_9", proof ] ∀ (x y : Nat), x * (y - y) = 0 ===> True
@@ -80,9 +80,9 @@ variable (x : Nat)
 #testOptimize [ "NatMulOne_4", proof ] ∀ (x y : Nat), (10 - 9) * x < y ===> ∀ (x y : Nat), x < y
 
 -- ((((Nat.succ y) - 1) - y) + 1) * x ===> x
-#testOptimize [ "NatMulOne_5" ] ∀ (x y z : Nat), ((((Nat.succ y) - 1) - y) + 1) * x < z ===>
-                                ∀ (x z : Nat), x < z
-
+#testOptimize [ "NatMulOne_5" ]
+  ∀ (x y z : Nat), ((((Nat.succ y) - 1) - y) + 1) * x < z ===>
+  ∀ (x z : Nat), x < z
 
 
 /-! Test cases to ensure that the following simplification rules are not wrongly applied:
@@ -116,11 +116,13 @@ elab "natMulCstUnchanged_1" : term => return natMulCstUnchanged_1
 
 -- (100 - 90) * x ===> 10 * x
 -- TODO: remove unused quantifier when COI performed on forall
-#testOptimize [ "NatMulCstUnchanged_2", proof ] ∀ (x y : Nat), (100 - 90) * x ≤ y ===> natMulCstUnchanged_1
+#testOptimize [ "NatMulCstUnchanged_2", proof ]
+  ∀ (x y : Nat), (100 - 90) * x ≤ y ===> natMulCstUnchanged_1
 
 -- x * (y - z) ===> Nat.mul x (Nat.sub y z)
-#testOptimize [ "NatMulCstUnchanged_3", proof ] ∀ (x y z m : Nat), x * (y - z) < m ===>
-                                         ∀ (x y z m : Nat), Nat.mul x (Nat.sub y z) < m
+#testOptimize [ "NatMulCstUnchanged_3", proof ]
+  ∀ (x y z m : Nat), x * (y - z) < m ===>
+  ∀ (x y z m : Nat), Nat.mul x (Nat.sub y z) < m
 
 
 /-! Test cases for simplification rule `N1 * (N2 * n) ===> (N1 "*" N2) * n`. -/
@@ -166,16 +168,20 @@ elab "natAddCstProp_5" : term => return natAddCstProp_5
 #testOptimize [ "NatMulCstProp_7", proof ] ∀ (x : Nat), 10 * (2 * (x * 40)) = 800 * x ===> True
 
 -- 10 * (20 * (x - 10)) = 200 * (x - 10) ===> True
-#testOptimize [ "NatMulCstProp_8", proof ] ∀ (x : Nat), 10 * (20 * (x - 10)) = 200 * (x - 10)===> True
+#testOptimize [ "NatMulCstProp_8", proof ]
+  ∀ (x : Nat), 10 * (20 * (x - 10)) = 200 * (x - 10)===> True
 
 -- 10 * (20 * (10 - x)) = 200 * (10 - x) ===> True
-#testOptimize [ "NatMulCstProp_9", proof ] ∀ (x : Nat), 10 * (20 * (10 - x)) = 200 * (10 - x) ===> True
+#testOptimize [ "NatMulCstProp_9", proof ]
+  ∀ (x : Nat), 10 * (20 * (10 - x)) = 200 * (10 - x) ===> True
 
 -- 10 * (2 * (5 * (x * 25))) = 2500 * x ===> True
-#testOptimize [ "NatMulCstProp_10", proof ] ∀ (x : Nat), 10 * (2 * (5 * (x * 25))) = 2500 * x ===> True
+#testOptimize [ "NatMulCstProp_10", proof ]
+  ∀ (x : Nat), 10 * (2 * (5 * (x * 25))) = 2500 * x ===> True
 
 -- 10 * (20 * ((x - 3) - 7)) = 200 * (x - 10) ===> True
-#testOptimize [ "NatMulCstProp_11", proof ] ∀ (x : Nat), 10 * (20 * ((x - 3) - 7)) = 200 * (x - 10) ===> True
+#testOptimize [ "NatMulCstProp_11", proof ]
+  ∀ (x : Nat), 10 * (20 * ((x - 3) - 7)) = 200 * (x - 10) ===> True
 
 -- 10 * (20 * (100 - (x + 190))) = 0 ===> True
 #testOptimize [ "NatMulCstProp_12", proof ] ∀ (x : Nat), 10 * (20 * (100 - (x + 190))) = 0 ===> True
@@ -209,7 +215,8 @@ def natMulCstPropUnchanged_1 : Expr :=
 
 elab "natMulCstPropUnchanged_1" : term => return natMulCstPropUnchanged_1
 
-#testOptimize [ "NatMulCstPropUnchanged_1", proof ] ∀ (x y : Nat), 40 * (x * y) < y ===> natMulCstPropUnchanged_1
+#testOptimize [ "NatMulCstPropUnchanged_1", proof ]
+  ∀ (x y : Nat), 40 * (x * y) < y ===> natMulCstPropUnchanged_1
 
 
 -- 40 * (x - y) ===> 40 * (x - y)
@@ -236,7 +243,8 @@ def natMulCstPropUnchanged_2 : Expr :=
 
 elab "natMulCstPropUnchanged_2" : term => return natMulCstPropUnchanged_2
 
-#testOptimize [ "NatMulCstPropUnchanged_2", proof ] ∀ (x y : Nat), 40 * (x - y) < y ===> natMulCstPropUnchanged_2
+#testOptimize [ "NatMulCstPropUnchanged_2", proof ]
+  ∀ (x y : Nat), 40 * (x - y) < y ===> natMulCstPropUnchanged_2
 
 
 -- 40 * (x + y) ===> 40 * (x + y)
@@ -263,7 +271,8 @@ def natMulCstPropUnchanged_3 : Expr :=
 
 elab "natMulCstPropUnchanged_3" : term => return natMulCstPropUnchanged_3
 
-#testOptimize [ "NatMulCstPropUnchanged_3", proof ] ∀ (x y : Nat), 40 * (x + y) < y ===> natMulCstPropUnchanged_3
+#testOptimize [ "NatMulCstPropUnchanged_3", proof ]
+  ∀ (x y : Nat), 40 * (x + y) < y ===> natMulCstPropUnchanged_3
 
 
 
@@ -279,7 +288,8 @@ elab "natMulCstPropUnchanged_3" : term => return natMulCstPropUnchanged_3
 #testOptimize [ "NatMulCommut_3", proof ] ∀ (x : Nat), x * 10 = 10 * x ===> True
 
 -- y * x ===> x * y (with `x` declared first)
-#testOptimize [ "NatMulCommut_4", proof ] ∀ (x y z : Nat), z < y * x ===> ∀ (x y z : Nat), z < Nat.mul x y
+#testOptimize [ "NatMulCommut_4", proof ]
+  ∀ (x y z : Nat), z < y * x ===> ∀ (x y z : Nat), z < Nat.mul x y
 
 -- x * 40 ===> 40 * x
 def natMulCommut_5 : Expr :=
@@ -304,14 +314,17 @@ elab "natMulCommut_5" : term => return natMulCommut_5
 #testOptimize [ "NatMulCommut_5", proof ] ∀ (x y : Nat), y < x * 40 ===> natMulCommut_5
 
 -- (x * (y * 20)) * z = z * ((y * 20) * x) ===> True
-#testOptimize [ "NatMulCommut_6", proof ] ∀ (x y z : Nat), (x * (y * 20)) * z = z * ((y * 20) * x) ===> True
+#testOptimize [ "NatMulCommut_6", proof ]
+  ∀ (x y z : Nat), (x * (y * 20)) * z = z * ((y * 20) * x) ===> True
 
 --- (x - y) * (p + q) ===> (p + q) * (x - y)
-#testOptimize [ "NatMulCommut_7", proof ] ∀ (x y z p q : Nat), (x - y) * (p + q) < z ===>
-                                   ∀ (x y z p q : Nat), Nat.mul (Nat.add p q) (Nat.sub x y) < z
+#testOptimize [ "NatMulCommut_7", proof ]
+  ∀ (x y z p q : Nat), (x - y) * (p + q) < z ===>
+  ∀ (x y z p q : Nat), Nat.mul (Nat.add p q) (Nat.sub x y) < z
 
 --- (x - y) * (p + q) = (p + q) * (x - y) ===> True
-#testOptimize [ "NatMulCommut_8", proof ] ∀ (x y p q : Nat), (x - y) * (p + q) = (p + q) * (x - y) ===> True
+#testOptimize [ "NatMulCommut_8", proof ]
+  ∀ (x y p q : Nat), (x - y) * (p + q) = (p + q) * (x - y) ===> True
 
 
 /-! Test cases to ensure that `Nat.mul` is preserved when expected. -/
@@ -356,13 +369,15 @@ variable (x : Nat)
 variable (y : Nat)
 
 -- (100 * (30 - ((180 - (x * 1)) - 150))) * ((320 - (y + 400)) - y) ===> 0
-#testOptimize [ "NatMulReduce_1", proof ] (100 * (30 - ((180 - (x * 1)) - 150))) * ((320 - (y + 400)) - y) ===> natMulCst_1
+#testOptimize [ "NatMulReduce_1", proof ]
+  (100 * (30 - ((180 - (x * 1)) - 150))) * ((320 - (y + 400)) - y) ===> natMulCst_1
 
 -- (100 * (((180 - (x * 40)) - 150) - 30)) * ((((20 - y) - 50) * 24) + 1) ===> 100
 def natMulReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 100)
 elab "natMulReduce_2" : term => return natMulReduce_2
 
-#testOptimize [ "NatMulReduce_2", proof ] (100 + (((180 - (x * 40)) - 150) - 30)) * ((((20 - y) - 50) * 24) + 1) ===> natMulReduce_2
+#testOptimize [ "NatMulReduce_2", proof ]
+  (100 + (((180 - (x * 40)) - 150) - 30)) * ((((20 - y) - 50) * 24) + 1) ===> natMulReduce_2
 
 
 end Test.OptimizeNatMul

--- a/Tests/Optimize/OptimizeNat/OptimizeNatMul.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatMul.lean
@@ -80,7 +80,7 @@ variable (x : Nat)
 #testOptimize [ "NatMulOne_4", proof ] ∀ (x y : Nat), (10 - 9) * x < y ===> ∀ (x y : Nat), x < y
 
 -- ((((Nat.succ y) - 1) - y) + 1) * x ===> x
-#testOptimize [ "NatMulOne_5" ]
+#testOptimize [ "NatMulOne_5", proof ]
   ∀ (x y z : Nat), ((((Nat.succ y) - 1) - y) + 1) * x < z ===>
   ∀ (x z : Nat), x < z
 

--- a/Tests/Optimize/OptimizeNat/OptimizeNatPow.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatPow.lean
@@ -1,0 +1,20 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Test.OptimizeNatPow
+
+/-! ## Test objectives to validate normalization and simplification rules on ``Nat.pow -/
+/-! Test cases for `reduceApp` rule on ``Nat.pow -/
+
+-- 5 ^ 0 ===> 1
+def natPowCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 1)
+elab "natPowCst_1": term => return natPowCst_1
+
+#testOptimize ["NatPowCst_1", proof] (5 : Nat) ^ 0 ===> natPowCst_1
+
+/-! Test cases for simplification rule `n ^ 0 ==> 1`-/
+#testOptimize ["NatPowIden_1", proof] ∀ (n : Nat), n ^ 0 = 1 ===> True
+
+end Test.OptimizeNatPow

--- a/Tests/Optimize/OptimizeNat/OptimizeNatPred.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatPred.lean
@@ -13,56 +13,56 @@ namespace Test.OptimizeNatPred
 def natPredCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 0)
 elab "natPredCst_1" : term => return natPredCst_1
 
-#testOptimize [ "NatPredCst_1" ] Nat.pred Nat.zero ===> natPredCst_1
+#testOptimize [ "NatPredCst_1", proof ] Nat.pred Nat.zero ===> natPredCst_1
 
 -- Nat.pred Nat.zero = 0 ===> True
-#testOptimize [ "NatPredCst_2" ] Nat.pred Nat.zero = 0 ===> True
+#testOptimize [ "NatPredCst_2", proof ] Nat.pred Nat.zero = 0 ===> True
 
 -- Nat.pred 0 ===> 0
-#testOptimize [ "NatPredCst_3" ] Nat.pred 0 ===> natPredCst_1
+#testOptimize [ "NatPredCst_3", proof ] Nat.pred 0 ===> natPredCst_1
 
 -- Nat.pred 1 = 0 ===> True
-#testOptimize [ "NatPredCst_4" ] Nat.pred 1 = 0 ===> True
+#testOptimize [ "NatPredCst_4", proof ] Nat.pred 1 = 0 ===> True
 
 -- Nat.pred 10 ===> 9
 def natPredCst_5 : Expr := Lean.Expr.lit (Lean.Literal.natVal 9)
 elab "natPredCst_5" : term => return natPredCst_5
 
-#testOptimize [ "NatPredCst_5" ] Nat.pred 10 ===> natPredCst_5
+#testOptimize [ "NatPredCst_5", proof ] Nat.pred 10 ===> natPredCst_5
 
 -- Nat.pred (Nat.pred 10) ===> 8
 def natPredCst_6 : Expr := Lean.Expr.lit (Lean.Literal.natVal 8)
 elab "natPredCst_6" : term => return natPredCst_6
 
-#testOptimize [ "NatPredCst_6" ] Nat.pred (Nat.pred 10) ===> natPredCst_6
+#testOptimize [ "NatPredCst_6", proof ] Nat.pred (Nat.pred 10) ===> natPredCst_6
 
 -- Nat.pred (Nat.pred (Nat.pred 10)) ===> 7
 def natPredCst_7 : Expr := Lean.Expr.lit (Lean.Literal.natVal 7)
 elab "natPredCst_7" : term => return natPredCst_7
 
 -- Nat.pred (Nat.pred 1)) ===> 0
-#testOptimize [ "NatPredCst_8" ] Nat.pred (Nat.pred (Nat.pred 1)) ===> natPredCst_1
+#testOptimize [ "NatPredCst_8", proof ] Nat.pred (Nat.pred (Nat.pred 1)) ===> natPredCst_1
 
 -- Nat.pred (10 + 30) ===> 39
 def natPredCst_9 : Expr := Lean.Expr.lit (Lean.Literal.natVal 39)
 elab "natPredCst_9" : term => return natPredCst_9
 
-#testOptimize [ "NatPredCst_9" ] Nat.pred (10 + 30) ===> natPredCst_9
+#testOptimize [ "NatPredCst_9", proof ] Nat.pred (10 + 30) ===> natPredCst_9
 
 -- Nat.pred (10 - 30) ===> 0
-#testOptimize [ "NatPredCst_10" ] Nat.pred (10 - 30) ===> natPredCst_1
+#testOptimize [ "NatPredCst_10", proof ] Nat.pred (10 - 30) ===> natPredCst_1
 
 -- Nat.pred (Nat.succ 10) ===> 10
 def natPredCst_11 : Expr := Lean.Expr.lit (Lean.Literal.natVal 10)
 elab "natPredCst_11" : term => return natPredCst_11
 
-#testOptimize [ "NatPredCst_11" ] Nat.pred (Nat.succ 10) ===> natPredCst_11
+#testOptimize [ "NatPredCst_11", proof ] Nat.pred (Nat.succ 10) ===> natPredCst_11
 
 
 /-! Test cases for normalization rule ` ``Nat.pred n ===> n - 1`. -/
 
 -- Nat.pred x = x - 1 ===> True
-#testOptimize [ "NatPredNorm_1" ] ∀ (x : Nat), (Nat.pred x) = x - 1 ===> True
+#testOptimize [ "NatPredNorm_1", proof ] ∀ (x : Nat), (Nat.pred x) = x - 1 ===> True
 
 -- Nat.pred x = ===> x - 1
 def natPredNorm_2 : Expr :=
@@ -83,31 +83,35 @@ def natPredNorm_2 : Expr :=
   (Lean.BinderInfo.default)
 elab "natPredNorm_2" : term => return natPredNorm_2
 
-#testOptimize [ "NatPredNorm_2" ] ∀ (x y : Nat), (Nat.pred x) < y ===> natPredNorm_2
+#testOptimize [ "NatPredNorm_2", proof ] ∀ (x y : Nat), (Nat.pred x) < y ===> natPredNorm_2
 
 -- Nat.pred (Nat.pred x) = x - 2 ===> True
-#testOptimize [ "NatPredNorm_3" ] ∀ (x : Nat), Nat.pred (Nat.pred x) = x - 2 ===> True
+#testOptimize [ "NatPredNorm_3", proof ] ∀ (x : Nat), Nat.pred (Nat.pred x) = x - 2 ===> True
 
 -- Nat.pred (Nat.pred (Nat.pred x)) = x -3 ===> True
-#testOptimize [ "NatPredNorm_4" ] ∀ (x : Nat), Nat.pred (Nat.pred (Nat.pred x)) = x - 3 ===> True
+#testOptimize [ "NatPredNorm_4", proof ]
+  ∀ (x : Nat), Nat.pred (Nat.pred (Nat.pred x)) = x - 3 ===> True
 
 -- Nat.pred (x + y) = (x + y) - 1 ===> True
-#testOptimize [ "NatPredNorm_5" ] ∀ (x y : Nat), Nat.pred (x + y) = (x + y) - 1 ===> True
+#testOptimize [ "NatPredNorm_5", proof ] ∀ (x y : Nat), Nat.pred (x + y) = (x + y) - 1 ===> True
 
 -- Nat.pred (x - y) = (x - y) + 1 ===> True
-#testOptimize [ "NatPredNorm_6" ] ∀ (x y : Nat), Nat.pred (x - y) = (x - y) - 1 ===> True
+#testOptimize [ "NatPredNorm_6", proof ] ∀ (x y : Nat), Nat.pred (x - y) = (x - y) - 1 ===> True
 
 -- Nat.pred (Nat.succ x) = x ===> True
-#testOptimize [ "NatPredNorm_7" ] ∀ (x : Nat), Nat.pred (Nat.succ x) = x ===> True
+#testOptimize [ "NatPredNorm_7", proof ] ∀ (x : Nat), Nat.pred (Nat.succ x) = x ===> True
 
 -- Nat.pred (Nat.pred (x + y)) = (x + y) - 2 ===> True
-#testOptimize [ "NatPredNorm_8" ] ∀ (x y : Nat), Nat.pred (Nat.pred (x + y)) = (x + y) - 2 ===> True
+#testOptimize [ "NatPredNorm_8", proof ]
+  ∀ (x y : Nat), Nat.pred (Nat.pred (x + y)) = (x + y) - 2 ===> True
 
 -- Nat.pred (Nat.pred (x - y)) = (x - y) - 2 ===> True
-#testOptimize [ "NatPredNorm_9" ] ∀ (x y : Nat), Nat.pred (Nat.pred (x - y)) = (x - y) - 2 ===> True
+#testOptimize [ "NatPredNorm_9", proof ]
+  ∀ (x y : Nat), Nat.pred (Nat.pred (x - y)) = (x - y) - 2 ===> True
 
 -- Nat.pred (Nat.pred (Nat.succ x)) = x - 1 ===> True
-#testOptimize [ "NatPredNorm_10" ] ∀ (x : Nat), Nat.pred (Nat.pred (Nat.succ x)) = x - 1 ===> True
+#testOptimize [ "NatPredNorm_10", proof ]
+  ∀ (x : Nat), Nat.pred (Nat.pred (Nat.succ x)) = x - 1 ===> True
 
 
 /-! TTest cases to ensure that constant propagation is properly performed
@@ -120,12 +124,14 @@ variable (y : Nat)
 def natPredReduce_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 99)
 elab "natPredReduce_1" : term => return natPredReduce_1
 
-#testOptimize [ "NatPredReduce_1" ] Nat.pred (100 + ((180 - (x + 40)) - 150)) ===> natPredReduce_1
+#testOptimize [ "NatPredReduce_1", proof ]
+  Nat.pred (100 + ((180 - (x + 40)) - 150)) ===> natPredReduce_1
 
 -- Nat.pred ((100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24)) ===> 123
 def natPredReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 123)
 elab "natPredReduce_2" : term => return natPredReduce_2
 
-#testOptimize [ "NatPredReduce_2" ] Nat.pred ((100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24))  ===> natPredReduce_2
+#testOptimize [ "NatPredReduce_2", proof ]
+  Nat.pred ((100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24))  ===> natPredReduce_2
 
 end Test.OptimizeNatPred

--- a/Tests/Optimize/OptimizeNat/OptimizeNatSub.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatSub.lean
@@ -14,27 +14,27 @@ namespace Test.OptimizeNatSub
 def natSubCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 73)
 elab "natSubCst_1" : term => return natSubCst_1
 
-#testOptimize [ "NatSubCst_1" ] (123 : Nat) - 50 ===> natSubCst_1
+#testOptimize [ "NatSubCst_1", proof ] (123 : Nat) - 50 ===> natSubCst_1
 
 -- 123 - 0 ===> 123
 def natSubCst_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 123)
 elab "natSubCst_2" : term => return natSubCst_2
 
-#testOptimize [ "NatSubCst_2" ] (123 : Nat) - 0 ===> natSubCst_2
+#testOptimize [ "NatSubCst_2", proof ] (123 : Nat) - 0 ===> natSubCst_2
 
 def natSubCst_3 : Expr := Lean.Expr.lit (Lean.Literal.natVal 0)
 elab "natSubCst_3" : term => return natSubCst_3
 -- 0 - 1 ===> 0
-#testOptimize [ "NatSubCst_3" ] (0 : Nat) - 1 ===> natSubCst_3
+#testOptimize [ "NatSubCst_3", proof ] (0 : Nat) - 1 ===> natSubCst_3
 
 -- 0 - 5 ===> 0
-#testOptimize [ "NatSubCst_4" ] (0 : Nat) - 5 ===> natSubCst_3
+#testOptimize [ "NatSubCst_4", proof ] (0 : Nat) - 5 ===> natSubCst_3
 
 -- 123 - 124 ===> 0
-#testOptimize [ "NatSubCst_5" ] (123 : Nat) - 124 ===> natSubCst_3
+#testOptimize [ "NatSubCst_5", proof ] (123 : Nat) - 124 ===> natSubCst_3
 
 -- 123 - 300 ===> 0
-#testOptimize [ "NatSubCst_6" ] (123 : Nat) - 300 ===> natSubCst_3
+#testOptimize [ "NatSubCst_6", proof ] (123 : Nat) - 300 ===> natSubCst_3
 
 
 /-! Test cases for simplification rule `n1 - n2 ==> 0 (if n1 =ₚₜᵣ n2)`. -/
@@ -54,64 +54,77 @@ def natSubReduceZero_1 : Expr :=
 
 elab "natSubReduceZero_1" : term => return natSubReduceZero_1
 
-#testOptimize [ "NatSubReduceZero_1" ] ∀ (x y : Nat), y > x - x ===> natSubReduceZero_1
+#testOptimize [ "NatSubReduceZero_1", proof ] ∀ (x y : Nat), y > x - x ===> natSubReduceZero_1
 
 -- x - x = 0 ===> True
-#testOptimize [ "NatSubReduceZero_2" ] ∀ (x : Nat), x - x = 0 ===> True
+#testOptimize [ "NatSubReduceZero_2", proof ] ∀ (x : Nat), x - x = 0 ===> True
 
 -- (x + y) - (y + x) = 0 ===> True
-#testOptimize [ "NatSubReduceZero_3" ] ∀ (x y : Nat), (x + y) - (y + x) = 0 ===> True
+#testOptimize [ "NatSubReduceZero_3", proof ] ∀ (x y : Nat), (x + y) - (y + x) = 0 ===> True
 
 -- (x - y) - (x - y) = 0 ===> True
-#testOptimize [ "NatSubReduceZero_4" ] ∀ (x y : Nat), (x - y) - (x - y) = 0 ===> True
+#testOptimize [ "NatSubReduceZero_4", proof ] ∀ (x y : Nat), (x - y) - (x - y) = 0 ===> True
 
 -- (x + 0) - x = 0 ===> True
-#testOptimize [ "NatSubReduceZero_5" ] ∀ (x : Nat), (x + 0) - x = 0 ===> True
+#testOptimize [ "NatSubReduceZero_5", proof ] ∀ (x : Nat), (x + 0) - x = 0 ===> True
 
 -- x - (x + 0) = 0 ===> True
-#testOptimize [ "NatSubReduceZero_6" ] ∀ (x : Nat), x - (x + 0) = 0 ===> True
+#testOptimize [ "NatSubReduceZero_6", proof ] ∀ (x : Nat), x - (x + 0) = 0 ===> True
 
 -- x - (x + (100 - (200 + x))) = 0 ===> True
-#testOptimize [ "NatSubReduceZero_7" ] ∀ (x : Nat), x - (x + (100 - (200 + x))) = 0 ===> True
+#testOptimize [ "NatSubReduceZero_7", proof ] ∀ (x : Nat), x - (x + (100 - (200 + x))) = 0 ===> True
 
 
 /-! Test cases to ensure that simplification rule `n1 - n2 ==> 0 (if n1 =ₚₜᵣ n2)` is not wrongly applied. -/
 
 -- x - y ===> Nat.sub x y
-#testOptimize [ "NatSubReduceZeroUnchanged_1" ] ∀ (x y z : Nat), z > x - y ===>
-                                                ∀ (x y z : Nat), Nat.sub x y < z
+#testOptimize [ "NatSubReduceZeroUnchanged_1", proof ]
+  ∀ (x y z : Nat), z > x - y ===>
+  ∀ (x y z : Nat), Nat.sub x y < z
+
 -- (x + y) - z ===> Nat.sub (Nat.add x y) z
-#testOptimize [ "NatSubReduceZeroUnchanged_2" ] ∀ (x y z m : Nat), (x + y) - z < m ===>
-                                                ∀ (x y z m : Nat), Nat.sub (Nat.add x y) z < m
+#testOptimize [ "NatSubReduceZeroUnchanged_2", proof ]
+  ∀ (x y z m : Nat), (x + y) - z < m ===>
+  ∀ (x y z m : Nat), Nat.sub (Nat.add x y) z < m
 
 -- (x - y) - z ===> Nat.sub (Nat.sub x y) z
-#testOptimize [ "NatSubReduceZeroUnchanged_3" ] ∀ (x y z m : Nat), (x - y) - z < m ===>
-                                                ∀ (x y z m : Nat), Nat.sub (Nat.sub x y) z < m
+#testOptimize [ "NatSubReduceZeroUnchanged_3", proof ]
+  ∀ (x y z m : Nat), (x - y) - z < m ===>
+  ∀ (x y z m : Nat), Nat.sub (Nat.sub x y) z < m
 
 -- (y + (100 - (200 + x))) - x ===> Nat.sub y x
-#testOptimize [ "NatSubReduceZeroUnchanged_4" ] ∀ (x y z : Nat), (y + (100 - (200 + x))) - x < z ===>
-                                                ∀ (x y z : Nat), Nat.sub y x < z
+#testOptimize [ "NatSubReduceZeroUnchanged_4", proof ]
+  ∀ (x y z : Nat), (y + (100 - (200 + x))) - x < z ===>
+  ∀ (x y z : Nat), Nat.sub y x < z
 
 
 /-! Test cases for simplification rule `0 - n ===> 0`. -/
 
 -- 0 - x = 0 ===> True
-#testOptimize [ "NatSubLeftZero_1" ] ∀ (x : Nat), 0 - x = 0 ===> True
+#testOptimize [ "NatSubLeftZero_1", proof ] ∀ (x : Nat), 0 - x = 0 ===> True
 
 -- 0 - x ===> 0
-#testOptimize [ "NatSubLeftZero_2" ] ∀ (x y : Nat), (0 - x) + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubLeftZero_2", proof ]
+  ∀ (x y : Nat), (0 - x) + x ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- Nat.zero - x = 0 ===> True
-#testOptimize [ "NatSubLeftZero_3" ] ∀ (x : Nat), Nat.zero - x = 0 ===> True
+#testOptimize [ "NatSubLeftZero_3", proof ] ∀ (x : Nat), Nat.zero - x = 0 ===> True
 
 -- Nat.zero - x ===> 0
-#testOptimize [ "NatSubLeftZero_4" ] ∀ (x y : Nat), (Nat.zero - x) + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubLeftZero_4", proof ]
+  ∀ (x y : Nat), (Nat.zero - x) + x ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- (27 - 27) - x ===> 0
-#testOptimize [ "NatSubLeftZero_5" ] ∀ (x y : Nat), ((27 - 27) - x) + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubLeftZero_5", proof ]
+  ∀ (x y : Nat), ((27 - 27) - x) + x ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- (127 - 145) - x ===> 0
-#testOptimize [ "NatSubLeftZero_6" ] ∀ (x y : Nat), ((127 - 145) - x) + x ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubLeftZero_6", proof ]
+  ∀ (x y : Nat), ((127 - 145) - x) + x ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- 1 - x ===> 1 - x
 def natSubLeftZeroUnchanged_1 : Expr :=
@@ -133,13 +146,16 @@ def natSubLeftZeroUnchanged_1 : Expr :=
 
 elab "natSubLeftZeroUnchanged_1" : term => return natSubLeftZeroUnchanged_1
 
-#testOptimize [ "NatSubLeftZeroUnchanged_1" ] ∀ (x y : Nat), (1 - x) < y ===> natSubLeftZeroUnchanged_1
+#testOptimize [ "NatSubLeftZeroUnchanged_1", proof ]
+  ∀ (x y : Nat), (1 - x) < y ===> natSubLeftZeroUnchanged_1
 
 -- (27 - 26) - x ===> 1 - x
-#testOptimize [ "NatSubLeftZeroUnchanged_2" ] ∀ (x y : Nat), (27 - 26) - x < y ===> natSubLeftZeroUnchanged_1
+#testOptimize [ "NatSubLeftZeroUnchanged_2", proof ]
+  ∀ (x y : Nat), (27 - 26) - x < y ===> natSubLeftZeroUnchanged_1
 
 -- (Nat.zero + 1) - x ===> 1 - x
-#testOptimize [ "NatSubLeftZeroUnchanged_3" ] ∀ (x y : Nat), (Nat.zero + 1) - x < y ===> natSubLeftZeroUnchanged_1
+#testOptimize [ "NatSubLeftZeroUnchanged_3", proof ]
+  ∀ (x y : Nat), (Nat.zero + 1) - x < y ===> natSubLeftZeroUnchanged_1
 
 -- (127 - 40) - x ===> 87 - x
 def natSubLeftZeroUnchanged_4 : Expr :=
@@ -161,31 +177,38 @@ def natSubLeftZeroUnchanged_4 : Expr :=
 
 elab "natSubLeftZeroUnchanged_4" : term => return natSubLeftZeroUnchanged_4
 
-#testOptimize [ "NatSubLeftZeroUnchanged_4" ] ∀ (x y : Nat), (127 - 40) - x < y ===> natSubLeftZeroUnchanged_4
+#testOptimize [ "NatSubLeftZeroUnchanged_4", proof ]
+  ∀ (x y : Nat), (127 - 40) - x < y ===> natSubLeftZeroUnchanged_4
 
 
 /-! Test cases for simplification rule `n - 0 ===> n`. -/
 
 -- x - 0 = x ===> x
-#testOptimize [ "NatSubRightZero_1" ] ∀ (x : Nat), x - 0 = x ===> True
+#testOptimize [ "NatSubRightZero_1", proof ] ∀ (x : Nat), x - 0 = x ===> True
 
 -- x - Nat.zero = x ===> x
-#testOptimize [ "NatSubRightZero_2" ] ∀ (x : Nat), x - Nat.zero = x ===> True
+#testOptimize [ "NatSubRightZero_2", proof ] ∀ (x : Nat), x - Nat.zero = x ===> True
 
 -- x - 0 ===> x
-#testOptimize [ "NatSubRightZero_3" ] ∀ (x y : Nat), x - 0 ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubRightZero_3", proof ] ∀ (x y : Nat), x - 0 ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- x - Nat.zero ===> x
-#testOptimize [ "NatSubRightZero_4" ] ∀ (x y : Nat), x - Nat.zero ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubRightZero_4", proof ]
+  ∀ (x y : Nat), x - Nat.zero ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- x - 0 ===> x
-#testOptimize [ "NatSubRightZero_5" ] ∀ (x y : Nat), x - 0 ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubRightZero_5", proof ] ∀ (x y : Nat), x - 0 ≤ y ===> ∀ (x y : Nat), ¬ y < x
 
 -- x - (27 - 27) ===> x
-#testOptimize [ "NatSubRightZero_6" ] ∀ (x y : Nat), x - (27 - 27) ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubRightZero_6", proof ]
+  ∀ (x y : Nat), x - (27 - 27) ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- x - (27 - 145) ===> x
-#testOptimize [ "NatSubRightZero_7" ] ∀ (x y : Nat), x - (27 - 145) ≤ y ===> ∀ (x y : Nat), ¬ y < x
+#testOptimize [ "NatSubRightZero_7", proof ]
+  ∀ (x y : Nat), x - (27 - 145) ≤ y ===>
+  ∀ (x y : Nat), ¬ y < x
 
 -- x - 1 ===> x - 1
 def natSubRightZeroUnchanged_1 : Expr :=
@@ -207,13 +230,16 @@ def natSubRightZeroUnchanged_1 : Expr :=
 
 elab "natSubRightZeroUnchanged_1" : term => return natSubRightZeroUnchanged_1
 
-#testOptimize [ "NatSubRightZeroUnchanged_1" ] ∀ (x y : Nat), (x - 1) < y ===> natSubRightZeroUnchanged_1
+#testOptimize [ "NatSubRightZeroUnchanged_1", proof ]
+  ∀ (x y : Nat), (x - 1) < y ===> natSubRightZeroUnchanged_1
 
 -- x - (127 - 126) ===> x - 1
-#testOptimize [ "NatSubRightZeroUnchanged_2" ] ∀ (x y : Nat), x - (127 - 126) < y ===> natSubRightZeroUnchanged_1
+#testOptimize [ "NatSubRightZeroUnchanged_2", proof ]
+  ∀ (x y : Nat), x - (127 - 126) < y ===> natSubRightZeroUnchanged_1
 
 -- x - (Nat.zero + 1) ===> x - 1
-#testOptimize [ "NatSubRightZeroUnchanged_3" ] ∀ (x y : Nat), x - (Nat.zero + 1) < y ===> natSubRightZeroUnchanged_1
+#testOptimize [ "NatSubRightZeroUnchanged_3", proof ]
+  ∀ (x y : Nat), x - (Nat.zero + 1) < y ===> natSubRightZeroUnchanged_1
 
 -- x - (127 - 40) ===> x - 87
 def natSubRightZeroUnchanged_4 : Expr :=
@@ -235,13 +261,14 @@ def natSubRightZeroUnchanged_4 : Expr :=
 
 elab "natSubRightZeroUnchanged_4" : term => return natSubRightZeroUnchanged_4
 
-#testOptimize [ "NatSubRightZeroUnchanged_4" ] ∀ (x y : Nat), x - (127 - 40) < y ===> natSubRightZeroUnchanged_4
+#testOptimize [ "NatSubRightZeroUnchanged_4", proof ]
+  ∀ (x y : Nat), x - (127 - 40) < y ===> natSubRightZeroUnchanged_4
 
 
 /-! Test cases for simplification rule `N1 - (N2 + n) ===> (N1 "-" N2) - n`. -/
 
 -- 120 - (40 + x) = 80 - x ===> True
-#testOptimize [ "NatSubAdd_1" ] ∀ (x : Nat), 120 - (40 + x) = 80 - x ===> True
+#testOptimize [ "NatSubAdd_1", proof ] ∀ (x : Nat), 120 - (40 + x) = 80 - x ===> True
 
 -- 120 - (40 + x) ===> 80 - x
 def natSubAdd_2 : Expr :=
@@ -263,37 +290,39 @@ def natSubAdd_2 : Expr :=
 
 elab "natSubAdd_2" : term => return natSubAdd_2
 
-#testOptimize [ "NatSubAdd_2" ] ∀ (x y : Nat), 120 - (40 + x) < y ===> natSubAdd_2
+#testOptimize [ "NatSubAdd_2", proof ] ∀ (x y : Nat), 120 - (40 + x) < y ===> natSubAdd_2
 
 -- 120 - (x + 40) = 80 - x ===> True
-#testOptimize [ "NatSubAdd_3" ] ∀ (x : Nat), 120 - (x + 40) = 80 - x ===> True
+#testOptimize [ "NatSubAdd_3", proof ] ∀ (x : Nat), 120 - (x + 40) = 80 - x ===> True
 
 -- 120 - (140 + x) = 0 ===> True
-#testOptimize [ "NatSubAdd_4" ] ∀ (x : Nat), 120 - (140 + x) = 0 ===> True
+#testOptimize [ "NatSubAdd_4", proof ] ∀ (x : Nat), 120 - (140 + x) = 0 ===> True
 
 -- 120 - (10 + (30 + x)) = 80 - x ===> True
-#testOptimize [ "NatSubAdd_5" ] ∀ (x : Nat), 120 - (10 + (30 + x)) = 80 - x ===> True
+#testOptimize [ "NatSubAdd_5", proof ] ∀ (x : Nat), 120 - (10 + (30 + x)) = 80 - x ===> True
 
 -- 120 - (10 + (x + 30)) = 80 - x ===> True
-#testOptimize [ "NatSubAdd_6" ] ∀ (x : Nat), 120 - (10 + (x + 30)) = 80 - x ===> True
+#testOptimize [ "NatSubAdd_6", proof ] ∀ (x : Nat), 120 - (10 + (x + 30)) = 80 - x ===> True
 
 -- 120 - (10 - (50 + x)) = 120 ===> True
-#testOptimize [ "NatSubAdd_7" ] ∀ (x : Nat), 120 - (10 - (50 + x)) = 120 ===> True
+#testOptimize [ "NatSubAdd_7", proof ] ∀ (x : Nat), 120 - (10 - (50 + x)) = 120 ===> True
 
 -- (250 - (150 + x)) - 20 = 80 - x ===> True
-#testOptimize [ "NatSubAdd_8" ] ∀ (x : Nat), (250 - (150 + x)) - 20 = 80 - x ===> True
+#testOptimize [ "NatSubAdd_8", proof ] ∀ (x : Nat), (250 - (150 + x)) - 20 = 80 - x ===> True
 
 -- 120 - (10 + (5 + (25 + x))) = 80 - x ===> True
-#testOptimize [ "NatSubAdd_9" ] ∀ (x : Nat), 120 - (10 + (5 + (25 + x))) = 80 - x ===> True
+#testOptimize [ "NatSubAdd_9", proof ] ∀ (x : Nat), 120 - (10 + (5 + (25 + x))) = 80 - x ===> True
 
 -- 120 - (10 + (150 - (100 + x))) = 110 - (50 - x) ===> True
-#testOptimize [ "NatSubAdd_10" ] ∀ (x : Nat), 120 - (10 + (150 - (100 + x))) = 110 - (50 - x) ===> True
+#testOptimize [ "NatSubAdd_10", proof ]
+  ∀ (x : Nat), 120 - (10 + (150 - (100 + x))) = 110 - (50 - x) ===> True
 
 -- 120 - (10 + (50 - (x + 100))) = 110 ===> True
-#testOptimize [ "NatSubAdd_11" ] ∀ (x : Nat), 120 - (10 + (50 - (x + 100))) = 110 ===> True
+#testOptimize [ "NatSubAdd_11", proof ] ∀ (x : Nat), 120 - (10 + (50 - (x + 100))) = 110 ===> True
 
 -- 120 - (25 + ((x - 3) - 2)) = 95 - (x - 5) ===> True
-#testOptimize [ "NatSubAdd_12" ] ∀ (x : Nat), 120 - (25 + ((x - 3) - 2)) = 95 - (x - 5) ===> True
+#testOptimize [ "NatSubAdd_12", proof ]
+  ∀ (x : Nat), 120 - (25 + ((x - 3) - 2)) = 95 - (x - 5) ===> True
 
 
 /-! Test cases to ensure that simplification rule `N1 - (N2 + n) ===> (N1 "-" N2) - n`
@@ -323,7 +352,8 @@ def natSubAddUnchanged_1 : Expr :=
 
 elab "natSubAddUnchanged_1" : term => return natSubAddUnchanged_1
 
-#testOptimize [ "NatSubAddUnchanged_1" ] ∀ (x y : Nat), 120 - (x - y) < y ===> natSubAddUnchanged_1
+#testOptimize [ "NatSubAddUnchanged_1", proof ]
+  ∀ (x y : Nat), 120 - (x - y) < y ===> natSubAddUnchanged_1
 
 -- 120 - (x + y) ===> 120 - (x + y)
 -- Must remain unchanged
@@ -348,7 +378,8 @@ def natSubAddUnchanged_2 : Expr :=
 
 elab "natSubAddUnchanged_2" : term => return natSubAddUnchanged_2
 
-#testOptimize [ "NatSubAddUnchanged_2" ] ∀ (x y : Nat), 120 - (x + y) < y ===> natSubAddUnchanged_2
+#testOptimize [ "NatSubAddUnchanged_2", proof ]
+  ∀ (x y : Nat), 120 - (x + y) < y ===> natSubAddUnchanged_2
 
 -- 120 - (x * y) ===> 120 - (x * y)
 -- Must remain unchanged
@@ -373,7 +404,8 @@ def natSubAddUnchanged_3 : Expr :=
 
 elab "natSubAddUnchanged_3" : term => return natSubAddUnchanged_3
 
-#testOptimize [ "NatSubAddUnchanged_3" ] ∀ (x y : Nat), 120 - (x * y) < y ===> natSubAddUnchanged_3
+#testOptimize [ "NatSubAddUnchanged_3", proof ]
+  ∀ (x y : Nat), 120 - (x * y) < y ===> natSubAddUnchanged_3
 
 -- 120 - (30 - x) ===> 120 - (30 - x)
 -- Must remain unchanged
@@ -398,12 +430,13 @@ def natSubAddUnchanged_4 : Expr :=
 
 elab "natSubAddUnchanged_4" : term => return natSubAddUnchanged_4
 
-#testOptimize [ "NatSubAddUnchanged_4" ] ∀ (x y : Nat), 120 - (30 - x) < y ===> natSubAddUnchanged_4
+#testOptimize [ "NatSubAddUnchanged_4", proof ]
+  ∀ (x y : Nat), 120 - (30 - x) < y ===> natSubAddUnchanged_4
 
 /-! Test cases for simplification rule `(N1 - n) - N2 ===> (N1 "-" N2) - n`. -/
 
 -- (20 - x) - 10 = 10 - x ===> True
-#testOptimize [ "NatSubSubLeft_1" ] ∀ (x : Nat), (20 - x) - 10 = 10 - x ===> True
+#testOptimize [ "NatSubSubLeft_1", proof ] ∀ (x : Nat), (20 - x) - 10 = 10 - x ===> True
 
 -- (20 - x) - 10 ===> 10 - x
 def natSubSubLeft_2 : Expr :=
@@ -425,34 +458,38 @@ def natSubSubLeft_2 : Expr :=
 
 elab "natSubSubLeft_2" : term => return natSubSubLeft_2
 
-#testOptimize [ "NatSubSubLeft_2" ] ∀ (x y : Nat), (20 - x) - 10 < y ===> natSubSubLeft_2
+#testOptimize [ "NatSubSubLeft_2", proof ] ∀ (x y : Nat), (20 - x) - 10 < y ===> natSubSubLeft_2
 
 -- (45 - x) - 125 = 0 ===> True
-#testOptimize [ "NatSubSubLeft_3" ] ∀ (x : Nat), (45 - x) - 125 = 0 ===> True
+#testOptimize [ "NatSubSubLeft_3", proof ] ∀ (x : Nat), (45 - x) - 125 = 0 ===> True
 
 -- ((20 - x) - 5) - 10 = 5 - x ===> True
-#testOptimize [ "NatSubSubLeft_4" ] ∀ (x : Nat), ((20 - x) - 5) - 10 = 5 - x ===> True
+#testOptimize [ "NatSubSubLeft_4", proof ] ∀ (x : Nat), ((20 - x) - 5) - 10 = 5 - x ===> True
 
 -- 10 - ((20 - x) - 5) = 10 - (15 - x) ===> True
-#testOptimize [ "NatSubSubLeft_5" ] ∀ (x : Nat), 10 - ((20 - x) - 5) = 10 - (15 - x) ===> True
+#testOptimize [ "NatSubSubLeft_5", proof ]
+  ∀ (x : Nat), 10 - ((20 - x) - 5) = 10 - (15 - x) ===> True
 
 -- (20 - (3 + x)) - 10 = 7 - x ===> True
-#testOptimize [ "NatSubSubLeft_6" ] ∀ (x : Nat), (20 - (3 + x)) - 10 = 7 - x ===> True
+#testOptimize [ "NatSubSubLeft_6", proof ] ∀ (x : Nat), (20 - (3 + x)) - 10 = 7 - x ===> True
 
 -- 20 - ((15 - (x + 10)) - 2) = 20 - (3 - x) ===> True
-#testOptimize [ "NatSubSubLeft_7" ] ∀ (x : Nat), (20 - ((15 - (x + 10)) - 2)) = 20 - (3 - x) ===> True
+#testOptimize [ "NatSubSubLeft_7", proof ]
+  ∀ (x : Nat), (20 - ((15 - (x + 10)) - 2)) = 20 - (3 - x) ===> True
 
 -- 20 - (((30 - x) - 4) - 10) = 20 - (16 - x) ===> True
-#testOptimize [ "NatSubSubLeft_8" ] ∀ (x : Nat), 20 - (((30 - x) - 4) - 10) = 20 - (16 - x) ===> True
+#testOptimize [ "NatSubSubLeft_8", proof ]
+  ∀ (x : Nat), 20 - (((30 - x) - 4) - 10) = 20 - (16 - x) ===> True
 
 -- ((200 - (150 + x)) - 20) - 10 = 20 - x ===> True
-#testOptimize [ "NatSubSubLeft_9" ] ∀ (x : Nat), ((200 - (150 + x)) - 20) - 10 = 20 - x ===> True
+#testOptimize [ "NatSubSubLeft_9", proof ]
+  ∀ (x : Nat), ((200 - (150 + x)) - 20) - 10 = 20 - x ===> True
 
 
 /-! Test cases for simplification rule `(n - N1) - N2 ===> n - (N1 "+" N2)`. -/
 
 -- (x - 20) - 10 = x - 30 ===> True
-#testOptimize [ "NatSubSubRight_1" ] ∀ (x : Nat), (x - 20) - 10 = x - 30 ===> True
+#testOptimize [ "NatSubSubRight_1", proof ] ∀ (x : Nat), (x - 20) - 10 = x - 30 ===> True
 
 -- (x - 20) - 10 ===> x - 30
 def natSubSubRight_2 : Expr :=
@@ -474,31 +511,34 @@ def natSubSubRight_2 : Expr :=
 
 elab "natSubSubRight_2" : term => return natSubSubRight_2
 
-#testOptimize [ "NatSubSubRight_2" ] ∀ (x y : Nat), (x - 20) - 10 < y ===> natSubSubRight_2
+#testOptimize [ "NatSubSubRight_2", proof ] ∀ (x y : Nat), (x - 20) - 10 < y ===> natSubSubRight_2
 
 -- ((x - 100) - 45) - 125 = x - 270 ===> True
-#testOptimize [ "NatSubSubRight_3" ] ∀ (x : Nat), ((x - 100) - 45) - 125 = x - 270 ===> True
+#testOptimize [ "NatSubSubRight_3", proof ] ∀ (x : Nat), ((x - 100) - 45) - 125 = x - 270 ===> True
 
 -- ((200 - x) - 45) - 125 = 30 - x ===> True
-#testOptimize [ "NatSubSubRight_4" ] ∀ (x : Nat), ((200 - x) - 45) - 125 = 30 - x ===> True
+#testOptimize [ "NatSubSubRight_4", proof ] ∀ (x : Nat), ((200 - x) - 45) - 125 = 30 - x ===> True
 
 -- ((100 - x) - 45) - 125 = 0 ===> True
-#testOptimize [ "NatSubSubRight_5" ] ∀ (x : Nat), ((100 - x) - 45) - 125 = 0 ===> True
+#testOptimize [ "NatSubSubRight_5", proof ] ∀ (x : Nat), ((100 - x) - 45) - 125 = 0 ===> True
 
 -- ((x - 200) - 45) - ((125 - x) - 130) = x - 245 ===> True
-#testOptimize [ "NatSubSubRight_6" ] ∀ (x : Nat), ((x - 200) - 45) - ((125 - x) - 130) = x - 245 ===> True
+#testOptimize [ "NatSubSubRight_6", proof ]
+  ∀ (x : Nat), ((x - 200) - 45) - ((125 - x) - 130) = x - 245 ===> True
 
 -- (((x - 60) - 40) - 45) - 125 = x - 270 ===> True
-#testOptimize [ "NatSubSubRight_7" ] ∀ (x : Nat), (((x - 60) - 40) - 45) - 125 = x - 270 ===> True
+#testOptimize [ "NatSubSubRight_7", proof ]
+  ∀ (x : Nat), (((x - 60) - 40) - 45) - 125 = x - 270 ===> True
 
 -- (100 - ((x - 100) - 45)) = 100 - (x - 145) ===> True
-#testOptimize [ "NatSubSubRight_8" ] ∀ (x : Nat), (100 - ((x - 100) - 45)) = 100 - (x - 145) ===> True
+#testOptimize [ "NatSubSubRight_8", proof ]
+  ∀ (x : Nat), (100 - ((x - 100) - 45)) = 100 - (x - 145) ===> True
 
 
 /-! Test cases for simplification rule `(N1 + n) - N2 ===> (N1 "-" N2) + n` (if N1 ≥ N2). -/
 
 -- (100 + x) - 20 = 80 + x
-#testOptimize [ "NatAddSub_1" ] ∀ (x : Nat), (100 + x) - 20 = 80 + x ===> True
+#testOptimize [ "NatAddSub_1", proof ] ∀ (x : Nat), (100 + x) - 20 = 80 + x ===> True
 
 -- (100 + x) - 20 ===> 80 + x
 def natAddSub_2 : Expr :=
@@ -520,25 +560,26 @@ def natAddSub_2 : Expr :=
 
 elab "natAddSub_2" : term => return natAddSub_2
 
-#testOptimize [ "NatAddSub_2" ] ∀ (x y : Nat), (100 + x) - 20 < y ===> natAddSub_2
+#testOptimize [ "NatAddSub_2", proof ] ∀ (x y : Nat), (100 + x) - 20 < y ===> natAddSub_2
 
 -- (120 + x) - 120 = x ===> True
-#testOptimize [ "NatAddSub_3" ] ∀ (x : Nat), (120 + x) - 120 = x ===> True
+#testOptimize [ "NatAddSub_3", proof ] ∀ (x : Nat), (120 + x) - 120 = x ===> True
 
 -- ((200 + x) - 120) - 20 = 60 + x ===> True
-#testOptimize [ "NatAddSub_4" ] ∀ (x : Nat), ((200 + x) - 120) - 20 = 60 + x ===> True
+#testOptimize [ "NatAddSub_4", proof ] ∀ (x : Nat), ((200 + x) - 120) - 20 = 60 + x ===> True
 
 -- (50 + (100 + x)) - 120 = 30 + x ===> True
-#testOptimize [ "NatAddSub_5" ] ∀ (x : Nat), (50 + (100 + x)) - 120 = 30 + x ===> True
+#testOptimize [ "NatAddSub_5", proof ] ∀ (x : Nat), (50 + (100 + x)) - 120 = 30 + x ===> True
 
 -- (50 + (40 + (x + 60))) - 120 = 30 + x ===> True
-#testOptimize [ "NatAddSub_6" ] ∀ (x : Nat), (50 + (40 + (x + 60))) - 120 = 30 + x ===> True
+#testOptimize [ "NatAddSub_6", proof ] ∀ (x : Nat), (50 + (40 + (x + 60))) - 120 = 30 + x ===> True
 
 -- (((230 + x) - 20) - 120) - 40 = 50 + x ===> True
-#testOptimize [ "NatAddSub_7" ] ∀ (x : Nat), (((230 + x) - 20) - 120) - 40 = 50 + x ===> True
+#testOptimize [ "NatAddSub_7", proof ] ∀ (x : Nat), (((230 + x) - 20) - 120) - 40 = 50 + x ===> True
 
 -- (((x + 180) - 100) - 20) + 120 = 180 + x ===> True
-#testOptimize [ "NatAddSub_8" ] ∀ (x : Nat), (((x + 180) - 100) - 20) + 120 = 180 + x ===> True
+#testOptimize [ "NatAddSub_8", proof ]
+  ∀ (x : Nat), (((x + 180) - 100) - 20) + 120 = 180 + x ===> True
 
 /-! Test cases to ensure that the following simplification rules are not applied wrongly:
      - `(N1 - n) - N2 ===> (N1 "-" N2) - n`
@@ -570,7 +611,8 @@ def natSubSubUnchanged_1 : Expr :=
 
 elab "natSubSubUnchanged_1" : term => return natSubSubUnchanged_1
 
-#testOptimize [ "NatSubSunUnchanged_1" ] ∀ (x y : Nat), (x - y) - 120 < y ===> natSubSubUnchanged_1
+#testOptimize [ "NatSubSunUnchanged_1", proof ]
+  ∀ (x y : Nat), (x - y) - 120 < y ===> natSubSubUnchanged_1
 
 -- (x + y) - 120 ===> (x + y) - 120
 -- Must remain unchanged
@@ -596,7 +638,8 @@ def natSubSubUnchanged_2 : Expr :=
 
 elab "natSubSubUnchanged_2" : term => return natSubSubUnchanged_2
 
-#testOptimize [ "NatSubSunUnchanged_2" ] ∀ (x y : Nat), (x + y) - 120 < y ===> natSubSubUnchanged_2
+#testOptimize [ "NatSubSunUnchanged_2", proof ]
+  ∀ (x y : Nat), (x + y) - 120 < y ===> natSubSubUnchanged_2
 
 -- (x * y) - 120  ===> (x * y) - 120
 -- Must remain unchanged
@@ -622,7 +665,8 @@ def natSubSubUnchanged_3 : Expr :=
 
 elab "natSubSubUnchanged_3" : term => return natSubSubUnchanged_3
 
-#testOptimize [ "NatSubSunUnchanged_3" ] ∀ (x y : Nat), (x * y) - 120 < y ===> natSubSubUnchanged_3
+#testOptimize [ "NatSubSunUnchanged_3", proof ]
+  ∀ (x y : Nat), (x * y) - 120 < y ===> natSubSubUnchanged_3
 
 -- 100 - (10 - x) ===> 100 - (10 - x)
 -- Must remain unchanged
@@ -648,7 +692,8 @@ def natSubSubUnchanged_4 : Expr :=
 
 elab "natSubSubUnchanged_4" : term => return natSubSubUnchanged_4
 
-#testOptimize [ "NatSubSunUnchanged_4" ] ∀ (x y : Nat), 100 - (10 - x) < y ===> natSubSubUnchanged_4
+#testOptimize [ "NatSubSunUnchanged_4", proof ]
+  ∀ (x y : Nat), 100 - (10 - x) < y ===> natSubSubUnchanged_4
 
 
 -- (100 + x) - 101 ===> (100 + x) - 101
@@ -676,7 +721,8 @@ def natSubSubUnchanged_5 : Expr :=
 
 elab "natSubSubUnchanged_5" : term => return natSubSubUnchanged_5
 
-#testOptimize [ "NatSubSunUnchanged_5" ] ∀ (x y : Nat), (100 + x) - 101 < y ===> natSubSubUnchanged_5
+#testOptimize [ "NatSubSunUnchanged_5", proof ]
+  ∀ (x y : Nat), (100 + x) - 101 < y ===> natSubSubUnchanged_5
 
 -- (100 + x) - 180 ===> (100 + x) - 180
 -- Must remain unchanged
@@ -703,28 +749,32 @@ def natSubSubUnchanged_6 : Expr :=
 
 elab "natSubSubUnchanged_6" : term => return natSubSubUnchanged_6
 
-#testOptimize [ "NatSubSunUnchanged_6" ] ∀ (x y : Nat), (100 + x) - 180 < y ===> natSubSubUnchanged_6
+#testOptimize [ "NatSubSunUnchanged_6", proof ]
+  ∀ (x y : Nat), (100 + x) - 180 < y ===> natSubSubUnchanged_6
 
 
 /-! Test cases to ensure that `Nat.sub` is preserved when expected and is not a commutative operator. -/
 
 -- x - y ===> x - y
-#testOptimize [ "NatSubVar_1" ] ∀ (x y z : Nat), x - y < z ===> ∀ (x y z : Nat), Nat.sub x y < z
+#testOptimize [ "NatSubVar_1", proof ]
+  ∀ (x y z : Nat), x - y < z ===> ∀ (x y z : Nat), Nat.sub x y < z
 
 -- x - y = x - y ===> True
-#testOptimize [ "NatSubVar_2" ] ∀ (x y : Nat), x - y = x - y ===> True
+#testOptimize [ "NatSubVar_2", proof ] ∀ (x y : Nat), x - y = x - y ===> True
 
 -- x - (y - 0) ===> x - y
-#testOptimize [ "NatSubVar_3" ] ∀ (x y z : Nat), x - (y - 0) < z ===> ∀ (x y z : Nat), Nat.sub x y < z
+#testOptimize [ "NatSubVar_3", proof ]
+  ∀ (x y z : Nat), x - (y - 0) < z ===> ∀ (x y z : Nat), Nat.sub x y < z
 
 -- (x - 0) - y ===> x - y
-#testOptimize [ "NatSubVar_4" ] ∀ (x y z : Nat), (x - 0) - y < z ===> ∀ (x y z : Nat), Nat.sub x y < z
+#testOptimize [ "NatSubVar_4", proof ]
+  ∀ (x y z : Nat), (x - 0) - y < z ===> ∀ (x y z : Nat), Nat.sub x y < z
 
 -- (x - 0) - (y - 0) = x - y ===> True
-#testOptimize [ "NatSubVar_5" ] ∀ (x y : Nat), (x - 0) - (y - 0) = x - y ===> True
+#testOptimize [ "NatSubVar_5", proof ] ∀ (x y : Nat), (x - 0) - (y - 0) = x - y ===> True
 
 -- (x - 10) - y = (x - 10) - y ===> True
-#testOptimize [ "NatSubVar_6" ] ∀ (x y : Nat), (x - 10) - y = (x - 10) - y ===> True
+#testOptimize [ "NatSubVar_6", proof ] ∀ (x y : Nat), (x - 10) - y = (x - 10) - y ===> True
 
 -- (x - 10) - y ===> (x - 10) - y
 def natSubVar_7 : Expr :=
@@ -753,7 +803,7 @@ def natSubVar_7 : Expr :=
 
 elab "natSubVar_7" : term => return natSubVar_7
 
-#testOptimize [ "NatSubVar_7" ] ∀ (x y z : Nat), (x - 10) - y < z ===> natSubVar_7
+#testOptimize [ "NatSubVar_7", proof ] ∀ (x y z : Nat), (x - 10) - y < z ===> natSubVar_7
 
 
 /-! Test cases to ensure that constant propagation is properly performed
@@ -767,12 +817,14 @@ variable (y : Nat)
 def natSubReduce_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 100)
 elab "natSubReduce_1" : term => return natSubReduce_1
 
-#testOptimize [ "NatSubReduce_1" ] (100 + ((180 - (x + 40)) - 150)) - ((200 - y) - 320) ===> natSubReduce_1
+#testOptimize [ "NatSubReduce_1", proof ]
+  (100 + ((180 - (x + 40)) - 150)) - ((200 - y) - 320) ===> natSubReduce_1
 
 def natSubReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 76)
 elab "natSubReduce_2" : term => return natSubReduce_2
 
 -- (100 + ((180 - (x + 40)) - 150)) - (((20 - y) - 50) + 24) ===> 76
-#testOptimize [ "NatSubReduce_2" ] (100 + ((180 - (x + 40)) - 150)) - (((20 - y) - 50) + 24)  ===> natSubReduce_2
+#testOptimize [ "NatSubReduce_2", proof ]
+  (100 + ((180 - (x + 40)) - 150)) - (((20 - y) - 50) + 24)  ===> natSubReduce_2
 
 end Test.OptimizeNatSub

--- a/Tests/Optimize/OptimizeNat/OptimizeNatSucc.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatSucc.lean
@@ -85,10 +85,11 @@ elab "natSuccNorm_3" : term => return natSuccNorm_3
 #testOptimize [ "NatSuccNorm_3", proof ] ∀ (x y : Nat), (Nat.succ x) < y ===> natSuccNorm_3
 
 -- Nat.succ (Nat.succ x) = x + 2 ===> True
-#testOptimize [ "NatSuccNorm_4" ] ∀ (x : Nat), Nat.succ (Nat.succ x) = x + 2 ===> True
+#testOptimize [ "NatSuccNorm_4", proof] ∀ (x : Nat), Nat.succ (Nat.succ x) = x + 2 ===> True
 
 -- Nat.succ (Nat.succ (Nat.succ x)) = x + 3 ===> True
-#testOptimize [ "NatSuccNorm_5" ] ∀ (x : Nat), Nat.succ (Nat.succ (Nat.succ x)) = x + 3 ===> True
+#testOptimize [ "NatSuccNorm_5", proof ]
+  ∀ (x : Nat), Nat.succ (Nat.succ (Nat.succ x)) = x + 3 ===> True
 
 -- Nat.succ (x + y) = (x + y) + 1 ===> True
 #testOptimize [ "NatSuccNorm_6", proof ] ∀ (x y : Nat), Nat.succ (x + y) = (x + y) + 1 ===> True
@@ -97,13 +98,16 @@ elab "natSuccNorm_3" : term => return natSuccNorm_3
 #testOptimize [ "NatSuccNorm_7", proof ] ∀ (x y : Nat), Nat.succ (x - y) = (x - y) + 1 ===> True
 
 -- Nat.succ (Nat.succ (x + y)) = 2 + (x + y) ===> True
-#testOptimize [ "NatSuccNorm_8" ] ∀ (x y : Nat), Nat.succ (Nat.succ (x + y)) = (x + y) + 2 ===> True
+#testOptimize [ "NatSuccNorm_8", proof ]
+  ∀ (x y : Nat), Nat.succ (Nat.succ (x + y)) = (x + y) + 2 ===> True
 
 -- Nat.succ (Nat.succ (x - y)) = 2 + (x - y) ===> True
-#testOptimize [ "NatSuccNorm_9" ] ∀ (x y : Nat), Nat.succ (Nat.succ (x - y)) = (x - y) + 2 ===> True
+#testOptimize [ "NatSuccNorm_9", proof ]
+  ∀ (x y : Nat), Nat.succ (Nat.succ (x - y)) = (x - y) + 2 ===> True
 
 -- Nat.succ (Nat.pred (Nat.succ x)) = 1 + x ===> True
-#testOptimize [ "NatSuccNorm_10" ] ∀ (x : Nat), Nat.succ (Nat.pred (Nat.succ x)) = 1 + x ===> True
+#testOptimize [ "NatSuccNorm_10", proof ]
+  ∀ (x : Nat), Nat.succ (Nat.pred (Nat.succ x)) = 1 + x ===> True
 
 
 /-! Test cases to ensure that `reduceApp` is properly called

--- a/Tests/Optimize/OptimizeNat/OptimizeNatSucc.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatSucc.lean
@@ -13,55 +13,55 @@ namespace Test.OptimizeNatSucc
 def natSuccCst_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 1)
 elab "natSuccCst_1" : term => return natSuccCst_1
 
-#testOptimize [ "NatSuccCst_1" ] Nat.succ Nat.zero ===> natSuccCst_1
+#testOptimize [ "NatSuccCst_1", proof ] Nat.succ Nat.zero ===> natSuccCst_1
 
 -- Nat.succ Nat.zero = 1 ===> True
-#testOptimize [ "NatSuccCst_2" ] Nat.succ Nat.zero = 1 ===> True
+#testOptimize [ "NatSuccCst_2", proof ] Nat.succ Nat.zero = 1 ===> True
 
 -- Nat.succ 0 ===> 1
-#testOptimize [ "NatSuccCst_3" ] Nat.succ 0 ===> natSuccCst_1
+#testOptimize [ "NatSuccCst_3", proof ] Nat.succ 0 ===> natSuccCst_1
 
 -- Nat.succ 0 = 1 ===> True
-#testOptimize [ "NatSuccCst_4" ] Nat.succ 0 = 1 ===> True
+#testOptimize [ "NatSuccCst_4", proof ] Nat.succ 0 = 1 ===> True
 
 -- Nat.succ 10 ===> 11
 def natSuccCst_5 : Expr := Lean.Expr.lit (Lean.Literal.natVal 11)
 elab "natSuccCst_5" : term => return natSuccCst_5
 
-#testOptimize [ "NatSuccCst_5" ] Nat.succ 10 ===> natSuccCst_5
+#testOptimize [ "NatSuccCst_5", proof ] Nat.succ 10 ===> natSuccCst_5
 
 -- Nat.succ (Nat.succ 10) ===> 12
 def natSuccCst_6 : Expr := Lean.Expr.lit (Lean.Literal.natVal 12)
 elab "natSuccCst_6" : term => return natSuccCst_6
 
-#testOptimize [ "NatSuccCst_6" ] Nat.succ (Nat.succ 10) ===> natSuccCst_6
+#testOptimize [ "NatSuccCst_6", proof ] Nat.succ (Nat.succ 10) ===> natSuccCst_6
 
 -- Nat.succ (Nat.succ (Nat.succ 10)) ===> 13
 def natSuccCst_7 : Expr := Lean.Expr.lit (Lean.Literal.natVal 13)
 elab "natSuccCst_7" : term => return natSuccCst_7
 
-#testOptimize [ "NatSuccCst_7" ] Nat.succ (Nat.succ (Nat.succ 10)) ===> natSuccCst_7
+#testOptimize [ "NatSuccCst_7", proof ] Nat.succ (Nat.succ (Nat.succ 10)) ===> natSuccCst_7
 
 -- Nat.succ (10 + 20) ===> 31
 def natSuccCst_8 : Expr := Lean.Expr.lit (Lean.Literal.natVal 31)
 elab "natSuccCst_8" : term => return natSuccCst_8
 
-#testOptimize [ "NatSuccCst_8" ] Nat.succ (10 + 20) ===> natSuccCst_8
+#testOptimize [ "NatSuccCst_8", proof ] Nat.succ (10 + 20) ===> natSuccCst_8
 
 -- Nat.succ (Nat.pred 10) ===> 10
 def natSuccCst_9 : Expr := Lean.Expr.lit (Lean.Literal.natVal 10)
 elab "natSuccCst_9" : term => return natSuccCst_9
 
-#testOptimize [ "NatSuccCst_9" ] Nat.succ (Nat.pred 10) ===> natSuccCst_9
+#testOptimize [ "NatSuccCst_9", proof ] Nat.succ (Nat.pred 10) ===> natSuccCst_9
 
 
 /-! Test cases for normalization rule on ` ``Nat.succ n ===> 1 + n `. -/
 
 -- Nat.succ x = x + 1 ===> True
-#testOptimize [ "NatSuccNorm_1" ] ∀ (x : Nat), (Nat.succ x) = x + 1 ===> True
+#testOptimize [ "NatSuccNorm_1", proof ] ∀ (x : Nat), (Nat.succ x) = x + 1 ===> True
 
 -- Nat.succ x = 1 + x ===> True
-#testOptimize [ "NatSuccNorm_2" ] ∀ (x : Nat), (Nat.succ x) = 1 + x ===> True
+#testOptimize [ "NatSuccNorm_2", proof ] ∀ (x : Nat), (Nat.succ x) = 1 + x ===> True
 
 -- Nat.succ x ===> 1 + x
 def natSuccNorm_3 : Expr :=
@@ -82,7 +82,7 @@ def natSuccNorm_3 : Expr :=
   (Lean.BinderInfo.default)
 elab "natSuccNorm_3" : term => return natSuccNorm_3
 
-#testOptimize [ "NatSuccNorm_3" ] ∀ (x y : Nat), (Nat.succ x) < y ===> natSuccNorm_3
+#testOptimize [ "NatSuccNorm_3", proof ] ∀ (x y : Nat), (Nat.succ x) < y ===> natSuccNorm_3
 
 -- Nat.succ (Nat.succ x) = x + 2 ===> True
 #testOptimize [ "NatSuccNorm_4" ] ∀ (x : Nat), Nat.succ (Nat.succ x) = x + 2 ===> True
@@ -91,10 +91,10 @@ elab "natSuccNorm_3" : term => return natSuccNorm_3
 #testOptimize [ "NatSuccNorm_5" ] ∀ (x : Nat), Nat.succ (Nat.succ (Nat.succ x)) = x + 3 ===> True
 
 -- Nat.succ (x + y) = (x + y) + 1 ===> True
-#testOptimize [ "NatSuccNorm_6" ] ∀ (x y : Nat), Nat.succ (x + y) = (x + y) + 1 ===> True
+#testOptimize [ "NatSuccNorm_6", proof ] ∀ (x y : Nat), Nat.succ (x + y) = (x + y) + 1 ===> True
 
 -- Nat.succ (x - y) = (x - y) + 1 ===> True
-#testOptimize [ "NatSuccNorm_7" ] ∀ (x y : Nat), Nat.succ (x - y) = (x - y) + 1 ===> True
+#testOptimize [ "NatSuccNorm_7", proof ] ∀ (x y : Nat), Nat.succ (x - y) = (x - y) + 1 ===> True
 
 -- Nat.succ (Nat.succ (x + y)) = 2 + (x + y) ===> True
 #testOptimize [ "NatSuccNorm_8" ] ∀ (x y : Nat), Nat.succ (Nat.succ (x + y)) = (x + y) + 2 ===> True
@@ -116,12 +116,14 @@ variable (y : Nat)
 def natSuccReduce_1 : Expr := Lean.Expr.lit (Lean.Literal.natVal 101)
 elab "natSuccReduce_1" : term => return natSuccReduce_1
 
-#testOptimize [ "NatSuccReduce_1" ] Nat.succ (100 + ((180 - (x + 40)) - 150)) ===> natSuccReduce_1
+#testOptimize [ "NatSuccReduce_1", proof ]
+  Nat.succ (100 + ((180 - (x + 40)) - 150)) ===> natSuccReduce_1
 
 def natSuccReduce_2 : Expr := Lean.Expr.lit (Lean.Literal.natVal 125)
 elab "natSuccReduce_2" : term => return natSuccReduce_2
 
 -- Nat.succ ((100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24)) ===> 125
-#testOptimize [ "NatSuccReduce_2" ] Nat.succ ((100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24))  ===> natSuccReduce_2
+#testOptimize [ "NatSuccReduce_2", proof ]
+  Nat.succ ((100 + ((180 - (x + 40)) - 150)) + (((20 - y) - 50) + 24))  ===> natSuccReduce_2
 
 end Test.OptimizeNatSucc

--- a/Tests/Optimize/OptimizeProp/OptimizeAnd.lean
+++ b/Tests/Optimize/OptimizeProp/OptimizeAnd.lean
@@ -9,16 +9,16 @@ namespace Test.OptimizeAnd
 /-! Test cases for simplification rule `False ∧ e ==> False`. -/
 
 -- False ∧ True ===> False
-#testOptimize [ "AndFalse_1" ] False ∧ True ===> False
+#testOptimize [ "AndFalse_1", proof ] False ∧ True ===> False
 
 -- (False ∧ True) = False ===> True
-#testOptimize [ "AndFalse_2" ] (False ∧ True) = False ===> True
+#testOptimize [ "AndFalse_2", proof ] (False ∧ True) = False ===> True
 
 -- True ∧ False ===> False
 #testOptimize [ "AndFalse_3" ] True ∧ False ===> False
 
 -- False ∧ False ===> False
-#testOptimize [ "AndFalse_4" ] False ∧ False ===> False
+#testOptimize [ "AndFalse_4", proof ] False ∧ False ===> False
 
 -- a ∧ False ===> False
 #testOptimize [ "AndFalse_5" ] ∀ (a : Prop), a ∧ False ===> False
@@ -27,10 +27,10 @@ namespace Test.OptimizeAnd
 #testOptimize [ "AndFalse_6" ] ∀ (a : Prop), (a ∧ False) = False ===> True
 
 -- False ∧ a ===> False
-#testOptimize [ "AndFalse_7" ] ∀ (a : Prop), False ∧ a ===> False
+#testOptimize [ "AndFalse_7", proof ] ∀ (a : Prop), False ∧ a ===> False
 
 -- False ∧ (a ∧ b) ===> False
-#testOptimize [ "AndFalse_8" ] ∀ (a b : Prop), False ∧ (a ∧ b) ===> False
+#testOptimize [ "AndFalse_8", proof ] ∀ (a b : Prop), False ∧ (a ∧ b) ===> False
 
 -- (a ∨ b) ∧ False ===> False
 #testOptimize [ "AndFalse_9" ] ∀ (a b : Prop), (a ∨ b) ∧ False ===> False
@@ -39,7 +39,7 @@ namespace Test.OptimizeAnd
 #testOptimize [ "AndFalse_10" ] ∀ (a b : Prop), (a ∧ False) ∧ b ===> False
 
 -- (False ∧ a) ∧ b  ===> False
-#testOptimize [ "AndFalse_11" ] ∀ (a b : Prop), (False ∧ a) ∧ b ===> False
+#testOptimize [ "AndFalse_11", proof ] ∀ (a b : Prop), (False ∧ a) ∧ b ===> False
 
 -- (a ∧ False) ∧ (a ∧ b) ===> False
 #testOptimize [ "AndFalse_12" ] ∀ (a b : Prop), (a ∧ False) ∧ (a ∧ b) ===> False
@@ -65,7 +65,7 @@ namespace Test.OptimizeAnd
 #testOptimize [ "AndTrue_1" ] True ∧ True ===> True
 
 -- (True ∧ True) = True ===> True
-#testOptimize [ "AndTrue_2" ] (True ∧ True) = True ===> True
+#testOptimize [ "AndTrue_2", proof ] (True ∧ True) = True ===> True
 
 -- a ∧ True ===> a
 #testOptimize [ "AndTrue_3" ] ∀ (a : Prop), a ∧ True ===> ∀ (a : Prop), a
@@ -74,10 +74,10 @@ namespace Test.OptimizeAnd
 #testOptimize [ "AndTrue_4" ] ∀ (a : Prop), (a ∧ True) = a ===> True
 
 -- True ∧ a ===> a
-#testOptimize [ "AndTrue_5" ] ∀ (a : Prop), True ∧ a ===> ∀ (a : Prop), a
+#testOptimize [ "AndTrue_5", proof ] ∀ (a : Prop), True ∧ a ===> ∀ (a : Prop), a
 
 -- True ∧ (a ∨ b) ===> a ∨ b
-#testOptimize [ "AndTrue_6" ] ∀ (a b : Prop), True ∧ (a ∨ b) ===> ∀ (a b : Prop), a ∨ b
+#testOptimize [ "AndTrue_6", proof ] ∀ (a b : Prop), True ∧ (a ∨ b) ===> ∀ (a b : Prop), a ∨ b
 
 -- (a ∧ b) ∧ True ==> a ∧ b
 #testOptimize [ "AndTrue_7" ] ∀ (a b : Prop), (a ∧ b) ∧ True ===> ∀ (a b : Prop), a ∧ b
@@ -86,7 +86,7 @@ namespace Test.OptimizeAnd
 #testOptimize [ "AndTrue_8" ] ∀ (a b : Prop), (a ∧ True) ∧ b ===> ∀ (a b : Prop), a ∧ b
 
 -- (True ∧ a) ∧ b ===> a ∧ b
-#testOptimize [ "AndTrue_9" ] ∀ (a b : Prop), (True ∧ a) ∧ b ===> ∀ (a b : Prop), a ∧ b
+#testOptimize [ "AndTrue_9", proof ] ∀ (a b : Prop), (True ∧ a) ∧ b ===> ∀ (a b : Prop), a ∧ b
 
 -- (a ∨ True) ∧ (a ∨ b) ===> a ∨ b
 #testOptimize [ "AndTrue_10" ] ∀ (a b : Prop), (a ∨ True) ∧ (a ∨ b) ===> ∀ (a b : Prop), a ∨ b
@@ -112,10 +112,10 @@ namespace Test.OptimizeAnd
 /-! Test cases for simplification rule `e ∧ ¬ e ==> False`. -/
 
 -- a ∧ ¬ a ===> False
-#testOptimize [ "AndNeg_1" ] ∀ (a : Prop), a ∧ ¬ a ===> False
+#testOptimize [ "AndNeg_1", proof ] ∀ (a : Prop), a ∧ ¬ a ===> False
 
 -- (a ∧ ¬ a) = False ===> True
-#testOptimize [ "AndNeg_2" ] ∀ (a : Prop), (a ∧ ¬ a) = False ===> True
+#testOptimize [ "AndNeg_2", proof ] ∀ (a : Prop), (a ∧ ¬ a) = False ===> True
 
 -- (a ∧ b) ∧ ¬ (b ∧ a) ===> False
 #testOptimize [ "AndNeg_3" ] ∀ (a b : Prop), (a ∧ b) ∧ ¬ (b ∧ a) ===> False
@@ -149,7 +149,7 @@ namespace Test.OptimizeAnd
 #testOptimize [ "AndNegUnchanged_1" ] ∀ (a b : Prop), ¬ a ∧ b ===> ∀ (a b : Prop), b ∧ ¬ a
 
 -- b ∧ ¬ a ===> b ∧ ¬ a
-#testOptimize [ "AndNegUnchanged_2" ] ∀ (a b : Prop), b ∧ ¬ a ===> ∀ (a b : Prop), b ∧ ¬ a
+#testOptimize [ "AndNegUnchanged_2", proof ] ∀ (a b : Prop), b ∧ ¬ a ===> ∀ (a b : Prop), b ∧ ¬ a
 
 -- ¬ (a ∧ b) ∧ c ===> ¬ (a ∧ b) ∧ c
 -- NOTE: reordering applied on operands
@@ -175,7 +175,7 @@ namespace Test.OptimizeAnd
 /-! Test cases for simplification rule `true = e ∧ false = e ==> False`. -/
 
 -- ∀ (a : Bool), true = a ∧ false = a ===> False
-#testOptimize [ "AndNegBoolEq_1" ] ∀ (a : Bool), true = a ∧ false = a ===> False
+#testOptimize [ "AndNegBoolEq_1", proof ] ∀ (a : Bool), true = a ∧ false = a ===> False
 
 -- ∀ (a : Bool), true = a ∧ a = false ===> False
 #testOptimize [ "AndNegBoolEq_2" ] ∀ (a : Bool), true = a ∧ a = false ===> False

--- a/Tests/Optimize/OptimizeProp/OptimizeNot.lean
+++ b/Tests/Optimize/OptimizeProp/OptimizeNot.lean
@@ -9,10 +9,10 @@ namespace Tests.OptimizeNot
 /-! Test cases for simplification rule `¬ False ==> True`. -/
 
 -- ¬ False ===> True
-#testOptimize [ "NotFalse_1" ] ¬ False ===> True
+#testOptimize [ "NotFalse_1", proof ] ¬ False ===> True
 
 -- ¬ (true = false) ===> True
-#testOptimize [ "NotFalse_2" ] ¬ (true = false) ===> True
+#testOptimize [ "NotFalse_2", proof ] ¬ (true = false) ===> True
 
 -- ¬ ((10 : Nat) = 20) ===> True
 #testOptimize [ "NotFalse_3" ] ¬ ((10 : Nat) = 20) ===> True
@@ -33,10 +33,10 @@ namespace Tests.OptimizeNot
 /-! Test cases for simplification rule `¬ True ==> False`. -/
 
 -- ¬ True ===> False
-#testOptimize [ "NotTrue_1" ] ¬ True ===> False
+#testOptimize [ "NotTrue_1", proof ] ¬ True ===> False
 
 -- ¬ (true = true) ===> False
-#testOptimize [ "NotTrue_2" ] ¬ (true = true) ===> False
+#testOptimize [ "NotTrue_2", proof ] ¬ (true = true) ===> False
 
 -- ¬ ((10 : Nat) = 10) ===> False
 #testOptimize [ "NotTrue_3" ] ¬ ((10 : Nat) = 10) ===> False
@@ -57,13 +57,13 @@ namespace Tests.OptimizeNot
 /-! Test cases for simplification rule `¬ (¬ e) ==> e`. -/
 
 -- ¬ (¬ a) ===> a
-#testOptimize [ "Not_1" ] ∀ (a : Prop), ¬ (¬ a) ===> ∀ (a : Prop), a
+#testOptimize [ "Not_1", proof ] ∀ (a : Prop), ¬ (¬ a) ===> ∀ (a : Prop), a
 
 -- ¬ (¬ a) = a ===> True
-#testOptimize [ "Not_2" ] ∀ (a : Prop), ¬ (¬ a) = a ===> True
+#testOptimize [ "Not_2", proof ] ∀ (a : Prop), (¬ (¬ a)) = a ===> True
 
 -- ¬ (¬ (¬ a)) ===> ¬ a
-#testOptimize [ "Not_3" ] ∀ (a : Prop), ¬ (¬ (¬ a)) ===> ∀ (a : Prop), ¬ a
+#testOptimize [ "Not_3", proof ] ∀ (a : Prop), ¬ (¬ (¬ a)) ===> ∀ (a : Prop), ¬ a
 
 -- ¬ (¬ (¬ (¬ a))) ===> a
 #testOptimize [ "Not_4" ] ∀ (a : Prop), ¬ (¬ (¬ (¬ a))) ===> ∀ (a : Prop), a
@@ -114,10 +114,10 @@ namespace Tests.OptimizeNot
 /-! Test cases for simplification rule `¬ (false = e) ==> true = e`. -/
 
 -- ¬ (false = a) ===> true = a (with Type(a) = Bool)
-#testOptimize [ "NotEqFalse_1" ] ∀ (a : Bool), ¬ (false = a) ===> ∀ (a : Bool), true = a
+#testOptimize [ "NotEqFalse_1", proof ] ∀ (a : Bool), ¬ (false = a) ===> ∀ (a : Bool), true = a
 
 -- (¬ (false = a)) = (true = a) ===> True (with Type(a) = Bool)
-#testOptimize [ "NotEqFalse_2" ] ∀ (a : Bool), (¬ (false = a)) = (true = a) ===> True
+#testOptimize [ "NotEqFalse_2", proof ] ∀ (a : Bool), (¬ (false = a)) = (true = a) ===> True
 
 -- ¬ (a = false) ===> true = a (with Type(a) = Bool)
 #testOptimize [ "NotEqFalse_3" ] ∀ (a : Bool), ¬ (a = false) ===> ∀ (a : Bool), true = a
@@ -151,10 +151,10 @@ namespace Tests.OptimizeNot
 /-! Test cases for simplification rule `¬ (true = e) ==> false = e`. -/
 
 -- ¬ (true = a) ===> false = a (with Type(a) = Bool)
-#testOptimize [ "NotEqTrue_1" ] ∀ (a : Bool), ¬ (true = a) ===> ∀ (a : Bool), false = a
+#testOptimize [ "NotEqTrue_1", proof ] ∀ (a : Bool), ¬ (true = a) ===> ∀ (a : Bool), false = a
 
 -- (¬ (true = a)) = (false = a) ===> True (with Type(a) = Bool)
-#testOptimize [ "NotEqTrue_2" ] ∀ (a : Bool), (¬ (true = a)) = (false = a) ===> True
+#testOptimize [ "NotEqTrue_2", proof ] ∀ (a : Bool), (¬ (true = a)) = (false = a) ===> True
 
 -- ¬ (a = true) ===> false = a (with Type(a) = Bool)
 #testOptimize [ "NotEqTrue_3" ] ∀ (a : Bool), ¬ (a = true) ===> ∀ (a : Bool), false = a

--- a/Tests/Optimize/OptimizeProp/OptimizeOr.lean
+++ b/Tests/Optimize/OptimizeProp/OptimizeOr.lean
@@ -9,16 +9,16 @@ namespace Tests.OptimizeOr
 /-! Test cases for simplification rule `False ∨ e ==> e`. -/
 
 -- False ∨ True ===> True
-#testOptimize [ "OrFalse_1"] False ∨ True ===> True
+#testOptimize [ "OrFalse_1" ] False ∨ True ===> True
 
 -- (False ∨ True) = True ===> True
-#testOptimize [ "OrFalse_2" ] (False ∨ True) = True ===> True
+#testOptimize [ "OrFalse_2", proof ] (False ∨ True) = True ===> True
 
 -- True ∨ False ===> True
 #testOptimize [ "OrFalse_3" ] True ∨ False ===> True
 
 -- False ∨ False ===> False
-#testOptimize [ "OrFalse_4" ] False ∨ False ===> False
+#testOptimize [ "OrFalse_4", proof ] False ∨ False ===> False
 
 -- a ∨ False ===> a
 #testOptimize [ "OrFalse_5" ] ∀ (a : Prop), a ∨ False ===> ∀ (a : Prop), a

--- a/Tests/Optimize/OptimizeProp/OptimizeOr.lean
+++ b/Tests/Optimize/OptimizeProp/OptimizeOr.lean
@@ -9,7 +9,7 @@ namespace Tests.OptimizeOr
 /-! Test cases for simplification rule `False ∨ e ==> e`. -/
 
 -- False ∨ True ===> True
-#testOptimize [ "OrFalse_1" ] False ∨ True ===> True
+#testOptimize [ "OrFalse_1"] False ∨ True ===> True
 
 -- (False ∨ True) = True ===> True
 #testOptimize [ "OrFalse_2" ] (False ∨ True) = True ===> True
@@ -27,10 +27,10 @@ namespace Tests.OptimizeOr
 #testOptimize [ "OrFalse_6" ] ∀ (a : Prop), (a ∨ False) = a ===> True
 
 -- False ∨ a ===> a
-#testOptimize [ "OrFalse_7" ] ∀ (a : Prop), False ∨ a ===> ∀ (a : Prop), a
+#testOptimize [ "OrFalse_7", proof ] ∀ (a : Prop), False ∨ a ===> ∀ (a : Prop), a
 
 -- False ∨ (a ∧ b) ===> a ∧ b
-#testOptimize [ "OrFalse_8" ] ∀ (a b : Prop), False ∨ (a ∧ b) ===> ∀ (a b : Prop), a ∧ b
+#testOptimize [ "OrFalse_8", proof ] ∀ (a b : Prop), False ∨ (a ∧ b) ===> ∀ (a b : Prop), a ∧ b
 
 -- (a ∨ b) ∨ False ===> a ∨ b
 #testOptimize [ "OrFalse_9" ] ∀ (a b : Prop), (a ∨ b) ∨ False ===> ∀ (a b : Prop), a ∨ b
@@ -39,7 +39,7 @@ namespace Tests.OptimizeOr
 #testOptimize [ "OrFalse_10" ] ∀ (a b : Prop), (a ∨ False) ∨ b ===> ∀ (a b : Prop), a ∨ b
 
 -- (False ∨ a) ∨ b  ===> a ∨ b
-#testOptimize [ "OrFalse_11" ] ∀ (a b : Prop), (False ∨ a) ∨ b ===> ∀ (a b : Prop), a ∨ b
+#testOptimize [ "OrFalse_11", proof ] ∀ (a b : Prop), (False ∨ a) ∨ b ===> ∀ (a b : Prop), a ∨ b
 
 -- (a ∧ False) ∨ (a ∨ b) ===> a ∨ b
 #testOptimize [ "OrFalse_12" ] ∀ (a b : Prop), (a ∧ False) ∨ (a ∨ b) ===>
@@ -57,10 +57,10 @@ namespace Tests.OptimizeOr
 /-! Test cases for simplification rule `True ∨ e ==> True`. -/
 
 -- True ∨ True ===> True
-#testOptimize [ "OrTrue_1" ] True ∨ True ===> True
+#testOptimize [ "OrTrue_1", proof ] True ∨ True ===> True
 
 -- (True ∨ True) = True ===> True
-#testOptimize [ "OrTrue_2" ] (True ∨ True) = True ===> True
+#testOptimize [ "OrTrue_2", proof ] (True ∨ True) = True ===> True
 
 -- a ∨ True ===> True
 #testOptimize [ "OrTrue_3" ] ∀ (a : Prop), a ∨ True ===> True
@@ -69,10 +69,10 @@ namespace Tests.OptimizeOr
 #testOptimize [ "OrTrue_4" ] ∀ (a : Prop), (a ∨ True) = True ===> True
 
 -- True ∨ a ===> True
-#testOptimize [ "OrTrue_5" ] ∀ (a : Prop), True ∨ a ===> True
+#testOptimize [ "OrTrue_5", proof ] ∀ (a : Prop), True ∨ a ===> True
 
 -- True ∨ (a ∧ b) ===> True
-#testOptimize [ "OrTrue_6" ] ∀ (a b : Prop), True ∨ (a ∧ b) ===> True
+#testOptimize [ "OrTrue_6", proof ] ∀ (a b : Prop), True ∨ (a ∧ b) ===> True
 
 -- (a ∨ b) ∨ True ===> True
 #testOptimize [ "OrTrue_7" ] ∀ (a b : Prop), (a ∨ b) ∨ True ===> True
@@ -99,10 +99,10 @@ namespace Tests.OptimizeOr
 /-! Test cases for simplification rule `e ∨ ¬ e ==> True`. -/
 
 -- a ∨ ¬ a ===> True
-#testOptimize [ "OrNeg_1" ] ∀ (a : Prop), a ∨ ¬ a ===> True
+#testOptimize [ "OrNeg_1", proof ] ∀ (a : Prop), a ∨ ¬ a ===> True
 
 -- (a ∨ ¬ a) = True ===> True
-#testOptimize [ "OrNeg_2" ] ∀ (a : Prop), (a ∨ ¬ a) = True ===> True
+#testOptimize [ "OrNeg_2", proof ] ∀ (a : Prop), (a ∨ ¬ a) = True ===> True
 
 -- (a ∧ b) ∨ ¬ (b ∧ a) ===> True
 #testOptimize [ "OrNeg_3" ] ∀ (a b : Prop), (a ∧ b) ∨ ¬ (b ∧ a) ===> True
@@ -164,7 +164,7 @@ namespace Tests.OptimizeOr
 /-! Test cases for simplification rule `true = e ∨ false = e ==> True`. -/
 
 -- ∀ (a : Bool), true = a ∨ false = a ===> True
-#testOptimize [ "OrNegBoolEq_1" ] ∀ (a : Bool), true = a ∨ false = a ===> True
+#testOptimize [ "OrNegBoolEq_1", proof ] ∀ (a : Bool), true = a ∨ false = a ===> True
 
 -- ∀ (a : Bool), true = a ∨ a = false ===> True
 #testOptimize [ "OrNegBoolEq_2" ] ∀ (a : Bool), true = a ∨ a = false ===> True
@@ -208,10 +208,10 @@ namespace Tests.OptimizeOr
 /-! Test cases for simplification rule `e1 ∨ e2 ==> e1 (if e1 =ₚₜᵣ e2)`. -/
 
 -- a ∨ a ===> a
-#testOptimize [ "OrSubsumption_1" ] ∀ (a : Prop), a ∨ a ===> ∀ (a : Prop), a
+#testOptimize [ "OrSubsumption_1", proof ] ∀ (a : Prop), a ∨ a ===> ∀ (a : Prop), a
 
 -- (a ∨ a) = a ===> True
-#testOptimize [ "OrSubsumption_2" ] ∀ (a : Prop), (a ∨ a) = a ===> True
+#testOptimize [ "OrSubsumption_2", proof ] ∀ (a : Prop), (a ∨ a) = a ===> True
 
 
 -- (a ∧ b) ∨ (b ∧ a) ===> a ∧ b

--- a/Tests/Optimize/OptimizeRecFun.lean
+++ b/Tests/Optimize/OptimizeRecFun.lean
@@ -17,12 +17,12 @@ def powerN (a : Int) (n : Nat) : Int :=
 
 -- ∀ (x : Int) (n : Nat), powerN x n = Int.pow x n ===> True
 -- NOTE: Equivalence detection with opaque function
-#testOptimize [ "NormRecFun_1" ] ∀ (x : Int) (n : Nat), powerN x n = Int.pow x n ===> True
+#testOptimize [ "NormRecFun_1", proof ] ∀ (x : Int) (n : Nat), powerN x n = Int.pow x n ===> True
 
 
 -- ∀ (x : Int) (n : Nat), x ^ n = powerN x n ===> True
 -- NOTE: Equivalence detection with opaque function
-#testOptimize [ "NormRecFun_2" ] ∀ (x : Int) (n : Nat), x ^ n = powerN x n ===> True
+#testOptimize [ "NormRecFun_2", proof ] ∀ (x : Int) (n : Nat), x ^ n = powerN x n ===> True
 
 def addNat (a : Nat) (b : Nat) : Nat :=
  match a, b with
@@ -31,11 +31,11 @@ def addNat (a : Nat) (b : Nat) : Nat :=
 
 -- ∀ (x y : Nat), addNat x y = x + y ===> True
 -- NOTE: Equivalence detection with opaque function
-#testOptimize [ "NormRecFun_3" ] ∀ (x y : Nat), addNat x y = x + y ===> True
+#testOptimize [ "NormRecFun_3", proof ] ∀ (x y : Nat), addNat x y = x + y ===> True
 
 -- ∀ (x y : Nat), x + y = addNat x y = ===> True
 -- NOTE: Equivalence detection with opaque function
-#testOptimize [ "NormRecFun_4" ] ∀ (x y : Nat), x + y = addNat x y ===> True
+#testOptimize [ "NormRecFun_4", proof ] ∀ (x y : Nat), x + y = addNat x y ===> True
 
 
 def listNatBeq (xs : List Nat) (ys : List Nat) : Bool :=
@@ -107,7 +107,7 @@ def powerNat (a : Nat) (n : Nat) : Nat :=
 -- ∀ (x y : Nat), x ^ y = powerNat x y ===> True
 -- NOTE: Equivalence detection between nested opaque function (i.e., here 3 nested level)
 -- NOTE: Also ensures that non-recursive function are inlined.
-#testOptimize [ "NormRecFun_12" ] ∀ (x y : Nat), x ^ y = powerNat x y ===> True
+#testOptimize [ "NormRecFun_12", proof ] ∀ (x y : Nat), x ^ y = powerNat x y ===> True
 
 
 -- ∀ (x y : Nat), powerNat y x + Nat.pow x y = Nat.pow y x + powerNat x y ===> True
@@ -420,7 +420,7 @@ def listPolyBeqInverse [BEq α] (xs : List α) (ys : List α) : Bool :=
 -- ∀ (xs ys : List Nat), listPolyBeq xs ys = listPolyBeqInverse xs ys ===>
 -- ∀ (xs ys : List Nat), listPolyBeq xs ys = listPolyBeqInverse xs ys
 -- NOTE: Test cases to ensure that structural equivalence no match are not wrongly applied
-#testOptimize [ "NormRecUnchanged_5" ]
+#testOptimize [ "NormRecUnchanged_5", proof ]
   ∀ (xs ys : List Nat), listPolyBeq xs ys = listPolyBeqInverse xs ys ===>
   ∀ (xs ys : List Nat), listPolyBeq xs ys = listPolyBeqInverse xs ys
 
@@ -447,7 +447,7 @@ def polyMul [Mul α] (x : α) (y : α) : α := x * y
 
 -- ∀ (x y z : Int), polyMul x y > z → polyMul x.toNat y.toNat > z.toNat ===>
 -- ∀ (x y z : Int), z < Int.mul x y → z.toNat < Nat.mul x.toNat y.toNat
-#testOptimize [ "NormRecUnchanged_7" ]
+#testOptimize [ "NormRecUnchanged_7", proof ]
   ∀ (x y z : Int), polyMul x y > z → polyMul x.toNat y.toNat > z.toNat ===>
   ∀ (x y z : Int), z < Int.mul x y → z.toNat < Nat.mul x.toNat y.toNat
 
@@ -456,7 +456,7 @@ def polyMul [Mul α] (x : α) (y : α) : α := x * y
 -- ∀ (a b : List Int) (c d : List Nat), (listPolyBeq a b) = (listPolyBeq c d)
 -- NOTE: test case to ensure that structural equivalence is not performed
 -- on polymorphic function instantiated with different types.
-#testOptimize [ "NormRecUnchanged_8" ]
+#testOptimize [ "NormRecUnchanged_8", proof ]
   ∀ (a b : List Int) (c d : List Nat), (listPolyBeq a b) = (listPolyBeq c d) ===>
   ∀ (a b : List Int) (c d : List Nat), (listPolyBeq a b) = (listPolyBeq c d)
 
@@ -615,7 +615,7 @@ where
 --   (∀ (n m : Nat), 0 < m → Nat.mod n m < n)
 -- NOTE: Test case can result to `True` when implementing structural
 -- equivalence with opaque function.
-#testOptimize [ "NormRecUnchanged_15" ] (norm-result: 1)
+#testOptimize [ "NormRecUnchanged_15", proof ] (norm-result: 1)
   (∀ (x y : Nat), y > 0 → modNat x y < y) → (∀ (n m : Nat), m > 0 → n % m < n) ===>
   (∀ (x y : Nat), 0 < y → Blaster.dite' (0 = x) (fun _h : 0 = x => 0) (fun _h : ¬ 0 = x => modNat.modAux x y) < y) →
     (∀ (n m : Nat), 0 < m → Nat.mod n m < n)
@@ -660,7 +660,7 @@ end
 -- ∀ (a : A), sizeAOne a = sizeATwo a ===> ∀ (a : A), sizeAOne a = sizeATwo a
 -- NOTE: Test case can result to `True` when implementing structural equivalence
 -- on mutually recursive functions
-#testOptimize [ "NormRecUnchanged_16" ]
+#testOptimize [ "NormRecUnchanged_16", proof ]
   ∀ (a : A), sizeAOne a = sizeATwo a ===> ∀ (a : A), sizeAOne a = sizeATwo a
 
 -- (∀ (a : A), sizeAOne (A.self a) > sizeAOne a) → (∀ (a : A), sizeATwo (A.self a) > sizeATwo a) ===>
@@ -672,7 +672,7 @@ end
 -- ∀ (b : B), sizeBOne b = sizeBTwo b ===> ∀ (b : B), sizeBOne b = sizeBTwo b
 -- NOTE: Test case can result to `True` when implementing structural equivalence
 -- on mutually recursive functions
-#testOptimize [ "NormRecUnchanged_18" ]
+#testOptimize [ "NormRecUnchanged_18", proof ]
   ∀ (b : B), sizeBOne b = sizeBTwo b ===> ∀ (b : B), sizeBOne b = sizeBTwo b
 
 -- (∀ (b : B), sizeBOne (B.self b) > sizeBOne b) → (∀ (b : B), sizeBTwo (B.self b) > sizeBTwo b) ===>

--- a/Tests/Optimize/OptimizeRecFun.lean
+++ b/Tests/Optimize/OptimizeRecFun.lean
@@ -102,7 +102,7 @@ def powerNat (a : Nat) (n : Nat) : Nat :=
 -- ∀ (x y : Nat), powerNat x y = Nat.pow x y ===> True
 -- NOTE: Equivalence detection between nested opaque functions (i.e., here 3 nested level)
 -- NOTE: Also ensures that non-recursive function are inlined.
-#testOptimize [ "NormRecFun_11" ] ∀ (x y : Nat), powerNat x y = Nat.pow x y ===> True
+#testOptimize [ "NormRecFun_11", proof ] ∀ (x y : Nat), powerNat x y = Nat.pow x y ===> True
 
 -- ∀ (x y : Nat), x ^ y = powerNat x y ===> True
 -- NOTE: Equivalence detection between nested opaque function (i.e., here 3 nested level)
@@ -114,7 +114,7 @@ def powerNat (a : Nat) (n : Nat) : Nat :=
 -- NOTE: Equivalence detection between nested opaque function (i.e., here 3 nested level)
 -- NOTE: Also ensures that structural equivalence is properly performed when
 -- a recursive function is referenced more than once (i.e., proper use of instance cache)
-#testOptimize [ "NormRecFun_13" ]
+#testOptimize [ "NormRecFun_13", proof ]
   ∀ (x y : Nat), powerNat y x + Nat.pow x y = Nat.pow y x + powerNat x y ===> True
 
 -- ∀ (x y : Nat), if x < y then powerNat y x else powerNat x y < Nat.pow x y ===>

--- a/Tests/Optimize/ReconstructLT.lean
+++ b/Tests/Optimize/ReconstructLT.lean
@@ -112,4 +112,53 @@ namespace Test.ReconstructLT
 -- ∀ (a b : Int), a < 1 + b ===> ∀ (a b : Int), ¬ (b < a)
 #testOptimize [ "LtOneAddInt", proof ] ∀ (a b : Int), a < 1 + b ===> ∀ (a b : Int), ¬ (b < a)
 
+/-! ## Hypothesis-context reductions (Int).
+    `a + b < a ==> False (if 0 ≤ b)` / `==> True (if b < 0)` (intRelLeftReduce?). -/
+
+-- ∀ (a b : Int), 0 < b → ((a + b < a) = False) ===> True
+#testOptimize [ "AddLtSelfNonNegInt", proof ] ∀ (a b : Int), 0 < b → ((a + b < a) = False) ===> True
+
+-- ∀ (a b : Int), b < 0 → ((a + b < a) = True) ===> True
+#testOptimize [ "AddLtSelfNegInt", proof ] ∀ (a b : Int), b < 0 → ((a + b < a) = True) ===> True
+
+/-! `a < a + b ==> False (if b ≤ 0)` / `==> True (if 0 < b)` (Int, intRelRightReduce?). -/
+
+-- ∀ (a b : Int), b < 0 → ((a < a + b) = False) ===> True
+#testOptimize [ "LtAddSelfNonPosInt", proof ] ∀ (a b : Int), b < 0 → ((a < a + b) = False) ===> True
+
+-- ∀ (a b : Int), 0 < b → ((a < a + b) = True) ===> True
+#testOptimize [ "LtAddSelfPosInt", proof ] ∀ (a b : Int), 0 < b → ((a < a + b) = True) ===> True
+
+/-! `a < a + b ==> False (if 0 = b)` / `==> True (if 0 < b)` (Nat, natRelRightReduce?). -/
+
+-- ∀ (a b : Nat), 0 = b → ((a < a + b) = False) ===> True
+#testOptimize [ "LtAddSelfZeroNat", proof ] ∀ (a b : Nat), 0 = b → ((a < a + b) = False) ===> True
+
+-- ∀ (a b : Nat), 0 < b → ((a < a + b) = True) ===> True
+#testOptimize [ "LtAddSelfPosNat", proof ] ∀ (a b : Nat), 0 < b → ((a < a + b) = True) ===> True
+
+/-! `0 < x + y ==> True / False` from the signs of `x` and `y` (Int, intZeroLtSum?). -/
+
+-- ∀ (x y : Int), 0 < x → 0 < y → ((0 < x + y) = True) ===> True
+#testOptimize [ "ZeroLtSumPosInt", proof ] ∀ (x y : Int), 0 < x → 0 < y → ((0 < x + y) = True) ===> True
+
+-- ∀ (x y : Int), x < 0 → y < 0 → ((0 < x + y) = False) ===> True
+#testOptimize [ "ZeroLtSumNegInt", proof ] ∀ (x y : Int), x < 0 → y < 0 → ((0 < x + y) = False) ===> True
+
+/-! `N < e ==> False (if ¬ (N - 1 < e))` (predCstLTInHyp). -/
+
+-- ∀ (e : Nat), ¬ (4 < e) → ((5 < e) = False) ===> True
+#testOptimize [ "PredCstLtNat", proof ] ∀ (e : Nat), ¬ (4 < e) → ((5 < e) = False) ===> True
+
+-- ∀ (e : Int), ¬ (4 < e) → (((5 : Int) < e) = False) ===> True
+#testOptimize [ "PredCstLtInt", proof ] ∀ (e : Int), ¬ ((4 : Int) < e) → (((5 : Int) < e) = False) ===> True
+
+/-! `x + y < 0 ==> False / True` from the signs of `x` and `y` (Int, intZeroLtSum?). -/
+
+-- ∀ (x y : Int), 0 < x → 0 < y → ((x + y < 0) = False) ===> True
+#testOptimize [ "SumLtZeroPosInt", proof ] ∀ (x y : Int), 0 < x → 0 < y → ((x + y < 0) = False) ===> True
+
+-- ∀ (x y : Int), x < 0 → y < 0 → ((x + y < 0) = True) ===> True
+#testOptimize [ "SumLtZeroNegInt", proof ] ∀ (x y : Int), x < 0 → y < 0 → ((x + y < 0) = True) ===> True
+
 end Test.ReconstructLT

--- a/Tests/Optimize/ReconstructLT.lean
+++ b/Tests/Optimize/ReconstructLT.lean
@@ -1,0 +1,115 @@
+import Lean
+import Tests.Utils
+
+open Lean Elab Command Term
+
+namespace Test.ReconstructLT
+/-! ## Proof reconstruction for the non-hypothesis `optimizeLT` reductions.
+    Each case emits a proof step; the `proof` flag replays the stack and checks
+    the reconstructed goal closes. -/
+
+/-! Simplification rule `e < e ==> False`. -/
+
+-- ∀ (a : Nat), a < a ===> False
+#testOptimize [ "LtSelfNat", proof ] ∀ (a : Nat), a < a ===> False
+
+-- ∀ (a : Int), a < a ===> False
+#testOptimize [ "LtSelfInt", proof ] ∀ (a : Int), a < a ===> False
+
+/-! Constant fold `N1 < N2 ==> N1 "<" N2`. -/
+
+-- (2 < 5) = True ===> True
+#testOptimize [ "LtCstNatTrue", proof ] (2 < 5) = True ===> True
+
+-- (5 < 2) = False ===> True
+#testOptimize [ "LtCstNatFalse", proof ] (5 < 2) = False ===> True
+
+-- ((2 : Int) < 5) = True ===> True
+#testOptimize [ "LtCstIntTrue", proof ] ((2 : Int) < 5) = True ===> True
+
+-- ((5 : Int) < 2) = False ===> True
+#testOptimize [ "LtCstIntFalse", proof ] ((5 : Int) < 2) = False ===> True
+
+/-! Normalization rule `0 < -e ==> e < 0` (Int). -/
+
+-- ∀ (a : Int), 0 < -a ===> ∀ (a : Int), a < 0
+#testOptimize [ "ZeroLtNeg", proof ] (norm-result: 1) ∀ (a : Int), 0 < -a ===> ∀ (a : Int), a < 0
+
+/-! Simplification rule `e < 1 ==> 0 = e` (Nat). -/
+
+-- ∀ (a : Nat), a < 1 ===> ∀ (a : Nat), 0 = a
+#testOptimize [ "LtOneNat", proof ] (norm-result: 1) ∀ (a : Nat), a < 1 ===> ∀ (a : Nat), 0 = a
+
+/-! Simplification rule `N + e < e ==> False (N > 0) | True (N < 0)` (Int). -/
+
+-- ∀ (a : Int), 3 + a < a ===> False
+#testOptimize [ "AddPosLtSelf", proof ] ∀ (a : Int), 3 + a < a ===> False
+
+-- ∀ (a : Int), (-3 + a < a) = True ===> True
+#testOptimize [ "AddNegLtSelf", proof ] ∀ (a : Int), (-3 + a < a) = True ===> True
+
+/-! Simplification rule `e < N + e ==> True (N > 0) | False (N < 0)` (Int). -/
+
+-- ∀ (a : Int), (a < 3 + a) = True ===> True
+#testOptimize [ "LtAddPosInt", proof ] ∀ (a : Int), (a < 3 + a) = True ===> True
+
+-- ∀ (a : Int), a < -3 + a ===> False
+#testOptimize [ "LtAddNegInt", proof ] ∀ (a : Int), a < -3 + a ===> False
+
+/-! Simplification rule `a + b < a | b + a < a ==> False` (Nat). -/
+
+-- ∀ (a b : Nat), a + b < a ===> False
+#testOptimize [ "AddLtSelfLeft", proof ] ∀ (a b : Nat), a + b < a ===> False
+
+-- ∀ (a b : Nat), b + a < a ===> False
+#testOptimize [ "AddLtSelfRight", proof ] ∀ (a b : Nat), b + a < a ===> False
+
+/-! Simplification rule `e < N + e ==> True (N > 0)` (Nat). -/
+
+-- ∀ (a : Nat), (a < 3 + a) = True ===> True
+#testOptimize [ "LtAddPosNat", proof ] ∀ (a : Nat), (a < 3 + a) = True ===> True
+
+/-! Simplification rule `N1 + a < N2 ==> False (N2 ≤ N1) | a < N2 "-" N1` (Nat). -/
+
+-- ∀ (a : Nat), 5 + a < 3 ===> False
+#testOptimize [ "AddConstLtFalse", proof ] ∀ (a : Nat), 5 + a < 3 ===> False
+
+-- ∀ (a : Nat), 3 + a < 5 ===> ∀ (a : Nat), a < 2
+#testOptimize [ "AddConstLtSub", proof ] (norm-result: 1) ∀ (a : Nat), 3 + a < 5 ===> ∀ (a : Nat), a < 2
+
+/-! Simplification rule `N1 < N2 + a ==> True (N1 < N2) | N1 "-" N2 < a` (Nat). -/
+
+-- ∀ (a : Nat), (3 < 5 + a) = True ===> True
+#testOptimize [ "ConstLtAddTrue", proof ] ∀ (a : Nat), (3 < 5 + a) = True ===> True
+
+-- ∀ (a : Nat), 5 < 3 + a ===> ∀ (a : Nat), 2 < a
+#testOptimize [ "ConstLtAddSub", proof ] (norm-result: 1) ∀ (a : Nat), 5 < 3 + a ===> ∀ (a : Nat), 2 < a
+
+/-! Simplification rule `N1 + a < N2 ==> a < N2 "-" N1` (Int). -/
+
+-- ∀ (a : Int), 3 + a < 5 ===> ∀ (a : Int), a < 2
+#testOptimize [ "AddConstLtSubInt", proof ] (norm-result: 1) ∀ (a : Int), 3 + a < 5 ===> ∀ (a : Int), a < 2
+
+/-! Simplification rule `N1 < N2 + a ==> N1 "-" N2 < a` (Int). -/
+
+-- ∀ (a : Int), 5 < 3 + a ===> ∀ (a : Int), 2 < a
+#testOptimize [ "ConstLtAddSubInt", proof ] (norm-result: 1) ∀ (a : Int), 5 < 3 + a ===> ∀ (a : Int), 2 < a
+
+/-! Simplification rule
+    `N1 + a < N2 + b ==> N1 "-" min(N1,N2) + a < N2 "-" min(N1,N2) + b`. -/
+
+-- ∀ (a b : Nat), 3 + a < 5 + b ===> ∀ (a b : Nat), a < Nat.add 2 b
+#testOptimize [ "AddBothNat", proof ] (norm-result: 1) ∀ (a b : Nat), 3 + a < 5 + b ===> ∀ (a b : Nat), a < Nat.add 2 b
+
+-- ∀ (a b : Int), 3 + a < 5 + b ===> ∀ (a b : Int), a < Int.add 2 b
+#testOptimize [ "AddBothInt", proof ] (norm-result: 1) ∀ (a b : Int), 3 + a < 5 + b ===> ∀ (a b : Int), a < Int.add 2 b
+
+/-! Normalization rule `a < 1 + b ==> ¬ (b < a)`. -/
+
+-- ∀ (a b : Nat), a < 1 + b ===> ∀ (a b : Nat), ¬ (b < a)
+#testOptimize [ "LtOneAddNat", proof ] ∀ (a b : Nat), a < 1 + b ===> ∀ (a b : Nat), ¬ (b < a)
+
+-- ∀ (a b : Int), a < 1 + b ===> ∀ (a b : Int), ¬ (b < a)
+#testOptimize [ "LtOneAddInt", proof ] ∀ (a b : Int), a < 1 + b ===> ∀ (a b : Int), ¬ (b < a)
+
+end Test.ReconstructLT

--- a/Tests/Reconstruct/Basic.lean
+++ b/Tests/Reconstruct/Basic.lean
@@ -2,22 +2,12 @@ import Blaster
 
 /-! ## Tests that `blaster` closes goals with valid proof certificates (no sorry). -/
 
--- Nat.zero_add: 0 + n → n
+-- Eliminative rewrites
 example : ∀ {n : Nat}, 0 + n = n := by blaster
-
--- Nat.sub_self: n - n → 0
 example : ∀ {n : Nat}, n - n = 0 := by blaster
-
--- Nat.zero_sub: 0 - n → 0
 example : ∀ {n : Nat}, 0 - n = 0 := by blaster
-
--- Nat.sub_zero: n - 0 → n
 example : ∀ {n : Nat}, n - 0 = n := by blaster
-
--- Nat.zero_mul: 0 * n → 0
 example : ∀ {n : Nat}, 0 * n = 0 := by blaster
-
--- Nat.one_mul: 1 * n → n
 example : ∀ {n : Nat}, 1 * n = n := by blaster
 
 -- Constant evaluation
@@ -28,38 +18,34 @@ example : (2 * 3) + 1 = 7 := by blaster
 -- Constant propagation
 example : ∀ (x : Nat), 10 + (20 + x) = 30 + x := by blaster
 example : ∀ (x : Nat), 120 - (40 + x) = 80 - x := by blaster
-example : ∀ (x : Nat), 120 - (x + 40) = 80 - x := by blaster
 
--- Nat.add commutativity
+-- Constant-level rewrites (Nat.succ / Nat.pred)
+example : ∀ (n : Nat), Nat.succ n = 1 + n := by blaster
+example : ∀ (n : Nat), Nat.pred n = n - 1 := by blaster
+example : ∀ (n : Nat), Nat.succ (Nat.succ n) = 1 + (1 + n) := by blaster
+
+-- Commutativity
 example : ∀ (m n : Nat), m + n = n + m := by blaster
-example : ∀ (n : Nat), n + 1 = 1 + n := by blaster
-
--- Nat.mul commutativity
 example : ∀ (m n : Nat), m * n = n * m := by blaster
-example : ∀ (n : Nat), 2 * n = n * 2 := by blaster
 
--- Mixed rewrites
+-- Mixed rewrites (chained eliminatives)
 example : ∀ {n : Nat}, 0 + (0 + n) = n := by blaster
-example : ∀ {n : Nat}, 0 * (0 * n) = 0 := by blaster
 example : ∀ {n : Nat}, 1 * (1 * n) = n := by blaster
-
 example : ∀ {n : Nat}, 0 + ((0 * (0 * (0 + n))) + n) = n := by blaster
 example : ∀ {n : Nat}, (1 * ((0 * n) + n)) - 0 = n := by blaster
-example : ∀ {n : Nat}, (0 + n) + 1 = n + 1 := by blaster
-example : ∀ {n : Nat}, 1 + (0 + n) = n + 1 := by blaster
 
--- Mixed rewrite + commutativity
+-- Mixed rewrites + commutativity
 example : ∀ (m n : Nat), 0 + (m + n) = n + m := by blaster
-example : ∀ (m n : Nat), (m + n) + 0 = n + m := by blaster
 example : ∀ (m n : Nat), 1 * (m + n) = n + m := by blaster
-example : ∀ (m n : Nat), (m + n) - 0 = n + m := by blaster
-example :  ∀ (x : Nat), 0 + (x + 40) - (40 + x) = 0 := by blaster
+example : ∀ (x : Nat), 0 + (x + 40) - (40 + x) = 0 := by blaster
 
--- Multiple arguments rewrites
+-- Multiple arguments
 example : ∀ {x y : Nat}, (x + 0) + (y - 0) = x + y := by blaster
-example : ∀ {x y : Nat}, (0 + x) + (0 + y)  = x + y := by blaster
-example : ∀ {x y : Nat}, (x - 0) + (y + 0) = y + x := by blaster
-example : ∀ {x y : Nat}, (0 + x) + (0 + y)  = y + x := by blaster
+example : ∀ {x y : Nat}, (0 + x) + (0 + y) = y + x := by blaster
+
+-- Multiple commutativity on different sub-expressions
+example : ∀ {m n p q : Nat}, (m + n) + (p + q) = (q + p) + (n + m) := by blaster
+example : ∀ {a b c d : Nat}, (a * b) + (c * d) = (d * c) + (b * a) := by blaster
 
 -- Rewrites inside if-then-else
 example : ∀ (c : Bool) (x y : Nat),
@@ -71,8 +57,11 @@ example : ∀ (n : Nat),
   (match n with | 0 => 0 + 1 | k + 1 => k + 0) =
   (match n with | 0 => 1 | k + 1 => k) := by blaster
 
--- Multiple commutativity on different sub-expressions
-example : ∀ {m n p q : Nat}, (m + n) + (p + q) = (q + p) + (n + m) := by blaster
+-- Propositional equality: (∀ xs, P xs) = (∀ xs, Q xs)
+example : (∀ (n : Nat), 0 + n = n) = (∀ (n : Nat), n = n) := by blaster
+example : (∀ (m n : Nat), m + n = n + m) = (∀ (m n : Nat), n + m = n + m) := by blaster
 
--- Commutativity on both sides of different operators
-example : ∀ {a b c d : Nat}, (a * b) + (c * d) = (d * c) + (b * a) := by blaster
+-- Propositional equality with True
+example : (∀ (x : Nat), 0 * x = 0) = True := by blaster
+example : (∀ (m n : Nat), m + n = n + m) = True := by blaster
+example : (0 + 0 = 0) = True := by blaster

--- a/Tests/Reconstruct/Basic.lean
+++ b/Tests/Reconstruct/Basic.lean
@@ -9,15 +9,21 @@ example : ∀ {n : Nat}, 0 - n = 0 := by blaster
 example : ∀ {n : Nat}, n - 0 = n := by blaster
 example : ∀ {n : Nat}, 0 * n = 0 := by blaster
 example : ∀ {n : Nat}, 1 * n = n := by blaster
+example : ∀ (n : Nat), n / 0 = 0 := by blaster
+example : ∀ (n : Nat), 0 / n = 0 := by blaster
+example : ∀ (n : Nat), n / 1 = n := by blaster
 
 -- Constant evaluation
 example : 1 + 2 = 3 := by blaster
 example : 2 * 3 = 6 := by blaster
 example : (2 * 3) + 1 = 7 := by blaster
+example : 18 / 3 = 6 := by blaster
 
 -- Constant propagation
 example : ∀ (x : Nat), 10 + (20 + x) = 30 + x := by blaster
 example : ∀ (x : Nat), 120 - (40 + x) = 80 - x := by blaster
+example : ∀ (x : Nat), (x / 10) / 20 = x / 200 := by blaster
+example : ∀ (x : Nat), (10 * x) / 5 = 2 * x := by blaster
 
 -- Constant-level rewrites (Nat.succ / Nat.pred)
 example : ∀ (n : Nat), Nat.succ n = 1 + n := by blaster
@@ -65,3 +71,8 @@ example : (∀ (m n : Nat), m + n = n + m) = (∀ (m n : Nat), n + m = n + m) :=
 example : (∀ (x : Nat), 0 * x = 0) = True := by blaster
 example : (∀ (m n : Nat), m + n = n + m) = True := by blaster
 example : (0 + 0 = 0) = True := by blaster
+
+-- Hypothesis-dependent rewrites
+example : ∀ (n : Nat), 0 < n → n / n = 1 := by blaster
+example : ∀ (x y : Nat), 0 < y → (x * y) / y = x := by blaster
+example : ∀ (x y : Nat), 0 < x → (x * y) / x = y := by blaster

--- a/Tests/Reconstruct/Basic.lean
+++ b/Tests/Reconstruct/Basic.lean
@@ -63,7 +63,8 @@ example : ∀ {x y : Nat}, (0 + x) + (0 + y)  = y + x := by blaster
 
 -- Rewrites inside if-then-else
 example : ∀ (c : Bool) (x y : Nat),
-  (if c then x + 0 else y) = (if c then 0 + x else 0 + y) := by blaster
+  (if c then x + 0 else y) =
+  (if c then 0 + x else 0 + y) := by blaster
 
 -- Rewrites inside match
 example : ∀ (n : Nat),

--- a/Tests/Reconstruct/Basic.lean
+++ b/Tests/Reconstruct/Basic.lean
@@ -12,6 +12,12 @@ example : ∀ {n : Nat}, 1 * n = n := by blaster
 example : ∀ (n : Nat), n / 0 = 0 := by blaster
 example : ∀ (n : Nat), 0 / n = 0 := by blaster
 example : ∀ (n : Nat), n / 1 = n := by blaster
+example : ∀ (n : Nat), n % 0 = n := by blaster
+example : ∀ (n : Nat), 0 % n = 0 := by blaster
+example : ∀ (n : Nat), n % 1 = 0 := by blaster
+example : ∀ (x : Nat), x % x = 0 := by blaster
+example : ∀ (x y : Nat), (x * y) % y = 0 := by blaster
+example : ∀ (x y : Nat), (y * x) % y = 0 := by blaster
 
 -- Constant evaluation
 example : 1 + 2 = 3 := by blaster
@@ -24,6 +30,7 @@ example : ∀ (x : Nat), 10 + (20 + x) = 30 + x := by blaster
 example : ∀ (x : Nat), 120 - (40 + x) = 80 - x := by blaster
 example : ∀ (x : Nat), (x / 10) / 20 = x / 200 := by blaster
 example : ∀ (x : Nat), (10 * x) / 5 = 2 * x := by blaster
+example : ∀ (x : Nat), (124 * x) % 4 = 0 := by blaster
 
 -- Constant-level rewrites (Nat.succ / Nat.pred)
 example : ∀ (n : Nat), Nat.succ n = 1 + n := by blaster

--- a/Tests/Reconstruct/Basic.lean
+++ b/Tests/Reconstruct/Basic.lean
@@ -53,6 +53,7 @@ example : ∀ (m n : Nat), 0 + (m + n) = n + m := by blaster
 example : ∀ (m n : Nat), (m + n) + 0 = n + m := by blaster
 example : ∀ (m n : Nat), 1 * (m + n) = n + m := by blaster
 example : ∀ (m n : Nat), (m + n) - 0 = n + m := by blaster
+example :  ∀ (x : Nat), 0 + (x + 40) - (40 + x) = 0 := by blaster
 
 -- Multiple arguments rewrites
 example : ∀ {x y : Nat}, (x + 0) + (y - 0) = x + y := by blaster
@@ -69,8 +70,8 @@ example : ∀ (n : Nat),
   (match n with | 0 => 0 + 1 | k + 1 => k + 0) =
   (match n with | 0 => 1 | k + 1 => k) := by blaster
 
--- TODO: Multiple commutativity on different sub-expressions
+-- Multiple commutativity on different sub-expressions
 example : ∀ {m n p q : Nat}, (m + n) + (p + q) = (q + p) + (n + m) := by blaster
 
--- TODO: Commutativity on both sides of different operators
+-- Commutativity on both sides of different operators
 example : ∀ {a b c d : Nat}, (a * b) + (c * d) = (d * c) + (b * a) := by blaster

--- a/Tests/Reconstruct/Basic.lean
+++ b/Tests/Reconstruct/Basic.lean
@@ -1,0 +1,76 @@
+import Blaster
+
+/-! ## Tests that `blaster` closes goals with valid proof certificates (no sorry). -/
+
+-- Nat.zero_add: 0 + n → n
+example : ∀ {n : Nat}, 0 + n = n := by blaster
+
+-- Nat.sub_self: n - n → 0
+example : ∀ {n : Nat}, n - n = 0 := by blaster
+
+-- Nat.zero_sub: 0 - n → 0
+example : ∀ {n : Nat}, 0 - n = 0 := by blaster
+
+-- Nat.sub_zero: n - 0 → n
+example : ∀ {n : Nat}, n - 0 = n := by blaster
+
+-- Nat.zero_mul: 0 * n → 0
+example : ∀ {n : Nat}, 0 * n = 0 := by blaster
+
+-- Nat.one_mul: 1 * n → n
+example : ∀ {n : Nat}, 1 * n = n := by blaster
+
+-- Constant evaluation
+example : 1 + 2 = 3 := by blaster
+example : 2 * 3 = 6 := by blaster
+example : (2 * 3) + 1 = 7 := by blaster
+
+-- Constant propagation
+example : ∀ (x : Nat), 10 + (20 + x) = 30 + x := by blaster
+example : ∀ (x : Nat), 120 - (40 + x) = 80 - x := by blaster
+example : ∀ (x : Nat), 120 - (x + 40) = 80 - x := by blaster
+
+-- Nat.add commutativity
+example : ∀ (m n : Nat), m + n = n + m := by blaster
+example : ∀ (n : Nat), n + 1 = 1 + n := by blaster
+
+-- Nat.mul commutativity
+example : ∀ (m n : Nat), m * n = n * m := by blaster
+example : ∀ (n : Nat), 2 * n = n * 2 := by blaster
+
+-- Mixed rewrites
+example : ∀ {n : Nat}, 0 + (0 + n) = n := by blaster
+example : ∀ {n : Nat}, 0 * (0 * n) = 0 := by blaster
+example : ∀ {n : Nat}, 1 * (1 * n) = n := by blaster
+
+example : ∀ {n : Nat}, 0 + ((0 * (0 * (0 + n))) + n) = n := by blaster
+example : ∀ {n : Nat}, (1 * ((0 * n) + n)) - 0 = n := by blaster
+example : ∀ {n : Nat}, (0 + n) + 1 = n + 1 := by blaster
+example : ∀ {n : Nat}, 1 + (0 + n) = n + 1 := by blaster
+
+-- Mixed rewrite + commutativity
+example : ∀ (m n : Nat), 0 + (m + n) = n + m := by blaster
+example : ∀ (m n : Nat), (m + n) + 0 = n + m := by blaster
+example : ∀ (m n : Nat), 1 * (m + n) = n + m := by blaster
+example : ∀ (m n : Nat), (m + n) - 0 = n + m := by blaster
+
+-- Multiple arguments rewrites
+example : ∀ {x y : Nat}, (x + 0) + (y - 0) = x + y := by blaster
+example : ∀ {x y : Nat}, (0 + x) + (0 + y)  = x + y := by blaster
+example : ∀ {x y : Nat}, (x - 0) + (y + 0) = y + x := by blaster
+example : ∀ {x y : Nat}, (0 + x) + (0 + y)  = y + x := by blaster
+
+-- Rewrites inside if-then-else
+example : ∀ (c : Bool) (x y : Nat),
+  (if c then x + 0 else y) = (if c then 0 + x else 0 + y) := by blaster
+
+-- Rewrites inside match
+example : ∀ (n : Nat),
+  (match n with | 0 => 0 + 1 | k + 1 => k + 0) =
+  (match n with | 0 => 1 | k + 1 => k) := by blaster
+
+-- TODO: Multiple commutativity on different sub-expressions
+example : ∀ {m n p q : Nat}, (m + n) + (p + q) = (q + p) + (n + m) := by blaster
+
+-- TODO: Commutativity on both sides of different operators
+example : ∀ {a b c d : Nat}, (a * b) + (c * d) = (d * c) + (b * a) := by blaster

--- a/Tests/Utils.lean
+++ b/Tests/Utils.lean
@@ -178,11 +178,31 @@ private def buildAndApplyProofStack (inputExpr : Expr) (optimized : Expr)
   let proofStack := substProofStackFVars proofStack optBinders goalFVarIds
   applyProofStack g proofStack
 
+/-- Return `true` if the expression contains `sorryAx` anywhere. -/
+private partial def containsSorry (e : Expr) : Bool :=
+  match e with
+  | .const ``sorryAx _ => true
+  | .app f a => containsSorry f || containsSorry a
+  | .lam _ t b _ => containsSorry t || containsSorry b
+  | .forallE _ t b _ => containsSorry t || containsSorry b
+  | .letE _ t v b _ => containsSorry t || containsSorry v || containsSorry b
+  | .mdata _ e => containsSorry e
+  | .proj _ _ e => containsSorry e
+  | _ => false
+
 private def replayProofStack (inputExpr : Expr) (optimized : Expr)
     (proofStack : Array Blaster.Optimize.ProofStep)
     (optBinders : Array FVarId) : TermElabM Bool := do
   let g ← buildAndApplyProofStack inputExpr optimized proofStack optBinders
-  if ← g.isAssigned then return true
+  if ← g.isAssigned then
+    -- Check that no proof step contains sorry
+    for step in proofStack do
+      let p := match step with
+        | .rewrite e _ => e
+        | .exact e => e
+      let p ← instantiateMVars p
+      if containsSorry p then return false
+    return true
   try g.refl; return true
   catch _ => return false
 

--- a/Tests/Utils.lean
+++ b/Tests/Utils.lean
@@ -8,32 +8,40 @@ namespace Tests
 /-- Parse a term syntax. -/
 def parseTerm (stx : Syntax) : TermElabM Expr := elabTermAndSynthesize stx none
 
-/-- Parse a term syntax and call optimize. -/
-def callOptimize (sOpts : BlasterOptions) (stx : Syntax) : TermElabM Expr :=
+/-- Parse a term syntax and call optimize, returning both the optimized expression
+    and the translation environment (which contains the proof stack). -/
+def callOptimize (sOpts : BlasterOptions) (stx : Syntax) :
+    TermElabM (Expr × Blaster.Optimize.TranslateEnv) :=
   withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0 }) $ do
-    let optRes ← (Blaster.Optimize.command sOpts (← parseTerm stx))
-    pure optRes.1
+    Blaster.Optimize.command sOpts (← parseTerm stx)
 
 /-! ## Definition of #testOptimize command to write unit test for Blaster.optimize
     The #testOptimize usage is as follows:
-     #testOptimize [ "TestName" ] (verbose: num)? (norm-result: num)? TermToOptimize ==> OptimizedTerm
+     #testOptimize [ "TestName" ] (verbose: num)? (norm-result: num)? TermToOptimize ===> OptimizedTerm
+     #testOptimize [ "TestName", proof ] (verbose: num)? (norm-result: num)? TermToOptimize ===> OptimizedTerm
 
     with options:
      - verbose: activate debug info
      - norm-result: apply nat literal normalization, beta reduction on lambda application
                     and structure projection normalization on expected result.
+     - proof: require that proof reconstruction succeeds for this test case.
+              The optimizer's proof stack is replayed and the resulting goal
+              must close via `refl` or `ac_rfl`, mirroring the `blaster` tactic.
 
     E.g.
-     #testOptimize [ "AndSubsumption" ] ∀ (a : Prop), a ∧ a ==> ∀ (a : Prop), a
+     #testOptimize [ "AndSubsumption" ] ∀ (a : Prop), a ∧ a ===> ∀ (a : Prop), a
+     #testOptimize [ "NatAddZero", proof ] ∀ (x : Nat), 0 + x = x ===> True
 -/
-syntax testName := "[" str "]"
+syntax testName := "[" str ("," "proof")? "]"
 syntax termReducedTo := term  "===>" term
 syntax normNatLitOption := ("(norm-result:" num ")")?
 syntax (name := testOptimize) "#testOptimize" testName solveOption* normNatLitOption termReducedTo : command
 
-def parseTestName : TSyntax `testName -> CommandElabM String
- | `(testName| [ $s:str ]) => pure s.getString
- | _ => throwUnsupportedSyntax
+/-- Parse test name and optional `proof` flag. -/
+def parseTestName : TSyntax `testName → CommandElabM (String × Bool)
+  | `(testName| [ $s:str , proof ]) => pure (s.getString, true)
+  | `(testName| [ $s:str ]) => pure (s.getString, false)
+  | _ => throwUnsupportedSyntax
 
 def parseTermReducedTo : TSyntax `termReducedTo -> CommandElabM (Syntax × Syntax)
 |`(termReducedTo | $t1 ===> $t2) => pure (t1.raw, t2.raw)
@@ -143,25 +151,73 @@ partial def normNatLitAndLambdaBeta (e : Expr) : MetaM Expr := do
     | _ => return e
   visit e
 
+/-- Replay the proof stack and attempt to close the goal, mirroring the
+    `blaster` tactic closing strategy exactly: try `refl`, otherwise report failure.
+    Returns `true` when the goal is closed without sorry. -/
+private def replayProofStack (inputExpr : Expr) (optimized : Expr)
+    (proofStack : Array Blaster.Optimize.ProofStep)
+    (optBinders : Array FVarId) : TermElabM Bool := do
+  -- For propositions prove the statement directly;
+  -- for non-Prop expressions prove `inputExpr = optimized`.
+  let isPropInput ← isProp inputExpr
+  let goalType ← if isPropInput then pure inputExpr else mkEq inputExpr optimized
+  let goal ← mkFreshExprMVar goalType
+  let goalId := goal.mvarId!
+  -- Intro all binders so rewrite can find patterns
+  let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
+  -- Apply proof stack rewrites
+  let (goalFVarIds, g) ← goalId.introNP numBinders
+  let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
+  let g ← Blaster.Tactic.applyProofStack g proofStack
+  try g.refl; return true
+  catch _ => return false
+
+/-- Build the remaining goal after proof stack application (for error reporting). -/
+private def showRemainingGoal (inputExpr : Expr) (optimized : Expr)
+    (proofStack : Array Blaster.Optimize.ProofStep)
+    (optBinders : Array FVarId) : TermElabM MessageData := do
+  let isPropInput ← isProp inputExpr
+  let goalType ← if isPropInput then pure inputExpr else mkEq inputExpr optimized
+  let goal ← mkFreshExprMVar goalType
+  let gid := goal.mvarId!
+  let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
+  let (goalFVarIds, g) ← gid.introNP numBinders
+  let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
+  let g ← Blaster.Tactic.applyProofStack g proofStack
+  g.withContext (ppExpr (← g.getType))
+
 @[command_elab testOptimize]
 def testOptimizeImp : CommandElab := fun stx => do
- let name ← parseTestName ⟨stx[1]⟩
- let sOpts ← parseVerbose default ⟨stx[2]⟩
- let normNatFlag ← parseNormNatLitOption ⟨stx[3]⟩
- let (t1, t2) ← parseTermReducedTo ⟨stx[4]⟩
- withoutModifyingEnv $ runTermElabM fun _ => do
-   -- create a local declaration name for the test case
-   let m ← getMainModule
-   withDeclName (m ++ name.toName) $ do
-     let actual ← callOptimize sOpts t1
-     let expected' := removeAnnotations (← parseTerm t2)
-     -- keep the current name generator and restore it afterwards
-     let ngen ← getNGen
-     let expected ← if normNatFlag then normNatLitAndLambdaBeta expected' else pure expected'
-     -- restore name generator
-     setNGen ngen
-     if actual == expected
-     then logInfo f!"{name} ✅ Success!"
-     else logError f!"{name} ❌ Failure! : expecting {reprStr expected} \nbut got {reprStr actual}"
+  let (name, requireProof) ← parseTestName ⟨stx[1]⟩
+  let sOpts ← parseVerbose default ⟨stx[2]⟩
+  let normNatFlag ← parseNormNatLitOption ⟨stx[3]⟩
+  let (t1, t2) ← parseTermReducedTo ⟨stx[4]⟩
+  withoutModifyingEnv $ runTermElabM fun _ => do
+    -- create a local declaration name for the test case
+    let m ← getMainModule
+    withDeclName (m ++ name.toName) $ do
+      let (actual, env) ← callOptimize sOpts t1
+      let expected' := removeAnnotations (← parseTerm t2)
+      -- keep the current name generator and restore it afterwards
+      let ngen ← getNGen
+      let expected ← if normNatFlag then normNatLitAndLambdaBeta expected' else pure expected'
+      -- restore name generator
+      setNGen ngen
+      if actual == expected then
+        if requireProof then
+          -- Re-elaborate to obtain the original (pre-optimization) expression
+          let inputExpr ← parseTerm t1
+          let proofStack := env.optEnv.proofStack
+          let optBinders := env.optEnv.optBinders
+          let closed ← replayProofStack inputExpr actual proofStack optBinders
+          if closed then
+            logInfo f!"{name} ✅ Success! [proof ✓]"
+          else
+            let remainingGoal ← showRemainingGoal inputExpr actual proofStack optBinders
+            logError m!"{name} ❌ Failure! : proof reconstruction failed\n  remaining goal: {remainingGoal}"
+        else
+          logInfo f!"{name} ✅ Success!"
+      else
+        logError f!"{name} ❌ Failure! : expecting {reprStr expected} \nbut got {reprStr actual}"
 
 end Tests

--- a/Tests/Utils.lean
+++ b/Tests/Utils.lean
@@ -1,8 +1,7 @@
 import Lean
-import Blaster.Optimize.Basic
-import Blaster
+import Blaster.Command.Tactic
 
-open Lean Elab Command Term Meta Blaster.Options Blaster.Syntax
+open Lean Elab Command Term Meta Blaster.Options Blaster.Syntax Blaster.Tactic
 
 namespace Tests
 /-- Parse a term syntax. -/
@@ -151,12 +150,10 @@ partial def normNatLitAndLambdaBeta (e : Expr) : MetaM Expr := do
     | _ => return e
   visit e
 
-/-- Replay the proof stack and attempt to close the goal, mirroring the
-    `blaster` tactic closing strategy exactly: try `refl`, otherwise report failure.
-    Returns `true` when the goal is closed without sorry. -/
-private def replayProofStack (inputExpr : Expr) (optimized : Expr)
+/-- Build the goal type and apply the proof stack. Returns the (possibly assigned) goal. -/
+private def buildAndApplyProofStack (inputExpr : Expr) (optimized : Expr)
     (proofStack : Array Blaster.Optimize.ProofStep)
-    (optBinders : Array FVarId) : TermElabM Bool := do
+    (optBinders : Array FVarId) : TermElabM MVarId := do
   let isPropInput ← isProp inputExpr
   let isOptTrue := optimized.isConstOf ``True
   let (goalType, numBinders) ←
@@ -166,8 +163,8 @@ private def replayProofStack (inputExpr : Expr) (optimized : Expr)
     else if isPropInput then
       let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
       let gt ← forallTelescope inputExpr fun inputFvars inputBody => do
-        let optBody ← forallBoundedTelescope optimized (some n) fun optFvars optBody =>
-          pure (optBody.replaceFVars optFvars inputFvars)
+        let optBody ← forallTelescope optimized fun optFvars optBody =>
+          mapOptBodyToInputFVars optBody optFvars inputFvars
         let eq ← mkEq inputBody optBody
         mkForallFVars inputFvars eq
       pure (gt, n)
@@ -178,39 +175,21 @@ private def replayProofStack (inputExpr : Expr) (optimized : Expr)
   let goal ← mkFreshExprMVar goalType
   let goalId := goal.mvarId!
   let (goalFVarIds, g) ← goalId.introNP numBinders
-  let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
-  let g ← Blaster.Tactic.applyProofStack g proofStack
+  let proofStack := substProofStackFVars proofStack optBinders goalFVarIds
+  applyProofStack g proofStack
+
+private def replayProofStack (inputExpr : Expr) (optimized : Expr)
+    (proofStack : Array Blaster.Optimize.ProofStep)
+    (optBinders : Array FVarId) : TermElabM Bool := do
+  let g ← buildAndApplyProofStack inputExpr optimized proofStack optBinders
   if ← g.isAssigned then return true
   try g.refl; return true
   catch _ => return false
 
-/-- Build the remaining goal after proof stack application (for error reporting). -/
 private def showRemainingGoal (inputExpr : Expr) (optimized : Expr)
     (proofStack : Array Blaster.Optimize.ProofStep)
     (optBinders : Array FVarId) : TermElabM MessageData := do
-  let isPropInput ← isProp inputExpr
-  let isOptTrue := optimized.isConstOf ``True
-  let (goalType, numBinders) ←
-    if isPropInput && isOptTrue then
-      let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
-      pure (inputExpr, n)
-    else if isPropInput then
-      let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
-      let gt ← forallTelescope inputExpr fun inputFvars inputBody => do
-        let optBody ← forallBoundedTelescope optimized (some n) fun optFvars optBody =>
-          pure (optBody.replaceFVars optFvars inputFvars)
-        let eq ← mkEq inputBody optBody
-        mkForallFVars inputFvars eq
-      pure (gt, n)
-    else
-      let gt ← mkEq inputExpr optimized
-      let n ← forallTelescope gt fun fvars _ => pure fvars.size
-      pure (gt, n)
-  let goal ← mkFreshExprMVar goalType
-  let gid := goal.mvarId!
-  let (goalFVarIds, g) ← gid.introNP numBinders
-  let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
-  let g ← Blaster.Tactic.applyProofStack g proofStack
+  let g ← buildAndApplyProofStack inputExpr optimized proofStack optBinders
   if ← g.isAssigned then return "goal closed by proof stack"
   g.withContext (ppExpr (← g.getType))
 

--- a/Tests/Utils.lean
+++ b/Tests/Utils.lean
@@ -180,6 +180,7 @@ private def replayProofStack (inputExpr : Expr) (optimized : Expr)
   let (goalFVarIds, g) ← goalId.introNP numBinders
   let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
   let g ← Blaster.Tactic.applyProofStack g proofStack
+  if ← g.isAssigned then return true
   try g.refl; return true
   catch _ => return false
 
@@ -210,6 +211,7 @@ private def showRemainingGoal (inputExpr : Expr) (optimized : Expr)
   let (goalFVarIds, g) ← gid.introNP numBinders
   let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
   let g ← Blaster.Tactic.applyProofStack g proofStack
+  if ← g.isAssigned then return "goal closed by proof stack"
   g.withContext (ppExpr (← g.getType))
 
 @[command_elab testOptimize]

--- a/Tests/Utils.lean
+++ b/Tests/Utils.lean
@@ -157,15 +157,26 @@ partial def normNatLitAndLambdaBeta (e : Expr) : MetaM Expr := do
 private def replayProofStack (inputExpr : Expr) (optimized : Expr)
     (proofStack : Array Blaster.Optimize.ProofStep)
     (optBinders : Array FVarId) : TermElabM Bool := do
-  -- For propositions prove the statement directly;
-  -- for non-Prop expressions prove `inputExpr = optimized`.
   let isPropInput ← isProp inputExpr
-  let goalType ← if isPropInput then pure inputExpr else mkEq inputExpr optimized
+  let isOptTrue := optimized.isConstOf ``True
+  let (goalType, numBinders) ←
+    if isPropInput && isOptTrue then
+      let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
+      pure (inputExpr, n)
+    else if isPropInput then
+      let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
+      let gt ← forallTelescope inputExpr fun inputFvars inputBody => do
+        let optBody ← forallBoundedTelescope optimized (some n) fun optFvars optBody =>
+          pure (optBody.replaceFVars optFvars inputFvars)
+        let eq ← mkEq inputBody optBody
+        mkForallFVars inputFvars eq
+      pure (gt, n)
+    else
+      let gt ← mkEq inputExpr optimized
+      let n ← forallTelescope gt fun fvars _ => pure fvars.size
+      pure (gt, n)
   let goal ← mkFreshExprMVar goalType
   let goalId := goal.mvarId!
-  -- Intro all binders so rewrite can find patterns
-  let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
-  -- Apply proof stack rewrites
   let (goalFVarIds, g) ← goalId.introNP numBinders
   let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
   let g ← Blaster.Tactic.applyProofStack g proofStack
@@ -177,10 +188,25 @@ private def showRemainingGoal (inputExpr : Expr) (optimized : Expr)
     (proofStack : Array Blaster.Optimize.ProofStep)
     (optBinders : Array FVarId) : TermElabM MessageData := do
   let isPropInput ← isProp inputExpr
-  let goalType ← if isPropInput then pure inputExpr else mkEq inputExpr optimized
+  let isOptTrue := optimized.isConstOf ``True
+  let (goalType, numBinders) ←
+    if isPropInput && isOptTrue then
+      let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
+      pure (inputExpr, n)
+    else if isPropInput then
+      let n ← forallTelescope inputExpr fun fvars _ => pure fvars.size
+      let gt ← forallTelescope inputExpr fun inputFvars inputBody => do
+        let optBody ← forallBoundedTelescope optimized (some n) fun optFvars optBody =>
+          pure (optBody.replaceFVars optFvars inputFvars)
+        let eq ← mkEq inputBody optBody
+        mkForallFVars inputFvars eq
+      pure (gt, n)
+    else
+      let gt ← mkEq inputExpr optimized
+      let n ← forallTelescope gt fun fvars _ => pure fvars.size
+      pure (gt, n)
   let goal ← mkFreshExprMVar goalType
   let gid := goal.mvarId!
-  let numBinders ← forallTelescope goalType fun fvars _ => pure fvars.size
   let (goalFVarIds, g) ← gid.introNP numBinders
   let proofStack := Blaster.Tactic.substProofStackFVars proofStack optBinders goalFVarIds
   let g ← Blaster.Tactic.applyProofStack g proofStack


### PR DESCRIPTION
Implements proof reconstruction via a proof stack that records rewrite lemmas during optimization. Instead of propagating proof terms through the pipeline, each optimization rule pushes a ProofStep onto a stack.