### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -49,14 +49,14 @@ jobs:
           z3 --version
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and Validate Blaster
         run: make check_blaster
 
       - name: Upload Blaster build log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: blaster-build
           path: ./Blaster/build.log
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Tests log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tests-build
           path: ./Tests/build.log

--- a/.github/workflows/ci-nightly-build.yaml
+++ b/.github/workflows/ci-nightly-build.yaml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Install elan
         run: |


### PR DESCRIPTION
Bump GitHub Actions to Node.js 24 compatible versions. Node.js 20 is deprecated June 2026.