### PR TITLE
feat: custom sorry

### DIFF
--- a/Blaster/Command/Syntax.lean
+++ b/Blaster/Command/Syntax.lean
@@ -153,10 +153,10 @@ def commandInvoker (f : BlasterOptions → Syntax → TermElabM Unit) : CommandE
     -- The direct use of whnf will soon be removed at the preprocessing phase.
     -- However, since we rely on functions like isProp, inferType and withLocalDecl, setting maxHearbeats
     -- to zero will still be required. Unless, we have a new implementation for these functions.
-      withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0, maxRecDepth := 0 }) $ do
-        f sOpts tr
+      withTheReader Core.Context (fun ctx => { ctx with maxHeartbeats := 0, maxRecDepth := 0 }) $
+        withRef stx[2] $ f sOpts tr
   let task ← BaseIO.asTask (prio := Task.Priority.dedicated) (act ())
-  logSnapshotTask { stx? := some stx, task, cancelTk? := cancelTk }
+  logSnapshotTask { stx? := some stx[2], task, cancelTk? := cancelTk }
 
 
 /-! ### Implementation of solve command -/

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -31,7 +31,14 @@ syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 /-- Custom sorry for Blaster
     Quite useful for AI tools to differentiate
     between SMT-verified goals and regular sorry-/
-axiom blasterProven : ∀ {α : Prop}, α
+private axiom blasterProven : ∀ {α : Sort u}, α
+
+private def blasterAdmit (mvarId : MVarId) : MetaM Unit :=
+  mvarId.withContext do
+    mvarId.checkNotAssigned `blasterAdmit
+    let mvarType ← mvarId.getType >>= instantiateMVars
+    let u ← getLevel mvarType
+    mvarId.assign (mkApp (mkConst ``blasterProven [u]) mvarType)
 
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
@@ -47,9 +54,10 @@ def blasterTacticImp : Tactic := fun stx =>
        Translate.main (← goal.getType >>= instantiateMVars') (logUndetermined := false) |>.run env
    match result with
    | .Valid =>
-      let p ← goal.getType >>= instantiateMVars
-      goal.assign (mkApp (mkConst ``blasterProven []) p)
-      logWarning "declaration uses 'blasterProven' (SMT-verified, no proof term)" -- TODO: replace with proof reconstruction
+      blasterAdmit goal
+      if (← getOptions).getBool `warn.sorry true then
+        logWarning "declaration uses 'blasterProven' (SMT-verified, no proof term)" -- TODO: replace with proof reconstruction
+
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression
@@ -92,6 +100,5 @@ def blasterTacticImp : Tactic := fun stx =>
              let (_, g) ← g.revert #[h]
              return g) goal
         return (goal', nbQuantifiers)
-
 
 end Blaster.Tactic

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -28,6 +28,11 @@ Example: `blaster (timeout: 10) (verbose: 1)`
 syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 
 
+/-- Custom sorry for Blaster
+    Quite useful for AI tools to differentiate
+    between SMT-verified goals and regular sorry-/
+axiom blasterProven : ∀ {α : Prop}, α
+
 @[tactic blasterTactic]
 def blasterTacticImp : Tactic := fun stx =>
   withMainContext $ do
@@ -41,7 +46,10 @@ def blasterTacticImp : Tactic := fun stx =>
        IO.setNumHeartbeats 0
        Translate.main (← goal.getType >>= instantiateMVars') (logUndetermined := false) |>.run env
    match result with
-   | .Valid => goal.admit -- TODO: replace with proof reconstruction
+   | .Valid =>
+      let p ← goal.getType >>= instantiateMVars
+      goal.assign (mkApp (mkConst ``blasterProven []) p)
+      logWarning "declaration uses 'blasterProven' (SMT-verified, no proof term)" -- TODO: replace with proof reconstruction
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>
         -- Replace the goal with the optimized expression

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -28,10 +28,9 @@ Example: `blaster (timeout: 10) (verbose: 1)`
 syntax (name := blasterTactic) "blaster" (solveOption)* : tactic
 
 
-/-- Custom sorry for Blaster
-    Quite useful for AI tools to differentiate
-    between SMT-verified goals and regular sorry-/
-private axiom blasterProven : ∀ {α : Sort u}, α
+/-- Custom sorry for Blaster to differentiate
+    between SMT-verified goals and regular `sorry`.-/
+axiom blasterProven : ∀ {α : Sort u}, α
 
 private def blasterAdmit (mvarId : MVarId) : MetaM Unit :=
   mvarId.withContext do
@@ -56,7 +55,7 @@ def blasterTacticImp : Tactic := fun stx =>
    | .Valid =>
       blasterAdmit goal
       if (← getOptions).getBool `warn.sorry true then
-        logWarning "declaration uses 'blasterProven' (SMT-verified, no proof term)" -- TODO: replace with proof reconstruction
+        logWarningAt stx "declaration uses 'blasterProven' (SMT-verified, no proof term)" -- TODO: replace with proof reconstruction
 
    | .Falsified cex => throwTacticEx `blaster goal "Goal was falsified (see counterexample above)"
    | .Undetermined =>

--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -48,9 +48,7 @@ def falsifiedError (r : Result) : String :=
   s!"Falsified result expected but got {reprStr r}"
 
 
-def blankRef : TranslateEnvT Syntax := do
-  let pos ← getRefPos
-  return Syntax.atom (SourceInfo.original "".toSubstring pos "  ".toSubstring pos) ""
+def blankRef : TranslateEnvT Syntax := getRef
 
 def logResult (r : Result) (isCTI := false) (indLabel := "") (cexLabel := "Counterexample") : TranslateEnvT Unit := do
   let sOpts := (← get).optEnv.options.solverOptions


### PR DESCRIPTION
## Description

This pull request introduces a custom axiom, `blasterProven`, to the Blaster tactic in Lean.
This allows the tactic to mark SMT-verified goals distinctly from those using the standard `sorry`.
Among other things, this aids AI tools as you want them to not use sorry, but use blaster and some of them couldn't differentiate between the two
The implementation of the tactic now assigns `blasterProven` to goals proven by SMT, and logs a warning when it is used, as regular `sorry` does.

It also reacts with `set_option warn.sorry` in a similar manner than `sorry` does.

This PR also fixes the underlines in `#blaster` calls.

<img width="457" height="44" alt="image" src="https://github.com/user-attachments/assets/fd5ea3a7-55db-4c0e-a716-81c10dcd613c" />

It doesn't work well on multilines.
## Type of Change

<!-- Please check the relevant option(s) -->

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Related Issue

None

## Changes Made

- blasterProven axiom, which is the same as sorry
- blasterTacticImp now uses blasterProven

## Testing

None, yolo.

### Test Coverage

- [ ] Added new tests for new functionality
- [ ] Updated existing tests
- [ ] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder

<!-- If breaking changes, provide details here -->

## Documentation

- [ ] README updated (if applicable)
- [ ] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules
<!-- - [ ] CONTRIBUTING.md updated (if workflow changes) -> 

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`
- [ ] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number

## Additional Notes

<!-- Add any additional notes, context, or screenshots here -->

**Blaster tactic enhancements:**

* Added a custom axiom `blasterProven` to distinguish SMT-verified goals from regular `sorry` usage. (`Blaster/Command/Tactic.lean`)
* Updated the `blasterTacticImp` implementation to assign `blasterProven` to SMT-verified goals and log a warning when it is used, instead of using `goal.admit`. (`Blaster/Command/Tactic.lean`)
* Reacts to `warn.sorry` option in the same way as `sorry` does