### PR TITLE
Feat/cvc5 backend

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -13,60 +13,113 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LEAN_VERSION: "4.24.0"
   Z3_VERSION: "4.15.2"
   GLIBC_Z3: "2.39"
+  CVC5_VERSION: "1.3.4"
 
 jobs:
-  build:
+  solver-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tier: z3
+            install_z3: true
+            install_cvc5: false
+          - tier: cvc5
+            install_z3: false
+            install_cvc5: true
+          - tier: all-solvers
+            install_z3: true
+            install_cvc5: true
+
+    name: solver tests (${{ matrix.tier }})
+
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Setup Lean
+        # The toolchain is pinned by the repo's `lean-toolchain` file (single
+        # source of truth); elan is installed without a default toolchain to
+        # avoid downloading an unpinned "stable" release.
         run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           echo "/home/runner/.elan/bin" >> $GITHUB_PATH
           chmod +x /home/runner/.elan/bin/*
 
-      - name: Fix Elan version
+      - name: Install Lean toolchain
+        # The toolchain download is a large GitHub-release fetch; retry
+        # transient failures before giving up.
         run: |
-          elan toolchain install ${{ env.LEAN_VERSION }}
-          elan default ${{ env.LEAN_VERSION }}
+          TOOLCHAIN="$(cat lean-toolchain)"
+          for attempt in 1 2 3; do
+            /home/runner/.elan/bin/elan toolchain install "$TOOLCHAIN" && break
+            if [ "$attempt" = 3 ]; then
+              echo "::error::Failed to install Lean toolchain $TOOLCHAIN after 3 attempts"
+              exit 1
+            fi
+            echo "elan toolchain install failed (attempt $attempt), retrying in 15s..."
+            sleep 15
+          done
+          /home/runner/.elan/bin/elan default "$TOOLCHAIN"
 
       - name: Install Z3
+        if: ${{ matrix.install_z3 }}
         run: |
           cd /home/runner/
           wget -q https://github.com/Z3Prover/z3/releases/download/z3-${{ env.Z3_VERSION }}/z3-${{ env.Z3_VERSION }}-x64-glibc-${{ env.GLIBC_Z3 }}.zip
           unzip -q z3-${{ env.Z3_VERSION }}-x64-glibc-${{ env.GLIBC_Z3 }}.zip
-          chmod +x z3-${{ env.Z3_VERSION }}-x64-glibc-${{ env.GLIBC_Z3 }}.zip
+          chmod +x /home/runner/z3-${{ env.Z3_VERSION }}-x64-glibc-${{ env.GLIBC_Z3 }}/bin/z3
           echo "/home/runner/z3-${{ env.Z3_VERSION }}-x64-glibc-${{ env.GLIBC_Z3 }}/bin" >> $GITHUB_PATH
 
-      - name: Tools version
+      - name: Install cvc5
+        if: ${{ matrix.install_cvc5 }}
+        run: |
+          cd /home/runner/
+          wget -q https://github.com/cvc5/cvc5/releases/download/cvc5-${{ env.CVC5_VERSION }}/cvc5-Linux-x86_64-static.zip
+          unzip -q cvc5-Linux-x86_64-static.zip
+          chmod +x /home/runner/cvc5-Linux-x86_64-static/bin/cvc5
+          echo "/home/runner/cvc5-Linux-x86_64-static/bin" >> $GITHUB_PATH
+
+
+      - name: Lean versions
         run: |
           elan --version
           lake --version
           lean --version
-          z3 --version
 
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Z3 version
+        if: ${{ matrix.install_z3 }}
+        run: z3 --version
+
+      - name: cvc5 version
+        if: ${{ matrix.install_cvc5 }}
+        run: cvc5 --version | head -1
 
       - name: Build and Validate Blaster
         run: make check_blaster
+
+
+      - name: Z3 backend tests
+        if: matrix.tier == 'z3'
+        run: make test-z3
+
+      - name: Strict cvc5 result conformance
+        if: matrix.tier == 'cvc5'
+        run: make test-cvc5
+
+      - name: Cross-backend integration
+        if: matrix.tier == 'all-solvers'
+        run: make test-all-solvers
+
 
       - name: Upload Blaster build log
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: blaster-build
-          path: ./Blaster/build.log
-
-      - name: Execute and Validate Tests
-        run: LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests
-
-      - name: Upload Tests log
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: tests-build
-          path: ./Tests/build.log
+          name: blaster-build-${{ matrix.tier }}
+          path: ./build.log
+          if-no-files-found: ignore

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -16,6 +16,7 @@ env:
   Z3_VERSION: "4.15.2"
   GLIBC_Z3: "2.39"
   CVC5_VERSION: "1.3.4"
+  CVC5_FLOOR_VERSION: "1.2.1"
 
 jobs:
   solver-tests:
@@ -28,12 +29,19 @@ jobs:
           - tier: z3
             install_z3: true
             install_cvc5: false
+            install_cvc5_floor: false
           - tier: cvc5
             install_z3: false
             install_cvc5: true
+            install_cvc5_floor: false
           - tier: all-solvers
             install_z3: true
             install_cvc5: true
+            install_cvc5_floor: false
+          - tier: cvc5-1.2.1
+            install_z3: false
+            install_cvc5: false
+            install_cvc5_floor: true
 
     name: solver tests (${{ matrix.tier }})
 
@@ -84,6 +92,15 @@ jobs:
           chmod +x /home/runner/cvc5-Linux-x86_64-static/bin/cvc5
           echo "/home/runner/cvc5-Linux-x86_64-static/bin" >> $GITHUB_PATH
 
+      - name: Install cvc5 support floor
+        if: ${{ matrix.install_cvc5_floor }}
+        run: |
+          cd /home/runner/
+          wget -q https://github.com/cvc5/cvc5/releases/download/cvc5-${{ env.CVC5_FLOOR_VERSION }}/cvc5-Linux-x86_64-static.zip
+          unzip -q cvc5-Linux-x86_64-static.zip
+          mv cvc5-Linux-x86_64-static cvc5-${{ env.CVC5_FLOOR_VERSION }}-Linux-x86_64-static
+          chmod +x /home/runner/cvc5-${{ env.CVC5_FLOOR_VERSION }}-Linux-x86_64-static/bin/cvc5
+          echo "/home/runner/cvc5-${{ env.CVC5_FLOOR_VERSION }}-Linux-x86_64-static/bin" >> $GITHUB_PATH
 
       - name: Lean versions
         run: |
@@ -96,12 +113,15 @@ jobs:
         run: z3 --version
 
       - name: cvc5 version
-        if: ${{ matrix.install_cvc5 }}
+        if: ${{ matrix.install_cvc5 || matrix.install_cvc5_floor }}
         run: cvc5 --version | head -1
 
       - name: Build and Validate Blaster
         run: make check_blaster
 
+      - name: Solver-independent tests
+        if: matrix.tier == 'z3' || matrix.tier == 'cvc5'
+        run: make test-pure
 
       - name: Z3 backend tests
         if: matrix.tier == 'z3'
@@ -109,12 +129,15 @@ jobs:
 
       - name: Strict cvc5 result conformance
         if: matrix.tier == 'cvc5'
-        run: make test-cvc5
+        run: make BLASTER_TIMEOUT=120 test-cvc5
 
       - name: Cross-backend integration
         if: matrix.tier == 'all-solvers'
         run: make test-all-solvers
 
+      - name: cvc5 1.2.1 support-floor compatibility
+        if: matrix.tier == 'cvc5-1.2.1'
+        run: make test-cvc5-floor
 
       - name: Upload Blaster build log
         if: failure()

--- a/Blaster/Command/Options.lean
+++ b/Blaster/Command/Options.lean
@@ -22,6 +22,24 @@ def isExpectedUndetermined : ExpectedResult -> Bool
 | .ExpectedUndetermined => true
 | _ => false
 
+/-- Backend SMT solver used to discharge the translated goals. -/
+inductive SmtSolver where
+  | z3
+  | cvc5
+deriving Repr, DecidableEq
+
+instance : ToString SmtSolver where
+  toString
+    | .z3 => "z3"
+    | .cvc5 => "cvc5"
+
+/-- Parse an `SmtSolver` from its name (as used in the `solver:` option and
+    the `BLASTER_SOLVER` environment variable). -/
+def SmtSolver.ofString? : String → Option SmtSolver
+  | "z3" => some .z3
+  | "cvc5" => some .cvc5
+  | _ => none
+
 /-- Type introducing the options passed on to the solver. -/
 structure BlasterOptions where
   /-- The number of unfolding steps to be considered when
@@ -65,8 +83,17 @@ structure BlasterOptions where
       It is set to `none` by default (i.e., no seed). -/
    randomSeed : Option Nat := none
 
+  /-- Backend SMT solver to be used (`z3` or `cvc5`).
+      When set to `none` (the default), the solver is taken from the
+      `BLASTER_SOLVER` environment variable if defined, and defaults to `z3` otherwise. -/
+  solver : Option SmtSolver := none
+
   /-- When set to `true`, trigger an error if the #solve command does not return a Falsified status. -/
   solveResult : ExpectedResult := .ExpectedValid
+
+  /-- Permit cvc5 to return `Undetermined` for an explicitly allowlisted test while
+      retaining `solveResult` as the expected result when the solver decides it. -/
+  allowCvc5Undetermined : Bool := false
 
   /-- Maximum analysis depth to be considered when performing BMC and K-Induction.
       It is set to 10 by default. -/

--- a/Blaster/Command/Options.lean
+++ b/Blaster/Command/Options.lean
@@ -46,7 +46,9 @@ structure BlasterOptions where
       unfolding a recursive function. It is set to 100 by default. -/
   unfoldDepth : Nat := 100
 
-  /-- The solving timeout in seconds. It is set to 'none' by default (i.e., unlimited). -/
+  /-- The solving timeout in seconds. An explicit value wins; otherwise,
+      `BLASTER_TIMEOUT` is trimmed. An unset or blank value means unlimited,
+      while any nonblank value must be a natural number of seconds or resolution fails. -/
   timeout : Option Nat := none
 
   /-- The verbosity level. It is set to zero by default (i.e., no verbosity).

--- a/Blaster/Command/Syntax.lean
+++ b/Blaster/Command/Syntax.lean
@@ -17,9 +17,13 @@ Options:
   - `only-optimize`: only perform optimization on lean specification and do not translate to smt-lib (default: 0)
   - `dump-smt-lib`: display the smt lib query to stdout (default: 0)
   - `random-seed`: seed for the random number generator (default: none)
+  - `solver`: backend SMT solver to be used, i.e., `z3` or `cvc5`
+              (default: the `BLASTER_SOLVER` environment variable if defined, `z3` otherwise)
   - `gen-cex`: generate counterexample for falsified theorems (default: 1)
   - `solve-result`: specify the expected result from the #blaster command, i.e.,
                     0 for 'Valid', 1 for 'Falsified' and 2 for 'Undetermined'. (default: 0)
+  - `cvc5-allow-undetermined`: allow cvc5 to return `Undetermined` for a known case
+                                  while retaining `solve-result` for decided outcomes (default: 0)
 
 Examples:
    - #blaster [∀ x y : Nat, x + y ≥ x]
@@ -36,8 +40,10 @@ syntax "(only-optimize:" num ")" : solveOption
 syntax "(dump-smt-lib:" num ")" : solveOption
 syntax "(gen-cex:" num ")" : solveOption
 syntax "(solve-result:" num ")" : solveOption
+syntax "(cvc5-allow-undetermined:" num ")" : solveOption
 syntax "(max-depth:" num ")" : solveOption
 syntax "(random-seed:" num ")" : solveOption
+syntax "(solver:" ident ")" : solveOption
 
 -- NOTE: Limited to one term for the time being
 syntax solveTerm := "[" term "]"
@@ -102,12 +108,27 @@ def parseRandomSeed (sOpts : BlasterOptions) : TSyntax `solveOption → m Blaste
       | n => return { sOpts with randomSeed := some n }
   | _ => return sOpts
 
+def parseSolver (sOpts : BlasterOptions) : TSyntax `solveOption → m BlasterOptions
+  | `(solveOption| (solver: $s:ident)) =>
+      match SmtSolver.ofString? s.getId.toString with
+      | some solver => return { sOpts with solver := some solver }
+      | none => throw <| .error s m!"unknown solver '{s.getId}' (expected 'z3' or 'cvc5')"
+  | _ => return sOpts
+
 def parseSolveResult (sOpts : BlasterOptions) : TSyntax `solveOption → m BlasterOptions
   | `(solveOption| (solve-result: $n:num)) =>
       match n.getNat with
       | 0 => return { sOpts with solveResult := .ExpectedValid }
       | 1 => return { sOpts with solveResult := .ExpectedFalsified }
       | 2 => return { sOpts with solveResult := .ExpectedUndetermined }
+      | _ => throwUnsupportedSyntax
+  | _ => return sOpts
+
+def parseCvc5AllowUndetermined (sOpts : BlasterOptions) : TSyntax `solveOption → m BlasterOptions
+  | `(solveOption| (cvc5-allow-undetermined: $n:num)) =>
+      match n.getNat with
+      | 0 => return { sOpts with allowCvc5Undetermined := false }
+      | 1 => return { sOpts with allowCvc5Undetermined := true }
       | _ => throwUnsupportedSyntax
   | _ => return sOpts
 
@@ -121,8 +142,10 @@ def parseSolveOption (sOpts : BlasterOptions) (opt : TSyntax `solveOption) : m B
   let sOpts ← parseDumpSmt sOpts opt
   let sOpts ← parseGenCex sOpts opt
   let sOpts ← parseSolveResult sOpts opt
+  let sOpts ← parseCvc5AllowUndetermined sOpts opt
   let sOpts ← parseMaxDepth sOpts opt
   let sOpts ← parseRandomSeed sOpts opt
+  let sOpts ← parseSolver sOpts opt
   return sOpts
 
 /-! ### Process Multiple Options -/

--- a/Blaster/Command/Syntax.lean
+++ b/Blaster/Command/Syntax.lean
@@ -11,7 +11,9 @@ backend Smt solver on the remaining unsolved goals.
 
 Options:
   - `unfold-depth`: specifying the number of unfolding to be performed on recursive functions (default: 100)
-  - `timeout`: specifying the timeout (in second) to be used for the backend smt solver (defaut: ∞)
+  - `timeout`: timeout in seconds for the backend SMT solver. An explicit option wins;
+               otherwise, trimmed `BLASTER_TIMEOUT` is used. Unset or blank means unlimited;
+               a nonblank value must be a natural number of seconds or resolution fails.
   - `verbose:` activating debug info (default: 0)
   - `only-smt-lib`: only translating unsolved goals to smt-lib without invoking the backend solver (default: 0)
   - `only-optimize`: only perform optimization on lean specification and do not translate to smt-lib (default: 0)

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -14,7 +14,9 @@ namespace Blaster.Tactic
 backend SMT solver (Z3 by default, or cvc5).
 
 Options:
-  - `timeout`: specifying the timeout (in second) to be used for the backend smt solver (defaut: ∞)
+  - `timeout`: timeout in seconds for the backend SMT solver. An explicit option wins;
+               otherwise, trimmed `BLASTER_TIMEOUT` is used. Unset or blank means unlimited;
+               a nonblank value must be a natural number of seconds or resolution fails.
   - `verbose:` activating debug info (default: 0)
   - `only-smt-lib`: only translating unsolved goals to smt-lib without invoking the backend solver (default: 0)
   - `only-optimize`: only perform optimization on lean specification and do not translate to smt-lib (default: 0)

--- a/Blaster/Command/Tactic.lean
+++ b/Blaster/Command/Tactic.lean
@@ -10,7 +10,8 @@ open Blaster.Optimize Blaster.Smt Blaster.Options Blaster.Syntax
 namespace Blaster.Tactic
 
 /--
-`blaster` is an SMT-based tactic that automatically proves goals using Z3.
+`blaster` is an SMT-based tactic that automatically proves goals using the
+backend SMT solver (Z3 by default, or cvc5).
 
 Options:
   - `timeout`: specifying the timeout (in second) to be used for the backend smt solver (defaut: ∞)
@@ -21,6 +22,8 @@ Options:
   - `gen-cex`: generate counterexample for falsified theorems (default: 1)
   - `unfold-depth`: specifying the number of unfolding to be performed on recursive functions (default: 100)
   - `random-seed`: seed for the random number generator (default: none)
+  - `solver`: backend SMT solver to be used, i.e., `z3` or `cvc5`
+              (default: the `BLASTER_SOLVER` environment variable if defined, `z3` otherwise)
   - `solve-result`: specify the expected result from the blaster tactic, i.e.,
                     0 for 'Valid', 1 for 'Falsified' and 2 for 'Undetermined'. (default: 0)
 Example: `blaster (timeout: 10) (verbose: 1)`

--- a/Blaster/Optimize/Env.lean
+++ b/Blaster/Optimize/Env.lean
@@ -349,8 +349,14 @@ structure SmtEnv where
   /-- Smt-Lib commands emitted to the backend solver. -/
   smtCommands : Array SmtCommand
 
-  /-- Backend solver process. -/
+  /-- Backend solver process, if one has been spawned. This remains `none` on
+      optimizer-only and `only-smt-lib` paths. -/
   smtProc : Option (IO.Process.Child ⟨.piped, .piped, .piped⟩)
+
+  /-- Selected backend solver. It defaults to Z3 and is resolved/stored when an
+      `Undetermined` optimizer-only result needs backend policy or during solver
+      setup; `smtProc` may remain `none` when no process is spawned. -/
+  solver : SmtSolver
 
   /-- Cache keeping track of visited inductive datatype during translation. -/
   indTypeVisited : Std.HashSet Lean.Name
@@ -450,6 +456,7 @@ instance : Inhabited SmtEnv where
    { translateCache := Std.HashMap.emptyWithCapacity,
      smtCommands := Array.mkEmpty 1023,
      smtProc := default,
+     solver := .z3,
      indTypeVisited := Std.HashSet.emptyWithCapacity,
      indTypeInstCache := Std.HashMap.emptyWithCapacity,
      funInstCache := Std.HashMap.emptyWithCapacity,

--- a/Blaster/Smt/EmitCommand.lean
+++ b/Blaster/Smt/EmitCommand.lean
@@ -334,10 +334,10 @@ def SmtCommand.emit (c : SmtCommand) : TranslateEnvT Unit := do
      | .exitSmt => h.putStr "(exit)\n"
      | .getModel => h.putStr "(get-model)\n"
      | .getProof => h.putStr "(get-proof)\n"
-     | .evalTerm t =>
-          h.putStr "(eval "
+     | .getValue t =>
+          h.putStr "(get-value ("
           t.emit
-          h.putStr ")\n"
+          h.putStr "))\n"
      | .setLogic l =>
           h.putStr "(set-logic "
           h.putStr l

--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -2,6 +2,7 @@ import Lean
 import Blaster.Command.Options
 import Blaster.Optimize.Env
 import Blaster.Smt.EmitCommand
+import Blaster.Smt.Model
 
 open Lean Meta Blaster.Optimize Blaster.Options
 
@@ -12,12 +13,62 @@ namespace Blaster.Smt
 private def normalizeLine (s : String) : String :=
   s.replace "\r" ""
 
-/-- Executable candidates, version arguments, and process arguments for a solver. -/
-private def solverConfig : SmtSolver → Array String × Array String × Array String
-  | .z3 => (#["z3", "wsl z3"], #["-version"], #["-in", "-smt2"])
+/-- One executable launch candidate. `cmd` is exactly one executable name;
+    wrapper subcommands such as WSL's solver name belong in `prefixArgs`. -/
+structure SolverCandidate where
+  cmd : String
+  prefixArgs : Array String := #[]
+deriving Repr, BEq, Inhabited
+
+/-- Human-readable candidate spelling used only in diagnostics. -/
+def SolverCandidate.display (candidate : SolverCandidate) : String :=
+  String.intercalate " " (candidate.cmd :: candidate.prefixArgs.toList)
+
+/-- Static description of a supported backend solver executable. -/
+structure SolverDescriptor where
+  /-- Display name of the solver. -/
+  name : String
+  /-- Launch candidates probed in order (Windows support goes through WSL). -/
+  candidates : Array SolverCandidate
+  /-- Arguments used to probe the executable and query its version. -/
+  versionArgs : Array String
+  /-- Minimal version of the solver we support. -/
+  minVersion : String
+  /-- Arguments used to spawn the solver reading SMT-LIB commands from stdin. -/
+  spawnArgs : Array String
+
+/-- Exact executable and argv used to probe a candidate's version. -/
+def SolverDescriptor.probeInvocation (desc : SolverDescriptor) (candidate : SolverCandidate) :
+    String × Array String :=
+  (candidate.cmd, candidate.prefixArgs ++ desc.versionArgs)
+
+/-- Exact executable and argv used to start a candidate as an SMT process. -/
+def SolverDescriptor.spawnInvocation (desc : SolverDescriptor) (candidate : SolverCandidate) :
+    String × Array String :=
+  (candidate.cmd, candidate.prefixArgs ++ desc.spawnArgs)
+
+/-- Per-solver executable description.
+    NOTE: cvc5 is spawned with `--parsing-mode=lenient` because Blaster emits
+    `@`-prefixed symbols (e.g. `@isNat`), which strict SMT-LIB parsing reserves
+    for solver-internal use. `--incremental` is required for `check-sat-assuming`
+    based strategies (BMC/K-Induction). `--dt-nested-rec` enables (experimental)
+    support for nested recursive datatypes (e.g. a constructor taking a
+    `(List Term)` argument), which cvc5 rejects by default whereas z3 accepts.
+    NOTE: Blaster enforces and smoke-tests cvc5 1.2.1 as the minimum supported
+    version; the required spawn arguments and SMT-LIB options work there. -/
+def _root_.Blaster.Options.SmtSolver.descriptor : SmtSolver → SolverDescriptor
+  | .z3 =>
+     { name := "z3",
+       candidates := #[{ cmd := "z3" }, { cmd := "wsl", prefixArgs := #["z3"] }],
+       versionArgs := #["-version"],
+       minVersion := "4.15.2",
+       spawnArgs := #["-in", "-smt2"] }
   | .cvc5 =>
-      (#["cvc5", "wsl cvc5"], #["--version"],
-        #["--lang", "smt2", "--incremental", "--parsing-mode=lenient", "--dt-nested-rec"])
+     { name := "cvc5",
+       candidates := #[{ cmd := "cvc5" }, { cmd := "wsl", prefixArgs := #["cvc5"] }],
+       versionArgs := #["--version"],
+       minVersion := "1.2.1",
+       spawnArgs := #["--lang", "smt2", "--incremental", "--parsing-mode=lenient", "--dt-nested-rec"] }
 
 /-- Result of an Smt query. -/
 inductive Result where
@@ -68,6 +119,7 @@ inductive UndeterminedAction where
   | warning
 deriving Repr, BEq, DecidableEq
 
+/-- Decide `Undetermined` handling without logging or consulting process state. -/
 def undeterminedAction
     (sOpts : BlasterOptions) (solver : SmtSolver) (strictRequested : Bool) :
     UndeterminedAction :=
@@ -110,25 +162,107 @@ def logResult (r : Result) (isCTI := false) (indLabel := "") (cexLabel := "Count
          cex.forM (λ s => f s!" - {s.trimRight}")
       else f failure
 
-/-- Find the first working executable candidate for `solver`. -/
-private def findSolverCmdAndVersion (solver : SmtSolver) : IO String := do
-  let (candidates, versionArgs, _) := solverConfig solver
-  let mut attemptLogs := #[]
-  for candidate in candidates do
-    try
-      let out ← IO.Process.output { cmd := candidate, args := versionArgs }
-      if out.exitCode == 0 then
-        return candidate
-      else
-        attemptLogs := attemptLogs.push
-          s!"Candidate '{candidate}': exit code {out.exitCode}"
-    catch e =>
-      attemptLogs := attemptLogs.push
-        s!"Candidate '{candidate}': IO error => {e}"
-  let attemptsReport := String.join (attemptLogs.toList.map (fun x => x ++ "\n"))
-  throw <| IO.userError s!"❌ Could not find a working {solver}.\n\nTried:\n{attemptsReport}"
+/-- Numeric components of the first dotted version number (e.g. `4.15.2`)
+    occurring in a solver's version banner; `none` when no such token exists. -/
+def parseVersionNumbers (banner : String) : Option (List Nat) :=
+  ((banner.split Char.isWhitespace).filterMap versionToken).head?
+ where
+  versionToken (tok : String) : Option (List Nat) :=
+    let tok := tok.takeWhile (λ c => c.isDigit || c == '.')
+    if tok.isEmpty || !tok.contains '.' then none
+    else (tok.split (· == '.')).mapM String.toNat?
 
-/-- Resolve a solver from an explicit option and a supplied environment value. -/
+/-- `a` is at least `b` where both are dotted-version components; missing
+    components count as zero (so `1.2` and `1.2.0` compare equal). -/
+def versionAtLeast : (a b : List Nat) → Bool
+  | _, [] => true
+  | [], b => b.all (· == 0)
+  | x :: xs, y :: ys => x > y || (x == y && versionAtLeast xs ys)
+
+/-- Verdict of checking a solver's version banner against the minimal
+    supported version. -/
+inductive VersionCheck where
+  | ok
+  /-- The banner parsed but the version is below the minimal supported one. -/
+  | tooOld (found : List Nat)
+  /-- No dotted version number could be found in the banner. -/
+  | unparseable
+deriving Repr, DecidableEq
+
+/-- Check a solver's version `banner` against `minVersion`.
+    Fails closed: a banner without a parseable version is rejected
+    (`.unparseable`) rather than accepted as an unknown solver build, since
+    accepting an executable whose version cannot be established risks
+    silently wrong solver behavior. Official z3/cvc5 banners — including dev
+    builds, whose `1.3.5-dev.105` style tokens parse up to the suffix — all
+    carry a parseable version.
+    An unparseable `minVersion` (a Blaster bug, not a user error) imposes no
+    lower bound instead of rejecting every solver. -/
+def checkVersionBanner (minVersion : String) (banner : String) : VersionCheck :=
+  let required := (parseVersionNumbers minVersion).getD []
+  match parseVersionNumbers banner with
+  | none => .unparseable
+  | some found => if versionAtLeast found required then .ok else .tooOld found
+
+/-- Outcome of probing one solver-executable candidate with its version
+    arguments. Pure data so that the acceptance policy can be unit-tested
+    without spawning processes (see `evalCandidateProbe`). -/
+inductive ProbeOutcome where
+  /-- The probe ran and exited with `exitCode`, producing `stdout`. -/
+  | ran (exitCode : UInt32) (stdout : String)
+  /-- The probe could not run at all (e.g. executable not found). -/
+  | failed (error : String)
+deriving Repr
+
+/-- First line of the probe's stdout (the solver's version banner). -/
+def ProbeOutcome.banner : ProbeOutcome → String
+  | .ran _ stdout => ((stdout.splitOn "\n").headD "").trimRight
+  | .failed _ => ""
+
+/-- Verdict for one candidate probe: accept the candidate, or produce the
+    human-readable rejection reason (one line of the discovery report).
+    This is the single acceptance-policy point shared by solver discovery
+    (`findSolverCandidateAndVersion`) and the `solvercheck` executable. -/
+def evalCandidateProbe (desc : SolverDescriptor) (candidate : SolverCandidate) :
+    ProbeOutcome → Except String Unit
+  | .failed err => .error s!"Candidate '{candidate.display}': IO error => {err}"
+  | outcome@(.ran exitCode _) =>
+      if exitCode != 0 then
+        .error s!"Candidate '{candidate.display}': exit code {exitCode}"
+      else
+        match checkVersionBanner desc.minVersion outcome.banner with
+        | .ok => .ok ()
+        | .tooOld found =>
+            .error s!"Candidate '{candidate.display}': version {String.intercalate "." (found.map toString)} is older than the minimal supported {desc.minVersion}"
+        | .unparseable =>
+            .error s!"Candidate '{candidate.display}': could not parse a version from '{outcome.banner}' (unrecognized {desc.name} builds are rejected; version ≥ {desc.minVersion} is required)"
+
+/-- Run one candidate's version probe, capturing failures to spawn (e.g.
+    executable not found) as data. -/
+def probeSolverCandidate (desc : SolverDescriptor) (candidate : SolverCandidate) : IO ProbeOutcome := do
+  let (cmd, args) := desc.probeInvocation candidate
+  try
+    let out ← IO.Process.output { cmd := cmd, args := args }
+    return .ran out.exitCode out.stdout
+  catch e =>
+    return .failed (toString e)
+
+/-- Find a usable solver launch specification: candidates are probed in order
+    (native executable first, then a best-effort WSL fallback) and the first
+    one passing the version policy (see `evalCandidateProbe`) wins. -/
+private def findSolverCandidateAndVersion (solver : SmtSolver) : IO SolverCandidate := do
+  let desc := solver.descriptor
+  let mut attemptLogs := #[]
+  for candidate in desc.candidates do
+    match evalCandidateProbe desc candidate (← probeSolverCandidate desc candidate) with
+    | .ok () => return candidate
+    | .error log => attemptLogs := attemptLogs.push log
+  -- If we get here, no candidate succeeded
+  let attemptsReport := String.join (attemptLogs.toList.map (fun x => x ++ "\n"))
+  throw <| IO.userError s!"❌ Could not find a working {desc.name} ≥ {desc.minVersion}.\n\nTried:\n{attemptsReport}"
+
+/-- Resolve a solver from an explicit option and a supplied environment value.
+    Surrounding whitespace is ignored, but solver names are case-sensitive. -/
 def resolveSolverConfig
     (sOpts : BlasterOptions) (envValue : Option String) : Except String SmtSolver := do
   if let some solver := sOpts.solver then return solver
@@ -137,17 +271,38 @@ def resolveSolverConfig
     | throw s!"❌ Unknown BLASTER_SOLVER value '{str}' (expected 'z3' or 'cvc5')."
   return solver
 
-/-- Resolve the explicit option, then `BLASTER_SOLVER`, then the Z3 default. -/
+/-- Resolve the backend solver to be used from the explicit option, then the
+    process environment, then the Z3 default. -/
 def resolveSolver (sOpts : BlasterOptions) : IO SmtSolver := do
   match resolveSolverConfig sOpts (← IO.getEnv "BLASTER_SOLVER") with
   | .ok solver => return solver
   | .error message => throw <| IO.userError message
 
-/-- Spawn the selected backend solver. -/
-def createBlasterProcess (solver : SmtSolver) :
-    IO (IO.Process.Child ⟨.piped, .piped, .piped⟩) := do
-  let cmd ← findSolverCmdAndVersion solver
-  let (_, _, args) := solverConfig solver
+/-- Resolve a timeout from an explicit option and a supplied environment value.
+    Surrounding whitespace is ignored; an unset or whitespace-only value means
+    no timeout, while any other value must be a natural number of seconds. -/
+def resolveTimeoutConfig
+    (sOpts : BlasterOptions) (envValue : Option String) : Except String (Option Nat) := do
+  if let some timeout := sOpts.timeout then return some timeout
+  let some str := envValue | return none
+  let value := str.trim
+  if value.isEmpty then return none
+  let some timeout := value.toNat?
+    | throw s!"❌ Invalid BLASTER_TIMEOUT value '{str}' (expected a number of seconds)."
+  return some timeout
+
+/-- Resolve the solving timeout from the explicit option, then the process
+    environment, then the unlimited default. -/
+def resolveTimeout (sOpts : BlasterOptions) : IO (Option Nat) := do
+  match resolveTimeoutConfig sOpts (← IO.getEnv "BLASTER_TIMEOUT") with
+  | .ok timeout => return timeout
+  | .error message => throw <| IO.userError message
+
+/-- Spawn a solver process w.r.t. the provided backend solver. -/
+def createBlasterProcess (solver : SmtSolver) : IO (IO.Process.Child ⟨.piped, .piped, .piped⟩) := do
+  let desc := solver.descriptor
+  let candidate ← findSolverCandidateAndVersion solver  -- ensures version is OK
+  let (cmd, args) := desc.spawnInvocation candidate
   IO.Process.spawn {
     stdin  := .piped
     stdout := .piped
@@ -156,6 +311,7 @@ def createBlasterProcess (solver : SmtSolver) :
     args   := args
   }
 
+/-- Return the backend solver in use (see `resolveSolver` and `setBlasterProcess`). -/
 def getSolver : TranslateEnvT SmtSolver :=
   return (← get).smtEnv.solver
 
@@ -191,18 +347,86 @@ def checkCancelTk? : TranslateEnvT Unit := do
       discard $ p.wait
       throwInterruptException
 
-/-- Retrieve model output from `h` when a counterexample is generated.
-    NOTE: A model output starts with "(" and ends with ")\n".
+/-- Retire the solver process and drain whatever it wrote to stderr. This error
+    path owns process cleanup: clearing `smtProc` before raising the contextual
+    error prevents `throwEnvError` from killing or waiting for
+    the same child again. An exited child needs neither operation; if it exits
+    between `tryWait` and `kill`, the failed kill is harmless and one wait
+    still reaps it. -/
+private def killAndDrainStderr : TranslateEnvT String := do
+  let some p := (← get).smtEnv.smtProc | return ""
+  modify fun env => { env with smtEnv.smtProc := none }
+  let shouldTerminate ←
+    try pure (← p.tryWait).isNone
+    catch _ => pure false
+  if shouldTerminate then
+    try p.kill catch _ => pure ()
+    try discard p.wait catch _ => pure ()
+  return (← p.stderr.readToEnd).trim
+
+/-- Render drained stderr for inclusion in an error message (empty when the
+    solver wrote nothing). -/
+private def stderrNote (stderr : String) : String :=
+  if stderr.isEmpty then "" else s!"\nSolver stderr:\n{stderr}"
+
+/-- State used when scanning a solver response for balanced parentheses.
+    Parentheses occurring inside string literals (`"…"`) and quoted symbols
+    (`|…|`) are not counted.
+-/
+private structure SexpScanState where
+  depth : Int := 0
+  seenParen : Bool := false
+  inString : Bool := false
+  inQuotedSym : Bool := false
+
+/-- Feed one line of solver output to the parenthesis scanner.
+    NOTE: SMT-LIB escapes a quote inside a string literal by doubling it (`""`).
+    Treating the doubled quote as close-then-reopen leaves the scanner in the
+    correct state without lookahead.
+-/
+private def scanSexpLine (st : SexpScanState) (s : String) : SexpScanState :=
+  s.foldl (λ st c =>
+    if st.inString then
+      if c == '"' then { st with inString := false } else st
+    else if st.inQuotedSym then
+      if c == '|' then { st with inQuotedSym := false } else st
+    else match c with
+      | '"' => { st with inString := true }
+      | '|' => { st with inQuotedSym := true }
+      | '(' => { st with depth := st.depth + 1, seenParen := true }
+      | ')' => { st with depth := st.depth - 1 }
+      | _ => st) st
+
+private def SexpScanState.isBalanced (st : SexpScanState) : Bool :=
+  st.seenParen && st.depth == 0
+
+/-- Retrieve a model (or proof) response from `h`.
+    A model response (`(get-model)`) is a single S-expression, possibly
+    spanning several lines: reading stops when parentheses tally to zero
+    (parentheses inside string literals and quoted symbols are not counted),
+    so single-line responses — including `(error "…")` reports — terminate
+    instead of waiting for closing lines that will never come.
+    A proof response (z3) is terminated by an empty line instead.
     Line endings are normalized to handle both Unix (LF) and Windows (CRLF).
+    NOTE: `getLine` returning the empty string means the solver closed its
+    output stream (e.g. it crashed mid-response): fail — surfacing the
+    solver's stderr — instead of spinning on a response that can never
+    complete.
 -/
 partial def getOutputModel (h : IO.FS.Handle) (proof := false) : TranslateEnvT String := do
-  let rec loop (acc : String) : TranslateEnvT String := do
+  let rec loop (acc : String) (st : SexpScanState) : TranslateEnvT String := do
     checkCancelTk?
     let line := normalizeLine (← h.getLine)
-    if (line == ")\n" && !proof) || (line == "\n" && proof) then
-      return acc
-    else loop (acc ++ line)
-  loop ""
+    if line.isEmpty then
+      let stderr ← killAndDrainStderr
+      throwEnvError s!"The solver closed its output stream while a model/proof response was pending.{stderrNote stderr}"
+    if proof then
+      if line == "\n" then return acc else loop (acc ++ line) st
+    else
+      let st := scanSexpLine st line
+      let acc := acc ++ line
+      if st.isBalanced then return acc else loop acc st
+  loop "" {}
 
 /-- Retrieve proof output for an `unsat` result.
     NOTE: A proof output starts with "(proof" and ends with ")\n\n".
@@ -216,53 +440,96 @@ def getOutputProof := λ h => getOutputModel h true
 -/
 partial def getErrorMsg (h : IO.FS.Handle) : IO String := normalizeLine <$> h.getLine
 
-/-- Retrieve a `get-value` response, which may span multiple lines. -/
+
+/-- Retrieve a `get-value` response from `h` after executing `(get-value (t))`.
+    The response has the form `((t v))` and may span several lines when `v` is
+    an inductive datatype value. Reading stops when parentheses tally to zero.
+    NOTE: `getLine` returning the empty string means the solver closed its
+    output stream (e.g. it crashed mid-response): fail instead of spinning on
+    a response that can never complete.
+-/
 partial def getOutputGetValue (h : IO.FS.Handle) : IO String := do
   let line := normalizeLine (← h.getLine)
+  if line.isEmpty then throw eofError
   if line.get! 0 != '(' then return line
-  getValue line (tallyParenthesis line 0)
- where
-  tallyParenthesis (s : String) (tally : Int) : Int :=
-    s.foldr (λ c acc =>
-      match c with
-      | '(' => acc + 1
-      | ')' => acc - 1
-      | _ => acc) tally
-  getValue (acc : String) (tally : Int) : IO String := do
-    if tally == 0 then return acc
-    let line := normalizeLine (← h.getLine)
-    getValue (acc ++ line) (tallyParenthesis line tally)
+  loop line (scanSexpLine {} line)
 
-/-- Extract `v` from a `get-value` response of the form `((t v))`. -/
+ where
+  eofError : IO.Error := .userError
+    "❌ The solver closed its output stream while a get-value response was pending."
+
+  loop (acc : String) (st : SexpScanState) : IO String := do
+    if st.isBalanced then return acc
+    else
+      let line := normalizeLine (← h.getLine)
+      if line.isEmpty then throw eofError
+      loop (acc ++ line) (scanSexpLine st line)
+
+/-- Drop one S-expression (atom, string literal, quoted symbol or
+    parenthesized expression) from the front of `cs`.
+-/
+private partial def dropSexp (cs : List Char) : List Char :=
+  match cs with
+  | [] => []
+  | '(' :: rest => dropParen rest 1
+  | '"' :: rest => dropDelimited rest '"'
+  | '|' :: rest => dropDelimited rest '|'
+  | _ :: _ => cs.dropWhile (λ c => !c.isWhitespace && c != '(' && c != ')')
+
+ where
+  dropParen (cs : List Char) (depth : Nat) : List Char :=
+    match cs with
+    | [] => []
+    | '"' :: rest => dropParen (dropDelimited rest '"') depth
+    | '|' :: rest => dropParen (dropDelimited rest '|') depth
+    | '(' :: rest => dropParen rest (depth + 1)
+    | ')' :: rest => if depth == 1 then rest else dropParen rest (depth - 1)
+    | _ :: rest => dropParen rest depth
+  dropDelimited (cs : List Char) (delim : Char) : List Char :=
+    match cs with
+    | [] => []
+    | c :: rest => if c == delim then rest else dropDelimited rest delim
+
+/-- Extract the value `v` from a `get-value` response of the form `((t v))`.
+    The result is trimmed. When the response does not have the expected shape
+    (e.g. an error), it is returned unchanged (trimmed) so that it can be
+    reported as-is.
+-/
 partial def unwrapGetValueOutput (s : String) : String :=
   let cs := s.toList.dropWhile Char.isWhitespace
   match cs with
   | '(' :: rest =>
       match rest.dropWhile Char.isWhitespace with
       | '(' :: inner =>
+          -- drop the echoed term, the remainder up to the innermost closing
+          -- parenthesis is the value
           let afterTerm := dropSexp (inner.dropWhile Char.isWhitespace)
-          String.mk (takeValue afterTerm 0 []) |>.trim
+          let value := takeValue afterTerm 0 []
+          String.mk value |>.trim
       | _ => s.trim
   | _ => s.trim
+
  where
-  dropSexp (cs : List Char) : List Char :=
-    match cs with
-    | [] => []
-    | '(' :: rest => dropParen rest 1
-    | _ :: _ => cs.dropWhile (λ c => !c.isWhitespace && c != '(' && c != ')')
-  dropParen (cs : List Char) (depth : Nat) : List Char :=
-    match cs with
-    | [] => []
-    | '(' :: rest => dropParen rest (depth + 1)
-    | ')' :: rest => if depth == 1 then rest else dropParen rest (depth - 1)
-    | _ :: rest => dropParen rest depth
   takeValue (cs : List Char) (depth : Nat) (acc : List Char) : List Char :=
     match cs with
     | [] => acc.reverse
     | '(' :: rest => takeValue rest (depth + 1) ('(' :: acc)
     | ')' :: rest =>
         if depth == 0 then acc.reverse else takeValue rest (depth - 1) (')' :: acc)
+    | '"' :: rest =>
+        let (chunk, rest) := takeDelimited rest '"' ['"']
+        takeValue rest depth (chunk ++ acc)
+    | '|' :: rest =>
+        let (chunk, rest) := takeDelimited rest '|' ['|']
+        takeValue rest depth (chunk ++ acc)
     | c :: rest => takeValue rest depth (c :: acc)
+  -- returns the delimited chunk in reverse order together with the remainder
+  takeDelimited (cs : List Char) (delim : Char) (acc : List Char) : List Char × List Char :=
+    match cs with
+    | [] => (acc, [])
+    | c :: rest =>
+        if c == delim then (c :: acc, rest)
+        else takeDelimited rest delim (c :: acc)
 
 /-- Push smt command `c` in the translation environment only when sOpts.dumpSmtLib is set -/
 def storeCommand (c : SmtCommand) : TranslateEnvT Unit := do
@@ -290,6 +557,9 @@ partial def trySubmitCommand! (c : SmtCommand) (checkSuccess := true) : Translat
   let out := normalizeLine (← h.getLine)
   match out with
   | "success\n" => return ()
+  | "" =>
+      let stderr ← killAndDrainStderr
+      throwEnvError s!"The solver closed its output stream while executing {c}.{stderrNote stderr}"
   | err => throwEnvError s!"Unexpected smt error: {err} for {c}"
 
 /-- Same as trySubmitCommand! but with flag `checkSuccess` set to `false`.
@@ -548,21 +818,44 @@ def defineInttoNat : TranslateEnvT Unit := do
   let fdef := iteSmt xGeqZero xId natZero
   defineFun toNatSymbol #[(xsym, intSort)] natSort fdef
 
-/-- Retrieve and unwrap the value of `t` using standard SMT-LIB `get-value`. -/
+/-- Try to retrieve the value of term `t` when a `sat` result is obtained, using the
+    standard `(get-value (t))` command, and return the reconstructed value
+    (see `Blaster.Smt.reconstructGetValue?`): solver-specific formatting —
+    cvc5's `as` constructor qualifiers and `let`-shared subterms, z3's line
+    wrapping, `(- n)` negatives, SMT-LIB string escapes — is normalized to a
+    Lean-flavored rendering.
+    When the solver reports an error instead of a value (e.g. a partial model
+    for an unsupported construct), an informative `<no value: …>` marker is
+    produced; any other unrecognized response is returned unwrapped and
+    trimmed, so it can be reported as-is.
+    Do nothing if the Smt process is not defined.
+-/
 def evalTerm (t : SmtTerm) : TranslateEnvT String := do
   let env ← get
   let some p := env.smtEnv.smtProc | return ""
   checkCancelTk?
   submitCommand (.getValue t)
-  return unwrapGetValueOutput (← getOutputGetValue p.stdout)
+  let response ←
+    try getOutputGetValue p.stdout
+    catch e =>
+      -- e.g. the solver closed its stdout mid-response: surface its stderr,
+      -- which typically carries the actual failure reason.
+      let stderr ← killAndDrainStderr
+      throwEnvError m!"{e.toMessageData}{stderrNote stderr}"
+  match reconstructGetValue? response with
+  | some v => return v
+  | none =>
+      match solverErrorMsg? response with
+      | some msg => return s!"<no value: {msg}>"
+      | none => return unwrapGetValueOutput response
 
 /-- Try to retrieve the model when a `sat` result is obtained and dump result to stdout.
     Do nothing when:
       - No solver instance is defined
       - Option solverOptions.generateCex is set to `false`
-    TODO: We need to define the Smt-lib syntax and term elaborator to parse produced model
-    and generate the corresponding Lean representation.
-    This will also be helpful when writing the test cases to validate the Smt-Lib translation.
+    NOTE: Values retrieved through `evalTerm` are reconstructed into a
+    Lean-flavored rendering; the raw `(get-model)` dump used when no top-level
+    variable exists is displayed as produced by the solver.
 -/
 def getModel : TranslateEnvT (List String) := do
   let env ← get
@@ -574,7 +867,12 @@ def getModel : TranslateEnvT (List String) := do
   then
     submitCommand (.getModel)
     let s ← getOutputModel p.stdout
-    return [s]
+    -- A solver may report an error instead of a model (e.g. a construct it
+    -- cannot model): surface the failure inline rather than displaying the
+    -- error report as if it were a model.
+    match solverErrorMsg? s with
+    | some msg => return [s!"<no model available: {msg}>"]
+    | none => return [s]
   else
     -- Note: List is append when adding top level variables
     -- We therefore need to traverse the list in reverse order to
@@ -604,7 +902,12 @@ partial def getSatResult (p : IO.Process.Child ⟨.piped, .piped, .piped⟩) : T
        match normalizeLine (← IO.ofExcept res.get) with
        | "sat\n"     => return (.Falsified (← getModel))
        | "unsat\n"   => return .Valid
-       | "unknown\n" => return .Undetermined -- unknown is also return when timeout is set to stdin
+       -- also returned when the per-check time limit is hit; a model MUST NOT
+       -- be queried in this state (SMT-LIB only allows it after `sat`)
+       | "unknown\n" => return .Undetermined
+       | "" =>
+           let stderr ← killAndDrainStderr
+           throwEnvError s!"checkSat: The solver closed its output stream before reporting a result (it may have crashed or run out of memory).{stderrNote stderr}"
        | err => throwEnvError s!"checkSat: Unexpected check-sat result: {err}"
      else
        let sleepTimeMs := (20 : UInt32)
@@ -670,13 +973,15 @@ def setProduceProofs (b : Bool) : TranslateEnvT Unit :=
 def setProduceModels (b : Bool) : TranslateEnvT Unit :=
   trySubmitCommand! (.setOption ":produce-models" (toString b))
 
-/-- Set model-based quantifier instantiation for the selected solver. -/
+/-- Set model-based quantifier instantiation to `b`
+    (z3: `smt.mbqi`, cvc5: `mbqi`; the underlying algorithms differ). -/
 def setMbqi (b : Bool) : TranslateEnvT Unit := do
   match ← getSolver with
   | .z3 => trySubmitCommand! (.setOption ":smt.mbqi" (toString b))
   | .cvc5 => trySubmitCommand! (.setOption ":mbqi" (toString b))
 
-/-- Set Z3's nested-quantifier option; cvc5 has no equivalent. -/
+/-- Set Smt `smt.pull-nested-quantifiers` option to `b`.
+    NOTE: z3-only option, no-op for other solvers. -/
 def setPullNestedQuantifiers (b : Bool) : TranslateEnvT Unit := do
   let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.pull-nested-quantifiers" (toString b))
@@ -685,57 +990,81 @@ def setPullNestedQuantifiers (b : Bool) : TranslateEnvT Unit := do
 def setPrintSuccess (b : Bool) : TranslateEnvT Unit :=
   trySubmitCommand! (.setOption ":print-success" (toString b))
 
-/-- Set the random seed using the selected solver's option name. -/
+/-- Set the random seed to `n` or none (z3: `smt.random-seed`, cvc5: `seed`). -/
 def setRandomSeed (n : Option Nat) : TranslateEnvT Unit := do
   let some n := n | return ()
   match ← getSolver with
   | .z3 => trySubmitCommand! (.setOption ":smt.random-seed" (toString n))
   | .cvc5 => trySubmitCommand! (.setOption ":seed" (toString n))
 
-/-- Set Z3's `auto_config` option; cvc5 has no equivalent. -/
+/-- Set Smt `auto_config` option to `b`.
+    NOTE: z3-only option, no-op for other solvers. -/
 def setAutoConfig (b : Bool) : TranslateEnvT Unit := do
   let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":auto_config" (toString b))
 
+/-- Set Smt `smt.case_split` to `n`, with n ∈ [0..6].
+    NOTE: z3-only option, no-op for other solvers. -/
 def setCaseSplit (n : Nat) : TranslateEnvT Unit := do
   let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.case_split" (toString n))
 
+/-- Set Smt `smt.qi.eager_threshold` to `n`.
+    NOTE: z3-only option, no-op for other solvers. -/
 def setQiEagerThreshold (n : Nat) : TranslateEnvT Unit := do
   let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.qi.eager_threshold" (toString n))
 
+
+/-- Set Smt `smt.delay_units` to `b`.
+    NOTE: z3-only option, no-op for other solvers. -/
 def setDelayUnits (b : Bool) : TranslateEnvT Unit := do
   let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.delay_units" (toString b))
 
-/-- Set macro handling using the selected solver's option name. -/
+/-- Set macro elimination to `b` (z3: `smt.macro_finder`, cvc5: `macros-quant`). -/
 def setMacroFinder (b : Bool) : TranslateEnvT Unit := do
   match ← getSolver with
   | .z3 => trySubmitCommand! (.setOption ":smt.macro_finder" (toString b))
   | .cvc5 => trySubmitCommand! (.setOption ":macros-quant" (toString b))
 
+/-- Set Smt `smt.relevancy` option to `i`.
+    NOTE: z3-only option, no-op for other solvers. -/
 def setRelevancy (n : Nat) : TranslateEnvT Unit := do
   let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.relevancy" (toString n))
 
-/-- Set the solver-specific per-check timeout when requested. -/
+/-- Set the solving timeout when the option is specified.
+    NOTE: z3's `timeout` applies per context whereas cvc5's `tlimit-per`
+    applies to each `check-sat` individually (cvc5's `tlimit` is a no-op
+    when set via `set-option`). Both are expressed in milliseconds.
+-/
 def setTimeout : TranslateEnvT Unit := do
   let sOpts := (← get).optEnv.options.solverOptions
   let some n := sOpts.timeout | return ()
+  -- need to convert timeout to milliseconds
   match ← getSolver with
   | .z3 => trySubmitCommand! (.setOption ":timeout" (toString (n * 1000)))
   | .cvc5 => trySubmitCommand! (.setOption ":tlimit-per" (toString (n * 1000)))
 
-/-- Set the default Smt options, i.e.:
+/-- Set the default Smt options, i.e., for every solver:
      - (set-option :print-success true)
      - (set-option :produce-models true)
      - (set-option :produce-proofs true)
-     - (set-option :smt-pull-nested-quantifiers true)
-     - (set-option :smt-mbqi true)
+    for z3:
+     - (set-option :smt.pull-nested-quantifiers true)
+     - (set-option :smt.mbqi true)
      - (set-option :auto_config false)
      - (set-option :smt.random-seed n) when `n` is provided in solver options
      - (set-option :smt.macro_finder true)
+     - (set-option :timeout n) when a timeout is provided in solver options
+    for cvc5:
+     - (set-option :mbqi true)
+     - (set-option :seed n) when `n` is provided in solver options
+     - (set-option :macros-quant true)
+     - (set-option :tlimit-per n) when a timeout is provided in solver options
+     - (set-logic ALL) — cvc5 requires the logic to be set before any
+       declaration (`ALL` matches z3's behavior when no logic is set)
 -/
 def setDefaultSmtOptions (sOpts : BlasterOptions) : TranslateEnvT Unit := do
  setPrintSuccess true
@@ -751,6 +1080,8 @@ def setDefaultSmtOptions (sOpts : BlasterOptions) : TranslateEnvT Unit := do
    setLogicAll
 
 /-- Perform the following actions:
+     - resolve the backend solver (see `resolveSolver`) and record it in the
+       translation environment
      - when option `only-smt-lib` is set to `false`:
        - Spawn the backend solver process and update TranslateEnv
        - set the default smt solver options by emitting the corresponding commands
@@ -760,11 +1091,15 @@ def setDefaultSmtOptions (sOpts : BlasterOptions) : TranslateEnvT Unit := do
 def setBlasterProcess : TranslateEnvT Unit := do
   let sOpts := (← get).optEnv.options.solverOptions
   let solver ← resolveSolver sOpts
-  modify fun env => { env with smtEnv.solver := solver }
+  let timeout ← resolveTimeout sOpts
+  modify fun env =>
+    { env with
+        smtEnv.solver := solver,
+        optEnv.options.solverOptions.timeout := timeout }
   unless sOpts.onlySmtLib do
     let proc ← createBlasterProcess solver
     modify fun env => { env with smtEnv.smtProc := proc }
-  setDefaultSmtOptions sOpts
+  setDefaultSmtOptions { sOpts with timeout }
 
 
 end Blaster.Smt

--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -12,8 +12,12 @@ namespace Blaster.Smt
 private def normalizeLine (s : String) : String :=
   s.replace "\r" ""
 
-/-- Minimal version of z3 we support -/
-private def minZ3Version : String := "4.15.2"
+/-- Executable candidates, version arguments, and process arguments for a solver. -/
+private def solverConfig : SmtSolver → Array String × Array String × Array String
+  | .z3 => (#["z3", "wsl z3"], #["-version"], #["-in", "-smt2"])
+  | .cvc5 =>
+      (#["cvc5", "wsl cvc5"], #["--version"],
+        #["--lang", "smt2", "--incremental", "--parsing-mode=lenient", "--dt-nested-rec"])
 
 /-- Result of an Smt query. -/
 inductive Result where
@@ -48,10 +52,37 @@ def falsifiedError (r : Result) : String :=
   s!"Falsified result expected but got {reprStr r}"
 
 
+/-- Whether strict cvc5 test conformance was requested for this process. -/
+def strictCvc5ResultCheckingRequested : IO Bool := do
+  let some value ← IO.getEnv "BLASTER_STRICT_CVC5_RESULTS" | return false
+  if value == "" || value == "0" then return false
+  if value == "1" then return true
+  throw <| IO.userError
+    s!"❌ Invalid BLASTER_STRICT_CVC5_RESULTS value '{value}' (expected '0' or '1')."
+
+/-- How a declared result contract handles an `Undetermined` outcome. -/
+inductive UndeterminedAction where
+  | expected
+  | allowed
+  | strictError
+  | warning
+deriving Repr, BEq, DecidableEq
+
+def undeterminedAction
+    (sOpts : BlasterOptions) (solver : SmtSolver) (strictRequested : Bool) :
+    UndeterminedAction :=
+  if isExpectedUndetermined sOpts.solveResult then .expected
+  else if sOpts.allowCvc5Undetermined && solver == .cvc5 then .allowed
+  else if strictRequested && solver == .cvc5 then .strictError
+  else .warning
+
 def blankRef : TranslateEnvT Syntax := getRef
 
 def logResult (r : Result) (isCTI := false) (indLabel := "") (cexLabel := "Counterexample") : TranslateEnvT Unit := do
-  let sOpts := (← get).optEnv.options.solverOptions
+  let env ← get
+  let sOpts := env.optEnv.options.solverOptions
+  let action := undeterminedAction sOpts env.smtEnv.solver
+    (← strictCvc5ResultCheckingRequested)
   let ref ← blankRef
   match r with
   | .Valid =>
@@ -65,52 +96,68 @@ def logResult (r : Result) (isCTI := false) (indLabel := "") (cexLabel := "Count
            then dumpCex (logInfoAt ref) "✅ Expected Falsified" cex
            else dumpCex (logErrorAt ref) "❌ Falsified" cex
   | .Undetermined =>
-      if isExpectedUndetermined sOpts.solveResult
-      then logInfoAt ref "✅ Expected Undetermined"
-      else logWarningAt ref "⚠️ Undetermined"
+      match action with
+      | .expected => logInfoAt ref "✅ Expected Undetermined"
+      | .allowed => logInfoAt ref "✅ Allowed cvc5 Undetermined"
+      | .strictError => logErrorAt ref "❌ Unexpected Undetermined"
+      | .warning => logWarningAt ref "⚠️ Undetermined"
 
   where
     dumpCex (f : MessageData -> MetaM Unit) (failure : String) (cex : List String) : TranslateEnvT Unit := do
       if (← get).optEnv.options.solverOptions.generateCex then
          f failure
          f s!"{cexLabel}:"
-         cex.forM (λ s => f s!" - {s.dropRight 1}")
+         cex.forM (λ s => f s!" - {s.trimRight}")
       else f failure
 
-/-- Tries to find if z3 is natively present in PATH, if not checks wsl z3 -/
-private def findZ3CmdAndVersion : IO (String) := do
-  let candidates := #["z3", "wsl z3"]
-  -- We'll store a short log message for each candidate attempt
+/-- Find the first working executable candidate for `solver`. -/
+private def findSolverCmdAndVersion (solver : SmtSolver) : IO String := do
+  let (candidates, versionArgs, _) := solverConfig solver
   let mut attemptLogs := #[]
   for candidate in candidates do
     try
-      let out ← IO.Process.output { cmd := candidate, args := #["-version"] }
+      let out ← IO.Process.output { cmd := candidate, args := versionArgs }
       if out.exitCode == 0 then
-        -- Found a good candidate => Return immediately
-        return (candidate)
+        return candidate
       else
         attemptLogs := attemptLogs.push
           s!"Candidate '{candidate}': exit code {out.exitCode}"
     catch e =>
-      -- “No such file or directory” or other IO error
       attemptLogs := attemptLogs.push
         s!"Candidate '{candidate}': IO error => {e}"
-
-  -- If we get here, no candidate succeeded
   let attemptsReport := String.join (attemptLogs.toList.map (fun x => x ++ "\n"))
-  throw <| IO.userError s!"❌ Could not find a working Z3 ≥ {minZ3Version}.\n\nTried:\n{attemptsReport}"
+  throw <| IO.userError s!"❌ Could not find a working {solver}.\n\nTried:\n{attemptsReport}"
 
+/-- Resolve a solver from an explicit option and a supplied environment value. -/
+def resolveSolverConfig
+    (sOpts : BlasterOptions) (envValue : Option String) : Except String SmtSolver := do
+  if let some solver := sOpts.solver then return solver
+  let some str := envValue | return .z3
+  let some solver := SmtSolver.ofString? str.trim
+    | throw s!"❌ Unknown BLASTER_SOLVER value '{str}' (expected 'z3' or 'cvc5')."
+  return solver
 
-/-- Spawn a z3 process w.r.t. the provided solver options. -/
-def createBlasterProcess : IO (IO.Process.Child ⟨.piped, .piped, .piped⟩) := do
-  let z3Cmd ← findZ3CmdAndVersion  -- ensures version is OK
+/-- Resolve the explicit option, then `BLASTER_SOLVER`, then the Z3 default. -/
+def resolveSolver (sOpts : BlasterOptions) : IO SmtSolver := do
+  match resolveSolverConfig sOpts (← IO.getEnv "BLASTER_SOLVER") with
+  | .ok solver => return solver
+  | .error message => throw <| IO.userError message
+
+/-- Spawn the selected backend solver. -/
+def createBlasterProcess (solver : SmtSolver) :
+    IO (IO.Process.Child ⟨.piped, .piped, .piped⟩) := do
+  let cmd ← findSolverCmdAndVersion solver
+  let (_, _, args) := solverConfig solver
   IO.Process.spawn {
     stdin  := .piped
     stdout := .piped
     stderr := .piped
-    cmd    := z3Cmd
-    args   := #["-in", "-smt2"]
+    cmd    := cmd
+    args   := args
   }
+
+def getSolver : TranslateEnvT SmtSolver :=
+  return (← get).smtEnv.solver
 
 /-- Update translation cache with `a := b`.
 -/
@@ -169,29 +216,53 @@ def getOutputProof := λ h => getOutputModel h true
 -/
 partial def getErrorMsg (h : IO.FS.Handle) : IO String := normalizeLine <$> h.getLine
 
-/-- Retrieve an `eval` output from `h` after execution `(eval t)`
-    NOTE: An eval output may either correspond to a scalar value
-    or to an inductive datatype one. In the latter case it's provided
-    within parenthesis. The number of opening and closing parenthesis
-    should tally to stop reading from `h`.
--/
-partial def getOutputEval (h : IO.FS.Handle) : IO String := do
+/-- Retrieve a `get-value` response, which may span multiple lines. -/
+partial def getOutputGetValue (h : IO.FS.Handle) : IO String := do
   let line := normalizeLine (← h.getLine)
   if line.get! 0 != '(' then return line
-  getIndValue line (tallyParenthesis line 0)
-
+  getValue line (tallyParenthesis line 0)
  where
   tallyParenthesis (s : String) (tally : Int) : Int :=
-   s.foldr (λ c acc =>
-              match c with
-              | '(' => acc + 1
-              | ')' => acc - 1
-              | _ => acc) tally
-  getIndValue (acc : String) (tally : Int) : IO String := do
+    s.foldr (λ c acc =>
+      match c with
+      | '(' => acc + 1
+      | ')' => acc - 1
+      | _ => acc) tally
+  getValue (acc : String) (tally : Int) : IO String := do
     if tally == 0 then return acc
-    else
-      let line := normalizeLine (← h.getLine)
-      getIndValue (acc ++ line) (tallyParenthesis line tally)
+    let line := normalizeLine (← h.getLine)
+    getValue (acc ++ line) (tallyParenthesis line tally)
+
+/-- Extract `v` from a `get-value` response of the form `((t v))`. -/
+partial def unwrapGetValueOutput (s : String) : String :=
+  let cs := s.toList.dropWhile Char.isWhitespace
+  match cs with
+  | '(' :: rest =>
+      match rest.dropWhile Char.isWhitespace with
+      | '(' :: inner =>
+          let afterTerm := dropSexp (inner.dropWhile Char.isWhitespace)
+          String.mk (takeValue afterTerm 0 []) |>.trim
+      | _ => s.trim
+  | _ => s.trim
+ where
+  dropSexp (cs : List Char) : List Char :=
+    match cs with
+    | [] => []
+    | '(' :: rest => dropParen rest 1
+    | _ :: _ => cs.dropWhile (λ c => !c.isWhitespace && c != '(' && c != ')')
+  dropParen (cs : List Char) (depth : Nat) : List Char :=
+    match cs with
+    | [] => []
+    | '(' :: rest => dropParen rest (depth + 1)
+    | ')' :: rest => if depth == 1 then rest else dropParen rest (depth - 1)
+    | _ :: rest => dropParen rest depth
+  takeValue (cs : List Char) (depth : Nat) (acc : List Char) : List Char :=
+    match cs with
+    | [] => acc.reverse
+    | '(' :: rest => takeValue rest (depth + 1) ('(' :: acc)
+    | ')' :: rest =>
+        if depth == 0 then acc.reverse else takeValue rest (depth - 1) (')' :: acc)
+    | c :: rest => takeValue rest depth (c :: acc)
 
 /-- Push smt command `c` in the translation environment only when sOpts.dumpSmtLib is set -/
 def storeCommand (c : SmtCommand) : TranslateEnvT Unit := do
@@ -477,18 +548,13 @@ def defineInttoNat : TranslateEnvT Unit := do
   let fdef := iteSmt xGeqZero xId natZero
   defineFun toNatSymbol #[(xsym, intSort)] natSort fdef
 
-/-- Try to retrieve to evaluate term `t` when a `sat` result is obtained and dump result to stdout.
-    TODO: We need to define the Smt-lib syntax and term elaborator to parse produced value
-    and generate the corresponding Lean representation.
-    This will also be helpful when writing the test cases to validate the Smt-Lib translation.
-    Do nothing if the Smt process is not defined.
--/
+/-- Retrieve and unwrap the value of `t` using standard SMT-LIB `get-value`. -/
 def evalTerm (t : SmtTerm) : TranslateEnvT String := do
   let env ← get
   let some p := env.smtEnv.smtProc | return ""
   checkCancelTk?
-  submitCommand (.evalTerm t)
-  getOutputEval p.stdout
+  submitCommand (.getValue t)
+  return unwrapGetValueOutput (← getOutputGetValue p.stdout)
 
 /-- Try to retrieve the model when a `sat` result is obtained and dump result to stdout.
     Do nothing when:
@@ -604,55 +670,62 @@ def setProduceProofs (b : Bool) : TranslateEnvT Unit :=
 def setProduceModels (b : Bool) : TranslateEnvT Unit :=
   trySubmitCommand! (.setOption ":produce-models" (toString b))
 
-/-- Set Smt `smt.mbqi` option to `b`. -/
-def setMbqi (b : Bool) : TranslateEnvT Unit :=
-  trySubmitCommand! (.setOption ":smt.mbqi" (toString b))
+/-- Set model-based quantifier instantiation for the selected solver. -/
+def setMbqi (b : Bool) : TranslateEnvT Unit := do
+  match ← getSolver with
+  | .z3 => trySubmitCommand! (.setOption ":smt.mbqi" (toString b))
+  | .cvc5 => trySubmitCommand! (.setOption ":mbqi" (toString b))
 
-/-- Set Smt `smt.pull-nested-quantifiers` option to `b`. -/
-def setPullNestedQuantifiers (b : Bool) : TranslateEnvT Unit :=
+/-- Set Z3's nested-quantifier option; cvc5 has no equivalent. -/
+def setPullNestedQuantifiers (b : Bool) : TranslateEnvT Unit := do
+  let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.pull-nested-quantifiers" (toString b))
 
 /-- Set Smt `print-success` option to `b`. -/
 def setPrintSuccess (b : Bool) : TranslateEnvT Unit :=
   trySubmitCommand! (.setOption ":print-success" (toString b))
 
-/-- Set Smt `smt.random-seed` option to `n` or none. -/
+/-- Set the random seed using the selected solver's option name. -/
 def setRandomSeed (n : Option Nat) : TranslateEnvT Unit := do
-  match n with
-  | some n => trySubmitCommand! (.setOption ":smt.random-seed" (toString n))
-  | none => pure ()
+  let some n := n | return ()
+  match ← getSolver with
+  | .z3 => trySubmitCommand! (.setOption ":smt.random-seed" (toString n))
+  | .cvc5 => trySubmitCommand! (.setOption ":seed" (toString n))
 
-/-- Set Smt `auto_config` option to `b`. -/
-def setAutoConfig (b : Bool) : TranslateEnvT Unit :=
+/-- Set Z3's `auto_config` option; cvc5 has no equivalent. -/
+def setAutoConfig (b : Bool) : TranslateEnvT Unit := do
+  let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":auto_config" (toString b))
 
-/-- Set Smt `smt.case_split` to `n`, with n ∈ [0..6]. -/
-def setCaseSplit (n : Nat) : TranslateEnvT Unit :=
+def setCaseSplit (n : Nat) : TranslateEnvT Unit := do
+  let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.case_split" (toString n))
 
-/-- Set Smt `smt.qi.eager_threshold` to `n`. -/
-def setQiEagerThreshold (n : Nat) : TranslateEnvT Unit :=
+def setQiEagerThreshold (n : Nat) : TranslateEnvT Unit := do
+  let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.qi.eager_threshold" (toString n))
 
-
-/-- Set Smt `smt.delay_units` to `b`. -/
-def setDelayUnits (b : Bool) : TranslateEnvT Unit :=
+def setDelayUnits (b : Bool) : TranslateEnvT Unit := do
+  let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.delay_units" (toString b))
 
-/-- Set Smt `smt.macro_finder` option to `b`. -/
-def setMacroFinder (b : Bool) : TranslateEnvT Unit :=
-  trySubmitCommand! (.setOption ":smt.macro_finder" (toString b))
+/-- Set macro handling using the selected solver's option name. -/
+def setMacroFinder (b : Bool) : TranslateEnvT Unit := do
+  match ← getSolver with
+  | .z3 => trySubmitCommand! (.setOption ":smt.macro_finder" (toString b))
+  | .cvc5 => trySubmitCommand! (.setOption ":macros-quant" (toString b))
 
-/-- Set Smt `smt.relevancy` option to `i`. -/
-def setRelevancy (n : Nat) : TranslateEnvT Unit :=
+def setRelevancy (n : Nat) : TranslateEnvT Unit := do
+  let .z3 ← getSolver | return ()
   trySubmitCommand! (.setOption ":smt.relevancy" (toString n))
 
-/-- Set Smt `timeout` when option is specified. -/
+/-- Set the solver-specific per-check timeout when requested. -/
 def setTimeout : TranslateEnvT Unit := do
   let sOpts := (← get).optEnv.options.solverOptions
   let some n := sOpts.timeout | return ()
-  -- need to convert timeout to milliseconds
-  trySubmitCommand! (.setOption ":timeout" (toString (n * 1000)))
+  match ← getSolver with
+  | .z3 => trySubmitCommand! (.setOption ":timeout" (toString (n * 1000)))
+  | .cvc5 => trySubmitCommand! (.setOption ":tlimit-per" (toString (n * 1000)))
 
 /-- Set the default Smt options, i.e.:
      - (set-option :print-success true)
@@ -674,6 +747,8 @@ def setDefaultSmtOptions (sOpts : BlasterOptions) : TranslateEnvT Unit := do
  setRandomSeed sOpts.randomSeed
  setMacroFinder true
  setTimeout
+ if (← getSolver) == .cvc5 then
+   setLogicAll
 
 /-- Perform the following actions:
      - when option `only-smt-lib` is set to `false`:
@@ -683,11 +758,12 @@ def setDefaultSmtOptions (sOpts : BlasterOptions) : TranslateEnvT Unit := do
        - only add the solver options to the list of smt commands.
 -/
 def setBlasterProcess : TranslateEnvT Unit := do
-  let env ← get
-  let sOpts := env.optEnv.options.solverOptions
+  let sOpts := (← get).optEnv.options.solverOptions
+  let solver ← resolveSolver sOpts
+  modify fun env => { env with smtEnv.solver := solver }
   unless sOpts.onlySmtLib do
-    let proc ← createBlasterProcess
-    set { env with smtEnv.smtProc := proc }
+    let proc ← createBlasterProcess solver
+    modify fun env => { env with smtEnv.smtProc := proc }
   setDefaultSmtOptions sOpts
 
 

--- a/Blaster/Smt/Model.lean
+++ b/Blaster/Smt/Model.lean
@@ -1,0 +1,457 @@
+import Std.Data.HashMap
+import Std.Data.HashSet
+
+/-! ## Solver model-value reconstruction
+
+`(get-value (t))` responses are S-expressions whose exact shape is
+solver-specific. This module parses them and reconstructs a Lean-flavored
+rendering of the returned value, so that counterexamples read as Lean values
+regardless of the backend solver:
+
+ - z3 wraps long values over several lines whereas cvc5 prints a single line;
+ - cvc5 qualifies parametric-datatype constructors with `as` sort ascriptions,
+   e.g. `(as Option.none (@Option Int))` and
+   `((as Prod.mk (@Prod Int Bool)) 1 true)`;
+ - cvc5 shares repeated subterms through `let` bindings, e.g.
+   `(let ((_let_1 (as List.cons (@List Int)))) (_let_1 1 (_let_1 0 (as List.nil (@List Int)))))`;
+ - both solvers print negative integers as `(- n)`, escape `"` in string
+   literals by doubling it, and escape characters through `\u{…}` sequences.
+
+Reconstruction is intentionally *total* over well-formed S-expressions:
+values with no direct Lean counterpart (SMT arrays, lambdas, uninterpreted
+constants, …) are rendered as raw S-expressions rather than rejected, and a
+malformed response makes the entry points return `none` so that callers can
+fall back to the raw solver output.
+
+TODO(design note): the `Sexp` parser and `normalizeValue` pipeline are
+deliberately independent of the string rendering below. This separation could
+later support typed decoding of solver values into user-defined Lean types
+(for example, through a `FromData`-style class) for programmatic counterexample
+consumption.
+-/
+
+namespace Blaster.Smt
+
+/-- S-expression view of a solver response. Atoms keep their raw spelling:
+    simple symbols, `|quoted symbols|` (pipes included), `"string literals"`
+    (quotes and `""` escapes included) and numerals. -/
+inductive Sexp where
+  | atom (s : String)
+  | app (elems : Array Sexp)
+deriving Repr, BEq, Inhabited
+
+namespace Sexp
+
+/-- Characters terminating a simple (unquoted) atom. -/
+private def isAtomBreak (c : Char) : Bool :=
+  c.isWhitespace || c == '(' || c == ')' || c == '"' || c == '|' || c == ';'
+
+/-- Parse a sequence of S-expressions, stopping at an unmatched `)` (left
+    unconsumed) or at the end of input. String literals keep their delimiting
+    quotes (`""` escapes intact) and quoted symbols keep their pipes, so that
+    atoms can be re-emitted verbatim. -/
+private partial def parseSeq (cs : List Char) (acc : Array Sexp) :
+    Except String (Array Sexp × List Char) :=
+  match cs with
+  | [] => .ok (acc, [])
+  | ')' :: _ => .ok (acc, cs)
+  | '(' :: rest =>
+      match parseSeq rest #[] with
+      | .error e => .error e
+      | .ok (elems, rest) =>
+          match rest with
+          | ')' :: rest => parseSeq rest (acc.push (.app elems))
+          | _ => .error "unbalanced '(' in solver response"
+  | '"' :: rest =>
+      match takeString rest ['"'] with
+      | .error e => .error e
+      | .ok (lit, rest) => parseSeq rest (acc.push (.atom lit))
+  | '|' :: rest =>
+      match takeQuotedSymbol rest ['|'] with
+      | .error e => .error e
+      | .ok (lit, rest) => parseSeq rest (acc.push (.atom lit))
+  | ';' :: rest => parseSeq (rest.dropWhile (· != '\n')) acc
+  | c :: rest =>
+      if c.isWhitespace then parseSeq rest acc
+      else
+        let tok := cs.takeWhile (fun c => !isAtomBreak c)
+        parseSeq (cs.drop tok.length) (acc.push (.atom (String.mk tok)))
+ where
+  -- NOTE: SMT-LIB escapes a quote inside a string literal by doubling it.
+  takeString : List Char → List Char → Except String (String × List Char)
+    | '"' :: '"' :: rest, acc => takeString rest ('"' :: '"' :: acc)
+    | '"' :: rest, acc => .ok (String.mk (('"' :: acc).reverse), rest)
+    | c :: rest, acc => takeString rest (c :: acc)
+    | [], _ => .error "unterminated string literal in solver response"
+  takeQuotedSymbol : List Char → List Char → Except String (String × List Char)
+    | '|' :: rest, acc => .ok (String.mk (('|' :: acc).reverse), rest)
+    | c :: rest, acc => takeQuotedSymbol rest (c :: acc)
+    | [], _ => .error "unterminated quoted symbol in solver response"
+
+/-- Parse all S-expressions of a solver response. -/
+def parseMany (s : String) : Except String (Array Sexp) :=
+  match parseSeq s.toList #[] with
+  | .ok (es, []) => .ok es
+  | .ok _ => .error "unbalanced ')' in solver response"
+  | .error e => .error e
+
+private def isBinderKeyword (name : String) : Bool :=
+  name == "lambda" || name == "forall" || name == "exists"
+
+private inductive AtomIdentity where
+  | symbol (name : String)
+  | other (raw : String)
+deriving BEq, Hashable
+
+private def isSimpleSymbolInitial (c : Char) : Bool :=
+  ('a' ≤ c && c ≤ 'z') || ('A' ≤ c && c ≤ 'Z') ||
+    "~!@$%^&*_-+=<>.?/".contains c
+
+private def isReservedToken : String → Bool
+  | "BINARY" => true
+  | "DECIMAL" => true
+  | "HEXADECIMAL" => true
+  | "NUMERAL" => true
+  | "STRING" => true
+  | "_" => true
+  | "!" => true
+  | "as" => true
+  | "let" => true
+  | "exists" => true
+  | "forall" => true
+  | "match" => true
+  | "par" => true
+  | "lambda" => true
+  | "assert" => true
+  | "check-sat" => true
+  | "check-sat-assuming" => true
+  | "declare-const" => true
+  | "declare-datatype" => true
+  | "declare-datatypes" => true
+  | "declare-fun" => true
+  | "declare-sort" => true
+  | "define-fun" => true
+  | "define-fun-rec" => true
+  | "define-funs-rec" => true
+  | "define-sort" => true
+  | "echo" => true
+  | "exit" => true
+  | "get-assertions" => true
+  | "get-assignment" => true
+  | "get-info" => true
+  | "get-model" => true
+  | "get-option" => true
+  | "get-proof" => true
+  | "get-unsat-assumptions" => true
+  | "get-unsat-core" => true
+  | "get-value" => true
+  | "pop" => true
+  | "push" => true
+  | "reset" => true
+  | "reset-assertions" => true
+  | "set-info" => true
+  | "set-logic" => true
+  | "set-option" => true
+  | _ => false
+
+private def isSimpleSymbol (name : String) : Bool :=
+  !isReservedToken name && match name.toList with
+    | [] => false
+    | first :: rest =>
+        isSimpleSymbolInitial first &&
+          rest.all fun c => isSimpleSymbolInitial c || c.isDigit
+
+/-- Semantic identity of a parsed SMT-LIB atom. Quoting changes a symbol's
+    spelling, not which symbol it denotes; non-symbol tokens remain a separate
+    lexical category. Raw spellings stay in the syntax tree for rendering. -/
+private def atomIdentity (name : String) : AtomIdentity :=
+  if name.startsWith "|" && name.endsWith "|" then
+    .symbol ((name.drop 1).dropRight 1)
+  else if isSimpleSymbol name then
+    .symbol name
+  else
+    .other name
+
+private def binderNames (declarations : Array Sexp) : Array AtomIdentity :=
+  declarations.filterMap fun declaration =>
+    match declaration with
+    | .app #[.atom name, _sort] => some (atomIdentity name)
+    | _ => none
+
+/-- Free semantic atom identities in term positions. Binder declarations, sort
+    positions, and indexed-identifier components do not contribute. -/
+private partial def freeAtoms (e : Sexp)
+    (bound : Std.HashSet AtomIdentity := {}) : Std.HashSet AtomIdentity :=
+  match e with
+  | .atom name =>
+      let identity := atomIdentity name
+      if bound.contains identity then {} else ({} : Std.HashSet AtomIdentity).insert identity
+  | .app #[.atom "let", .app bindings, body] =>
+      let fromBindings := bindings.foldl (init := ({} : Std.HashSet AtomIdentity)) fun free binding =>
+        match binding with
+        | .app #[.atom _name, value] => free.union (freeAtoms value bound)
+        | _ => free.union (freeAtoms binding bound)
+      let names := bindings.filterMap fun binding =>
+        match binding with
+        | .app #[.atom name, _value] => some (atomIdentity name)
+        | _ => none
+      let bodyBound := names.foldl (init := bound) fun names name => names.insert name
+      fromBindings.union (freeAtoms body bodyBound)
+  | .app #[.atom "as", .atom "const", _sort] => {}
+  | .app #[.atom "as", term, _sort] => freeAtoms term bound
+  | binderExpr@(.app #[.atom binder, .app declarations, body]) =>
+      if isBinderKeyword binder then
+        let bodyBound := (binderNames declarations).foldl (init := bound) fun names name =>
+          names.insert name
+        freeAtoms body bodyBound
+      else if binder == "_" then {}
+      else
+        match binderExpr with
+        | .app elems =>
+            elems.foldl (init := ({} : Std.HashSet AtomIdentity)) fun free elem =>
+              free.union (freeAtoms elem bound)
+        | _ => {}
+  | .app elems =>
+      match (elems[0]? : Option Sexp) with
+      | some (.atom "_") => {}
+      | _ =>
+          elems.foldl (init := ({} : Std.HashSet AtomIdentity)) fun free elem =>
+            free.union (freeAtoms elem bound)
+
+private partial def allAtoms : Sexp → Std.HashSet AtomIdentity
+  | .atom name => ({} : Std.HashSet AtomIdentity).insert (atomIdentity name)
+  | .app elems =>
+      elems.foldl (init := ({} : Std.HashSet AtomIdentity)) fun names elem =>
+        names.union (allAtoms elem)
+
+private partial def freshBinderName (used : Std.HashSet AtomIdentity) (index : Nat := 0) : String :=
+  let candidate := s!"_blaster_bound_{index}"
+  if used.contains (atomIdentity candidate) then freshBinderName used (index + 1) else candidate
+
+/-- Normalize a solver *value*:
+     - expand `let` bindings (cvc5 shares repeated subterms through them);
+     - drop `as` sort ascriptions (cvc5 qualifies parametric-datatype
+       constructors with the instantiated sort), except `(as const …)`,
+       which denotes a constant array and carries no value by itself;
+     - respect `lambda`, `forall`, and `exists` scopes, alpha-renaming a
+       binder when an inserted free atom would otherwise be captured;
+     - preserve any value containing an SMT-LIB `match` verbatim until match
+       pattern binding is implemented.
+    SMT-LIB `let` is parallel: bindings are evaluated in the enclosing
+    environment and only the body sees them. -/
+partial def normalizeValue (e : Sexp) : Sexp := go {} e
+ where
+  /-- `match` patterns bind variables in their branch terms. Until that scope is
+      modeled, preserve the complete enclosing value rather than substituting
+      through a pattern and changing its meaning. -/
+  containsUnsupportedBinder : Sexp → Bool
+    | .atom _ => false
+    | .app elems =>
+        match (elems[0]? : Option Sexp) with
+        | some (.atom "match") => true
+        | _ => elems.any containsUnsupportedBinder
+
+  go (env : Std.HashMap AtomIdentity Sexp) (e : Sexp) : Sexp :=
+    if containsUnsupportedBinder e then e
+    else
+      match e with
+      | .atom a => env.getD (atomIdentity a) (.atom a)
+      | .app #[.atom "let", .app bindings, body] =>
+          let env' := bindings.foldl (init := env) fun acc b =>
+            match b with
+            | .app #[.atom x, v] => acc.insert (atomIdentity x) (go env v)
+            | _ => acc
+          go env' body
+      | .app #[.atom "as", t, sort] =>
+          if t == .atom "const" then .app #[.atom "as", t, sort]
+          else go env t
+      | binderExpr@(.app #[.atom binder, .app declarations, body]) =>
+          if isBinderKeyword binder then
+            let names := binderNames declarations
+            let scopedEnv := names.foldl (init := env) fun env name => env.erase name
+            let captures := scopedEnv.fold
+              (fun free _name value => free.union (freeAtoms value))
+              ({} : Std.HashSet AtomIdentity)
+            let used := env.fold
+              (fun used name value => (used.insert name).union (allAtoms value))
+              (allAtoms binderExpr)
+            let (bodyEnv, _used, declarations, _nextIndex) :=
+              declarations.foldl (init := (scopedEnv, used, #[], 0)) fun state declaration =>
+                let (bodyEnv, used, declarations, nextIndex) := state
+                match declaration with
+                | .app #[.atom name, sort] =>
+                    let identity := atomIdentity name
+                    if captures.contains identity then
+                      let fresh := freshBinderName used nextIndex
+                      (bodyEnv.insert identity (.atom fresh), used.insert (atomIdentity fresh),
+                        declarations.push (.app #[.atom fresh, sort]), nextIndex + 1)
+                    else
+                      (bodyEnv, used, declarations.push declaration, nextIndex)
+                | _ => (bodyEnv, used, declarations.push declaration, nextIndex)
+            .app #[.atom binder, .app declarations, go bodyEnv body]
+          else if binder == "_" then binderExpr
+          else
+            match binderExpr with
+            | .app elems => .app (elems.map (go env))
+            | _ => binderExpr
+      | indexed@(.app elems) =>
+          match (elems[0]? : Option Sexp) with
+          | some (.atom "_") => indexed
+          | _ => .app (elems.map (go env))
+
+/-- Decode an SMT-LIB string literal (with its surrounding quotes) into the
+    string it denotes: `""` undoubles to `"`, and `\u{X…}` / `\uXXXX` escape
+    sequences (SMT-LIB Unicode strings theory) decode to their code point.
+    A `\u` not forming a well-formed escape stands for itself. -/
+partial def decodeStringLit? (lit : String) : Option String :=
+  match lit.toList with
+  | '"' :: cs => go cs []
+  | _ => none
+ where
+  go : List Char → List Char → Option String
+    | '"' :: '"' :: rest, acc => go rest ('"' :: acc)
+    | ['"'], acc => some (String.mk acc.reverse)
+    | '"' :: _, _ => none -- content after the closing quote
+    | '\\' :: 'u' :: rest, acc =>
+        match takeUniEscape? rest with
+        | some (c, rest) => go rest (c :: acc)
+        | none => go ('u' :: rest) ('\\' :: acc)
+    | c :: rest, acc => go rest (c :: acc)
+    | [], _ => none -- missing closing quote
+  takeUniEscape? : List Char → Option (Char × List Char)
+    | '{' :: rest => do
+        let hex := rest.takeWhile (· != '}')
+        if hex.isEmpty || hex.length > 6 then failure
+        let c ← charOf? (← hexNat? hex)
+        match rest.drop hex.length with
+        | '}' :: rest => return (c, rest)
+        | _ => failure
+    | cs => do
+        let hex := cs.take 4
+        if hex.length != 4 then failure
+        return (← charOf? (← hexNat? hex), cs.drop 4)
+  hexNat? (cs : List Char) : Option Nat :=
+    cs.foldlM (fun acc c => (hexVal? c).map (acc * 16 + ·)) 0
+  hexVal? (c : Char) : Option Nat :=
+    let n := c.toNat
+    if 48 ≤ n && n ≤ 57 then some (n - 48) -- 0-9
+    else if 97 ≤ n && n ≤ 102 then some (n - 87) -- a-f
+    else if 65 ≤ n && n ≤ 70 then some (n - 55) -- A-F
+    else none
+  charOf? (n : Nat) : Option Char :=
+    if n.isValidChar then some (Char.ofNat n) else none
+
+/-- Render an S-expression in canonical single-line SMT-LIB form. Parsed atom
+    spellings are preserved, but original whitespace and comments are not.
+    Used for values that have no Lean counterpart (SMT arrays, lambdas, …). -/
+partial def toRaw : Sexp → String
+  | .atom a => a
+  | .app es => s!"({String.intercalate " " (es.toList.map toRaw)})"
+
+/-- `true` when `s` is a numeral. -/
+private def isNumeral (s : String) : Bool :=
+  !s.isEmpty && s.all Char.isDigit
+
+/-- SMT-LIB forms that never denote a datatype constructor: applications with
+    such a head are rendered as raw S-expressions. -/
+private def smtKeywordHeads : Array String :=
+  #["let", "as", "lambda", "forall", "exists", "match", "ite",
+    "store", "const", "select", "and", "or", "not", "xor", "distinct",
+    "div", "mod", "abs", "to_int", "to_real"]
+
+/-- `true` when `h` can denote a datatype constructor in a model value
+    (identifier-like and not an SMT-LIB keyword). -/
+private def isCtorHead (h : String) : Bool :=
+  match h.toList with
+  | [] => false
+  | c :: _ => (c.isAlpha || c == '@' || c == '|') && !smtKeywordHeads.contains h
+
+mutual
+
+/-- Render `e` for an application-argument position: parenthesized when the
+    rendering is not atomic (e.g. constructor applications, negative
+    numbers). -/
+private partial def renderArg (e : Sexp) : String :=
+  let (s, atomic) := renderValue e
+  if atomic then s else s!"({s})"
+
+/-- Chain of `List.cons` applications ending in `List.nil` (a Lean list
+    value), `none` otherwise. -/
+private partial def asListElems? : Sexp → Option (List Sexp)
+  | .atom "List.nil" => some []
+  | .app #[.atom "List.cons", h, t] => (asListElems? t).map (h :: ·)
+  | _ => none
+
+/-- Components of a (right-nested) `Prod.mk` tuple tail. -/
+private partial def tupleTail : Sexp → List Sexp
+  | .app #[.atom "Prod.mk", x, y] => x :: tupleTail y
+  | e => [e]
+
+/-- Render a normalized value as Lean-flavored text; the Bool is `true` when
+    the rendering needs no parentheses in argument position. -/
+private partial def renderValue : Sexp → String × Bool
+  | .atom a =>
+      if a.startsWith "\"" then
+        match decodeStringLit? a with
+        | some s => (s.quote, true)
+        | none => (a, true)
+      else if a == "List.nil" then ("[]", true)
+      else if a.startsWith "|" && a.endsWith "|" && a.length ≥ 2 then
+        (a.drop 1 |>.dropRight 1, true)
+      else (a, true)
+  | e@(.app es) =>
+      match asListElems? e with
+      | some elems => (s!"[{renderCommaSep elems}]", true)
+      | none =>
+        match es with
+        | #[.atom "-", .atom n] =>
+            if isNumeral n then (s!"-{n}", false) else (toRaw e, true)
+        | #[.atom "Prod.mk", a, b] =>
+            (s!"({renderCommaSep (a :: tupleTail b)})", true)
+        | _ =>
+            match (es[0]? : Option Sexp) with
+            | some (Sexp.atom h) =>
+                if es.size ≥ 2 && isCtorHead h then
+                  let head := (renderValue (.atom h)).1
+                  let args := (es.toList.drop 1).map renderArg
+                  (String.intercalate " " (head :: args), false)
+                else (toRaw e, true)
+            | _ => (toRaw e, true)
+
+/-- Comma-separated rendering of `elems` (list/tuple components). -/
+private partial def renderCommaSep (elems : List Sexp) : String :=
+  String.intercalate ", " (elems.map (fun x => (renderValue x).1))
+
+end
+
+/-- Normalize and render a parsed value as Lean-flavored text. -/
+def reconstructSexp (e : Sexp) : String :=
+  (renderValue (normalizeValue e)).1
+
+end Sexp
+
+/-- Reconstruct the Lean-flavored value from a `get-value` response of the
+    form `((t v))`. Returns `none` when the response has any other shape
+    (parse failure, solver error report, …) so that callers can fall back to
+    the raw output. -/
+def reconstructGetValue? (response : String) : Option String :=
+  match Sexp.parseMany response with
+  | .ok #[.app #[.app #[_t, v]]] => some (Sexp.reconstructSexp v)
+  | _ => none
+
+/-- Reconstruct a single S-expression *value* (no `((t v))` wrapping).
+    Mainly used by tests. -/
+def reconstructValue? (value : String) : Option String :=
+  match Sexp.parseMany value with
+  | .ok #[e] => some (Sexp.reconstructSexp e)
+  | _ => none
+
+/-- Message of an `(error "…")` solver response, `none` for any other
+    response shape. -/
+def solverErrorMsg? (response : String) : Option String :=
+  match Sexp.parseMany response with
+  | .ok #[.app #[.atom "error", .atom lit]] =>
+      Sexp.decodeStringLit? lit <|> some lit
+  | _ => none
+
+end Blaster.Smt

--- a/Blaster/Smt/Syntax.lean
+++ b/Blaster/Smt/Syntax.lean
@@ -151,7 +151,7 @@ inductive SmtCommand where
   | exitSmt
   | getModel
   | getProof
-  | evalTerm (t : SmtTerm)
+  | getValue (t : SmtTerm)
   | setLogic (l : String)
   | setOption (opt : String) (value : String)
 
@@ -320,7 +320,7 @@ instance : ToString SmtFunDecl where
  | .exitSmt => s!"(exit)"
  | .getModel => s!"(get-model)"
  | .getProof => s!"(get-proof)"
- | .evalTerm t => s!"(eval {t})"
+ | .getValue t => s!"(get-value ({t}))"
  | .setLogic l => s!"(set-logic {l})"
  | .setOption opt v => s!"(set-option {opt} {v})"
 

--- a/Blaster/Smt/Term.lean
+++ b/Blaster/Smt/Term.lean
@@ -399,8 +399,21 @@ def intLitSmt (n : Int) : SmtTerm :=
 /-! Convert an Nat literal to an Smt representation. -/
 def natLitSmt (n : Nat) : SmtTerm := .NumTerm n
 
+/-! Quote `s` as an SMT-LIB 2.6 string literal: `"` is escaped by doubling;
+    `\` and characters outside the printable ASCII range are emitted as
+    `\u{…}` escapes. (The SMT-LIB Unicode strings theory interprets `\u{…}`
+    sequences inside string constants — so a literal backslash must itself be
+    escaped — and only printable ASCII characters may appear verbatim.)
+    The mirror decoding lives in `Blaster.Smt.Sexp.decodeStringLit?`. -/
+def quoteSmtString (s : String) : String :=
+  s.foldl (init := "\"") (fun acc c =>
+    if c == '"' then acc ++ "\"\""
+    else if c == '\\' || c.toNat < 0x20 || c.toNat > 0x7e then
+      acc ++ s!"\\u\{{String.mk (Nat.toDigits 16 c.toNat)}}"
+    else acc.push c) ++ "\""
+
 /-! Convert an String literal to an Smt representation. -/
-def strLitSmt (s : String) : SmtTerm := .StrTerm s!"\"{s}\""
+def strLitSmt (s : String) : SmtTerm := .StrTerm (quoteSmtString s)
 
 /-! Create an Smt variable identifier. -/
 def smtSimpleVarId (nm : SmtSymbol) : SmtTerm := .SmtIdent (.SimpleIdent nm)

--- a/Blaster/Smt/Translate.lean
+++ b/Blaster/Smt/Translate.lean
@@ -43,6 +43,13 @@ partial def translateExpr (e : Expr) (topLevel := true) : TranslateEnvT SmtTerm 
      | Expr.sort _ => throwEnvError "translateExpr: unexpected sort type {reprStr e}" -- sort type are handled elsewhere
   visit e topLevel
 
+private def shouldLogUndetermined (logOrdinary : Bool) : TranslateEnvT Bool := do
+  if logOrdinary then return true
+  let env ← get
+  let sOpts := env.optEnv.options.solverOptions
+  return undeterminedAction sOpts env.smtEnv.solver
+    (← strictCvc5ResultCheckingRequested) == .strictError
+
 def Translate.main (e : Expr) (logUndetermined := true) : TranslateEnvT (Result × Expr) := do
     let e' ← addAxioms (← toPropExpr e) (← findLocalAxioms)
     let optExpr ← profileTask "Optimization" $ Optimize.main e'
@@ -50,7 +57,10 @@ def Translate.main (e : Expr) (logUndetermined := true) : TranslateEnvT (Result 
     match (toResult optExpr) with
     | res@(.Undetermined) =>
         if (← get).optEnv.options.solverOptions.onlyOptimize then
-          if logUndetermined then logResult res
+          let sOpts := (← get).optEnv.options.solverOptions
+          let solver ← resolveSolver sOpts
+          modify fun env => { env with smtEnv.solver := solver }
+          if ← shouldLogUndetermined logUndetermined then logResult res
           return (res, optExpr)
         else
           -- set backend solver
@@ -61,7 +71,10 @@ def Translate.main (e : Expr) (logUndetermined := true) : TranslateEnvT (Result 
           -- dump smt commands submitted to backend solver when `dumpSmtLib` option is set.
           logSmtQuery
           let res ← profileTask "Solve" checkSat
-          if !isUndeterminedResult res || logUndetermined then logResult res
+          if isUndeterminedResult res then
+            if ← shouldLogUndetermined logUndetermined then logResult res
+          else
+            logResult res
           discard $ exitSmt
           return (res, optExpr)
     | res =>

--- a/Blaster/Smt/Translate/Application.lean
+++ b/Blaster/Smt/Translate/Application.lean
@@ -1178,51 +1178,42 @@ def translateApp
       hasSorryTheorem e "translateApp: Theorem {n} has `sorry` demonstration"
       termTranslator (← optimizeExpr' (betaForAll info.type args))
 
-/-- Given `e := λ (x₁ : t₁) → λ (xₙ : tₙ) => b`, perform the following:
-     - let V := [ v | v ∈ getFVarsInExpr b ∧ ¬ isType v.type ∧ ¬ isClassConstraintExpr v.type ∧ ¬ isTopLevelFVar v ]
-     - let A := [x₁, ..., xₙ]
-     - let (x₁, st₁) ... (xₘ, stₘ) := [(A[i], translateFunLambdaParamType tᵢ termTranslator) | i ∈ [0..n] ∧ isExplicit A[i]]
-     - let rt ← translateFunLambdaParamType (← inferTypEnv b) termTranslator
-     - let n ← mkFreshId
-     - let FunArrowType := ArrowTN st₁ ... stₘ rt
-     - let decl ← generateFunInstDeclAux (← inferTypeEnv e) FunArrowType
-     - let some @apply{k} := decl.applyInstName
-     - let sb := termTranslator b
-     - When V = ∅
-        - declare smt function `(declare-const @lambda{n} FunArrowType)`
-        - assert the following proposition to properly constrain @lambda{n}:
-          `(assert (forall ((x₁ st₁) ... (xₘ stₘ))
-             (! (= (@apply{k} @lambda{n} x₁ ... xₘ) sb)
-               :pattern ((@apply{k} @lambda{n} x₁ ... xₘ))
-               :qid @lambda{n]_def_cstr)))`
-        - return `smtSimpleVarId @lambda{n}`
-     - When V ≠ ∅
-        - let (y₁, yt₁) ... (yₖ, ytₖ) := [(V[i], translateFunLambdaParamType V[i].type termTranslator) | i ∈ [0..V.size-1]]
-        - let GlobalArrowType := ArrowTN yt₁ ... ytₖ FunArrowType
-        - let [v₁, ..., vₖ] = V
-        - let globalType ← ∀ v₁ → ... ∀ vₖ → outParam (← inferTypeEnv e)
-        - let globalDecl ← generateFunInstDeclAux globalType GlobalArrowType
-        - let some @apply{n} := globalDecl.applyInstName
-        - declare smt function `(declare-const @global_lambda{n} GlobalArrowType)`
-        - assert the following proposition to properly constrain @global_lambda{n}!
-           - `(assert (forall ((y₁, yt₁) ... (yₖ, ytₖ) (x₁, st₁) ... (xₘ, stₘ))
-               (! (= (@apply{k} (@apply{n} @global_lambda{n} y₁ ... yₖ) x₁ ... xₘ) sb)
-                  :pattern ((@apply{k} (@apply{n} @global_lambda{n} y₁ ... yₖ) x₁ ... xₘ))
-                  :qid @global_lambda{n}_def_cstr)))`
-       - return `(@apply{n} @global_lambda{n} y₁ ... yₖ)`
--/
+/-- Translate a lambda to Blaster's first-order function encoding.
+
+    Explicit lambda binders become arguments to an `@apply` declaration. Local
+    free value variables become leading arguments to a closure-converted
+    `@global_lambda`; a lambda without captures uses an `@lambda` constant.
+    Both forms receive a universally quantified defining equation, with the
+    application term retained as its SMT pattern.
+
+    SMT carriers can overapproximate Lean types (`Nat` uses `Int`, for example).
+    Each monomorphic captured value and explicit binder therefore contributes
+    its predicate qualifier as a premise of the defining equation. Without
+    those premises, closure definitions constrain non-Lean carrier values and
+    can contradict valid-domain function extensionality. Polymorphic qualifier
+    applications also mention type-value symbols that are not currently scoped
+    by these top-level axioms, so no polymorphic premise is emitted until lambda
+    closure conversion captures those type parameters. -/
 def translateLambda
   (e : Expr) (termTranslator : Expr → TranslateEnvT SmtTerm) : TranslateEnvT SmtTerm := do
  let pInfo ← getFunEnvInfo e
  Optimize.lambdaTelescope e fun fvars b => do
    let mut svars := (#[] : SortedVars)
+   let mut sguards := (#[] : Array SmtTerm)
    for h1 : i in [:fvars.size] do
      let fv := fvars[i]
      let decl ← getFVarLocalDecl fv
      updateQuantifiedFVarsCache fv.fvarId! false
      if pInfo.paramsInfo[i]!.isExplicit then
        let st ← translateFunLambdaParamType decl.type termTranslator
-       svars := svars.push (← fvarIdToSmtSymbol fv.fvarId!, st)
+       let symbol ← fvarIdToSmtSymbol fv.fvarId!
+       svars := svars.push (symbol, st)
+       -- A polymorphic qualifier also mentions type-value symbols that are not
+       -- in scope in this top-level axiom. Guard monomorphic domains here;
+       -- polymorphic lambdas require capturing those type parameters first.
+       if (← retrieveGenericArgs #[decl.type]).isEmpty then
+         sguards := sguards.push (← createPredQualifierAppAux
+           (smtSimpleVarId symbol) decl.type (inPredQualifier := true))
    let bodyType ← inferTypeEnv b
    let rt ← translateFunLambdaParamType bodyType termTranslator
    let v ← mkFreshId
@@ -1244,16 +1235,23 @@ def translateLambda
      let lamId := smtSimpleVarId lambdaName
      let applyArgs := Array.foldl (λ acc s => acc.push (smtSimpleVarId s.1)) #[lamId] svars
      let applyTerm := mkSimpleSmtAppN applyName applyArgs
-     let forallBody := eqSmt applyTerm sb
+     let mut forallBody := eqSmt applyTerm sb
+     for guard in sguards do
+       forallBody := impliesSmt guard forallBody
      assertTerm (mkForallTerm none svars forallBody (some #[mkPattern #[applyTerm], mkQid qidName]))
      return lamId
    else
     let mut gvars := (#[] : SortedVars)
+    let mut gguards := (#[] : Array SmtTerm)
     for h2 : i in [:lvars.size] do
      let fv := lvars[i]
      let decl ← getFVarLocalDecl fv
      let st ← translateFunLambdaParamType decl.type termTranslator
-     gvars := gvars.push (← fvarIdToSmtSymbol fv.fvarId!, st)
+     let symbol ← fvarIdToSmtSymbol fv.fvarId!
+     gvars := gvars.push (symbol, st)
+     if (← retrieveGenericArgs #[decl.type]).isEmpty then
+       gguards := gguards.push (← createPredQualifierAppAux
+         (smtSimpleVarId symbol) decl.type (inPredQualifier := true))
     let arrowT ← declareArrowTypeSort (lvars.size + 1)
     let globalArrowType := paramSort arrowT ((Array.map (λ s => s.2) gvars).push funArrowType)
     -- wrapping lamType within `outParam` to properly generate function instance
@@ -1274,7 +1272,12 @@ def translateLambda
     let qidName := appendSymbol globalName "def_cstr"
     let g_patterns := some #[mkPattern #[applyTerm], mkQid qidName]
     gvars := Array.foldl (λ acc s => acc.push s) gvars svars
-    assertTerm (mkForallTerm none gvars (eqSmt applyTerm sb) g_patterns)
+    let mut forallBody := eqSmt applyTerm sb
+    for guard in sguards do
+      forallBody := impliesSmt guard forallBody
+    for guard in gguards do
+      forallBody := impliesSmt guard forallBody
+    assertTerm (mkForallTerm none gvars forallBody g_patterns)
     return globalAppTerm
 
  where

--- a/Blaster/StateMachine/StateMachine.lean
+++ b/Blaster/StateMachine/StateMachine.lean
@@ -97,12 +97,16 @@ def defineSmtDepthFlag : TranslateEnvT SmtTerm := do
   return (smtSimpleVarId dflag)
 
 def logNotInductiveAtDepth : TranslateEnvT Unit := do
-  let sOpts := (← get).optEnv.options.solverOptions
+  let env ← get
+  let sOpts := env.optEnv.options.solverOptions
+  let action := undeterminedAction sOpts env.smtEnv.solver
+    (← strictCvc5ResultCheckingRequested)
   let msg := s!"Failed to establish induction up to Depth {← getMaxDepth}"
-  if isExpectedUndetermined sOpts.solveResult then
-    logInfoAt (← blankRef) s!"✅ Expected {msg}"
-  else
-    logWarningAt (← blankRef) s!"⚠️ {msg}"
+  match action with
+  | .expected => logInfoAt (← blankRef) s!"✅ Expected {msg}"
+  | .allowed => logInfoAt (← blankRef) s!"✅ Allowed cvc5 {msg}"
+  | .strictError => logErrorAt (← blankRef) s!"❌ {msg}"
+  | .warning => logWarningAt (← blankRef) s!"⚠️ {msg}"
   -- dump smt commands submitted to backend solver when `dumpSmtLib` option is set.
   logSmtQuery
   discard $ exitSmt
@@ -112,7 +116,16 @@ def logNoCexAtDepth : TranslateEnvT Unit := do
   discard $ exitSmt
 
 def logUndeterminedAtDepth : TranslateEnvT Unit := do
-  logWarningAt (← blankRef) f!"⚠️ Undetermined at Depth {← getCurrentDepth}"
+  let env ← get
+  let sOpts := env.optEnv.options.solverOptions
+  let action := undeterminedAction sOpts env.smtEnv.solver
+    (← strictCvc5ResultCheckingRequested)
+  let msg := f!"Undetermined at Depth {← getCurrentDepth}"
+  match action with
+  | .expected => logInfoAt (← blankRef) f!"✅ Expected {msg}"
+  | .allowed => logInfoAt (← blankRef) f!"✅ Allowed cvc5 {msg}"
+  | .strictError => logErrorAt (← blankRef) f!"❌ Unexpected {msg}"
+  | .warning => logWarningAt (← blankRef) f!"⚠️ {msg}"
   discard $ exitSmt
 
 def logCexAtDepth (r : Result) : TranslateEnvT Unit := do
@@ -181,10 +194,14 @@ def assertAssumptions (smInst : Expr) (iVar : Expr) (state : Expr) : StateMachin
         s!"Checking contradiction at Depth {currDepth}"
         (checkContradiction env.initFlag)
         (verboseLevel := 2)
-    if isValidResult res then
-      logContradictionAtDepth
-      return true
-    else return false
+    match res with
+    | .Valid =>
+        logContradictionAtDepth
+        return true
+    | .Falsified _ => return false
+    | .Undetermined =>
+        logUndeterminedAtDepth
+        return true
  | .Valid => return false
  | .Falsified .. =>
      logContradictionAtDepth

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,12 @@ usage:
 	@echo " - build_blaster: Build Blaster."
 	@echo " - clean_blaster: Clean compiled lean files for Blaster."
 	@echo " - check_blaster: Same as build_blaster but also checks that each lean file"
-	@echo " - build_tests: Build Tests."
-	@echo " - clean_tests: Clean compiled lean files for Tests."
-	@echo " - check_tests: Same as build_tests but also checks that each lean file"
+	@echo " - build_tests: Build Tests with the default Z3 backend."
+	@echo " - clean_tests: Clean compiled Lean files."
+	@echo " - check_tests: Run the default Z3 test tier from a clean state."
+	@echo " - test-z3: Run backend tests with Z3 only."
+	@echo " - test-cvc5: Run strict backend tests with cvc5 only."
+	@echo " - test-all-solvers: Run cross-backend tests (both solvers required)."
 	@echo " - build_all: Blaster, and Tests."
 	@echo " - clean_all: Blaster, and Tests."
 	@echo " - check_all: Blaster, and Tests."
@@ -23,24 +26,46 @@ clean_blaster:
 check_blaster: clean_blaster
 	./scripts/check_lean_project_compilation.sh Blaster
 
+.PHONY: test-z3
+test-z3:
+	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
+	env -u BLASTER_SOLVER -u BLASTER_STRICT_CVC5_RESULTS LEAN_NUM_THREADS=5 lake build Tests.Z3
+
+.PHONY: test-cvc5
+test-cvc5:
+	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
+	BLASTER_SOLVER=cvc5 BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 lake build Tests.Cvc5
+
+.PHONY: test-all-solvers
+test-all-solvers:
+	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
+	env -u BLASTER_SOLVER BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests Tests.AllSolvers
+
 .PHONY: build_tests
 build_tests:
-	LEAN_NUM_THREADS=5 lake test
+	$(MAKE) test-z3
 
 .PHONY: clean_tests
 clean_tests:
 	lake clean
 
 .PHONY: check_tests
-check_tests: clean_tests
-	LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests
+check_tests:
+	$(MAKE) test-z3
 
 # Aggregate commands
 # To maintain when you add new components
 .PHONY: build_all
-build_all: build_blaster build_tests
+build_all:
+	$(MAKE) build_blaster
+	$(MAKE) build_tests
+
 .PHONY: clean_all
-clean_all: clean_blaster clean_tests
+clean_all:
+	$(MAKE) clean_blaster
+	$(MAKE) clean_tests
 
 .PHONY: check_all
-check_all: check_blaster check_tests
+check_all:
+	$(MAKE) check_blaster
+	$(MAKE) check_tests

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,19 @@
 .PHONY: usage
 
+BLASTER_TIMEOUT ?= 30
+CVC5_FLOOR_VERSION ?= 1.2.1
+
 usage:
 	@echo " - build_blaster: Build Blaster."
 	@echo " - clean_blaster: Clean compiled lean files for Blaster."
 	@echo " - check_blaster: Same as build_blaster but also checks that each lean file"
-	@echo " - build_tests: Build Tests with the default Z3 backend."
+	@echo " - build_tests: Build the pure and default Z3 test tiers."
 	@echo " - clean_tests: Clean compiled Lean files."
-	@echo " - check_tests: Run the default Z3 test tier from a clean state."
+	@echo " - check_tests: Run the pure and default Z3 test tiers from clean states."
+	@echo " - test-pure: Run solver-independent tests (no solver required)."
 	@echo " - test-z3: Run backend tests with Z3 only."
 	@echo " - test-cvc5: Run strict backend tests with cvc5 only."
+	@echo " - test-cvc5-floor: Run cvc5 1.2.1 discovery and smoke checks."
 	@echo " - test-all-solvers: Run cross-backend tests (both solvers required)."
 	@echo " - build_all: Blaster, and Tests."
 	@echo " - clean_all: Blaster, and Tests."
@@ -26,23 +31,36 @@ clean_blaster:
 check_blaster: clean_blaster
 	./scripts/check_lean_project_compilation.sh Blaster
 
+.PHONY: test-pure
+test-pure:
+	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
+	env -u BLASTER_SOLVER -u BLASTER_TIMEOUT -u BLASTER_STRICT_CVC5_RESULTS LEAN_NUM_THREADS=5 lake build Tests.Pure
+
 .PHONY: test-z3
 test-z3:
 	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
-	env -u BLASTER_SOLVER -u BLASTER_STRICT_CVC5_RESULTS LEAN_NUM_THREADS=5 lake build Tests.Z3
+	BLASTER_SOLVER=z3 BLASTER_TIMEOUT=$(BLASTER_TIMEOUT) BLASTER_STRICT_CVC5_RESULTS=0 LEAN_NUM_THREADS=5 lake build Tests.Z3
 
 .PHONY: test-cvc5
 test-cvc5:
 	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
-	BLASTER_SOLVER=cvc5 BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 lake build Tests.Cvc5
+	BLASTER_SOLVER=cvc5 BLASTER_TIMEOUT=$(BLASTER_TIMEOUT) BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 lake build Tests.Cvc5
+
+.PHONY: test-cvc5-floor
+test-cvc5-floor:
+	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
+	cvc5 --version | head -1 | grep -F "version $(CVC5_FLOOR_VERSION) ["
+	env -u BLASTER_TIMEOUT BLASTER_SOLVER=cvc5 BLASTER_STRICT_CVC5_RESULTS=1 lake exe solvercheck cvc5
+	env -u BLASTER_TIMEOUT BLASTER_SOLVER=cvc5 BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 lake build Tests.Smt.Cvc5Floor
 
 .PHONY: test-all-solvers
 test-all-solvers:
 	rm -rf .lake/build/lib/lean/Tests .lake/build/ir/Tests
-	env -u BLASTER_SOLVER BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests Tests.AllSolvers
+	env -u BLASTER_SOLVER -u BLASTER_TIMEOUT BLASTER_STRICT_CVC5_RESULTS=1 LEAN_NUM_THREADS=5 ./scripts/check_lean_project_compilation.sh Tests Tests.AllSolvers
 
 .PHONY: build_tests
 build_tests:
+	$(MAKE) test-pure
 	$(MAKE) test-z3
 
 .PHONY: clean_tests
@@ -51,6 +69,7 @@ clean_tests:
 
 .PHONY: check_tests
 check_tests:
+	$(MAKE) test-pure
 	$(MAKE) test-z3
 
 # Aggregate commands

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Lean Version](https://img.shields.io/badge/Lean-v4.24.0-blue.svg)](https://github.com/leanprover/lean4)
 [![Z3 Version](https://img.shields.io/badge/Z3-v4.15.2-green.svg)](https://github.com/Z3Prover/z3)
+[![cvc5 Version](https://img.shields.io/badge/cvc5-v1.3.4-green.svg)](https://github.com/cvc5/cvc5)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-Blaster provides an SMT backend for Z3 proofs. Blaster works by first aggressively optimizing the Lean expression of a theorem, sometimes up to a `True` goal, before sending the remaining goal and context to an SMT solver.
+Blaster provides an SMT backend for Z3 and cvc5 proofs. Blaster works by first aggressively optimizing the Lean expression of a theorem, sometimes up to a `True` goal, before sending the remaining goal and context to an SMT solver.
 
 ## Table of Contents
 
@@ -14,6 +15,7 @@ Blaster provides an SMT backend for Z3 proofs. Blaster works by first aggressive
   - [Prerequisites](#prerequisites)
   - [Installing Lean4](#installing-lean4)
   - [Installing Z3](#installing-z3)
+  - [Installing cvc5](#installing-cvc5)
 - [How to use?](#how-to-use)
   - [Using lakefile.toml](#using-lakefiletoml)
   - [Using lakefile.lean](#using-lakefilelean)
@@ -49,6 +51,7 @@ Blaster is built with the philosophy that fewer dependencies mean better maintai
 
 - **Lean4** v4.24.0 (or compatible version)
 - **Z3** v4.15.2 (or compatible version)
+- **cvc5** v1.3.4 (optional alternative to Z3)
 
 ### Installing Lean4
 
@@ -70,6 +73,28 @@ The section on [Installing the Z3 Solver](#installing-the-z3-solver)
 below explains how to get the right version of Z3 installed and check that
 Lean is using that version.  If you need more help, please see the official
 installation guidelines from the [Z3 GitHub repository](https://github.com/Z3Prover/z3).
+
+### Installing cvc5
+
+Download a cvc5 release from the [official cvc5 releases](https://github.com/cvc5/cvc5/releases)
+and place the `cvc5` executable on `PATH`.
+
+**Currently tested version:** cvc5 v1.3.4
+
+Z3 remains the default. Select cvc5 with the `solver` option:
+
+```lean
+#blaster (solver: cvc5) [∀ (x : Nat), x + 0 = x]
+```
+
+or for a process with the `BLASTER_SOLVER` environment variable:
+
+```bash
+BLASTER_SOLVER=cvc5 lake build
+```
+
+An explicit `solver` option takes precedence over `BLASTER_SOLVER`. Supported
+values are `z3` and `cvc5`.
 
 ## How to use?
 
@@ -98,6 +123,9 @@ require «Blaster» from git
   - `only-optimize`: only perform optimization on lean specification and do not translate to smt-lib (default: 0)
   - `dump-smt-lib`: display the smt lib query to stdout (default: 0)
   - `random-seed`: seed for the random number generator (default: none)
+  - `solver`: backend SMT solver, `z3` or `cvc5` (default: `BLASTER_SOLVER`, then `z3`)
+  - `cvc5-allow-undetermined`: allow an explicitly identified cvc5 case to return
+                                `Undetermined` without weakening decided-result expectations
   - `gen-cex`: generate counterexample for falsified theorems (default: 1)
   - `solve-result`: specify the expected result from the #blaster command, i.e.,
                     0 for 'Valid', 1 for 'Falsified' and 2 for 'Undetermined'. (default: 0)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Lean Version](https://img.shields.io/badge/Lean-v4.24.0-blue.svg)](https://github.com/leanprover/lean4)
 [![Z3 Version](https://img.shields.io/badge/Z3-v4.15.2-green.svg)](https://github.com/Z3Prover/z3)
-[![cvc5 Version](https://img.shields.io/badge/cvc5-v1.3.4-green.svg)](https://github.com/cvc5/cvc5)
+[![cvc5 Version](https://img.shields.io/badge/cvc5-v1.2.1-green.svg)](https://github.com/cvc5/cvc5)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-Blaster provides an SMT backend for Z3 and cvc5 proofs. Blaster works by first aggressively optimizing the Lean expression of a theorem, sometimes up to a `True` goal, before sending the remaining goal and context to an SMT solver.
+Blaster provides an SMT backend for Lean4 proofs, supporting both the Z3 (default) and cvc5 solvers. Blaster works by first aggressively optimizing the Lean expression of a theorem, sometimes up to a `True` goal, before sending the remaining goal and context to an SMT solver.
 
 ## Table of Contents
 
@@ -47,11 +47,14 @@ Blaster provides an SMT backend for Z3 and cvc5 proofs. Blaster works by first a
 
 ### Prerequisites
 
-Blaster is built with the philosophy that fewer dependencies mean better maintainability and more optimization opportunities. That said, Blaster requires:
+Blaster requires Lean. Invoking a solver additionally requires the selected
+backend executable; solver-independent translation and pure tests require neither:
 
-- **Lean4** v4.24.0 (or compatible version)
-- **Z3** v4.15.2 (or compatible version)
-- **cvc5** v1.3.4 (optional alternative to Z3)
+- **Lean4** v4.24.0 (or compatible version);
+- **Z3** v4.15.2 (or compatible version) — the default backend, required only
+  when using the default/explicit Z3 path or running Z3 tests;
+- **cvc5** v1.2.1 or later — the optional alternative, required only when
+  selecting or testing the cvc5 backend.
 
 ### Installing Lean4
 
@@ -76,25 +79,43 @@ installation guidelines from the [Z3 GitHub repository](https://github.com/Z3Pro
 
 ### Installing cvc5
 
-Download a cvc5 release from the [official cvc5 releases](https://github.com/cvc5/cvc5/releases)
-and place the `cvc5` executable on `PATH`.
+The cvc5 backend is optional: Blaster only looks for a `cvc5` executable when the
+`(solver: cvc5)` option (or `BLASTER_SOLVER=cvc5`) is used. The test entry points
+preserve that isolation:
 
-**Currently tested version:** cvc5 v1.3.4
+- `make test-pure` runs parser, model-reconstruction, version-policy, launch-spec,
+  setup-command, and configuration-precedence tests without either solver;
+- `make test-z3` runs the default backend suite and requires only Z3;
+- `make test-cvc5` runs the cvc5 backend suite in strict result-conformance mode
+  and requires only cvc5;
+- `make test-all-solvers` checks every test module plus same-process backend
+  selection and requires both solvers;
+- `make test-cvc5-floor` requires exactly cvc5 1.2.1 and runs the focused
+  support-floor checks described below.
 
-Z3 remains the default. Select cvc5 with the `solver` option:
+`make check_tests` runs the pure and Z3 tiers. Linux CI mirrors this topology in
+separate Z3-only, cvc5-only, dual-solver, and cvc5-support-floor matrix legs.
 
-```lean
-#blaster (solver: cvc5) [∀ (x : Nat), x + 0 = x]
-```
+**Full-suite tested version:** cvc5 v1.3.4. Version 1.2.1 is the hard support
+floor enforced by Blaster's solver-version validation. A dedicated CI leg
+downloads the official cvc5 1.2.1 static binary and requires
+discovery/version validation, one satisfiable query, one unsatisfiable query,
+and one counterexample/model query to pass.
 
-or for a process with the `BLASTER_SOLVER` environment variable:
+Install a release binary from the [cvc5 GitHub repository](https://github.com/cvc5/cvc5/releases)
+and make sure it is available in your `PATH` as `cvc5`. You can check the setup with:
 
 ```bash
-BLASTER_SOLVER=cvc5 lake build
+lake exe solvercheck cvc5
 ```
 
-An explicit `solver` option takes precedence over `BLASTER_SOLVER`. Supported
-values are `z3` and `cvc5`.
+Solver executables are validated before use: a candidate whose version banner
+cannot be parsed, or reports a version below the supported minimum, is
+rejected with a diagnostic listing every candidate tried (fail-closed; this
+also applies to `z3`). On Windows, Blaster makes a best-effort fallback by
+probing `wsl` with `z3` / `cvc5` as its first argument when no native solver
+is found. Automated Linux CI does not exercise this fallback, so it is not a
+tested Windows-support guarantee.
 
 ## How to use?
 
@@ -117,15 +138,19 @@ require «Blaster» from git
 ```
 
 ### Solver options
-  - `timeout`: specifying the timeout (in second) to be used for the backend smt solver (defaut: ∞)
+  - `timeout`: timeout in seconds for the backend solver. Precedence is the explicit
+               option, then `BLASTER_TIMEOUT`, then no timeout (∞). Surrounding
+               whitespace is ignored; an unset or blank environment value means ∞,
+               and any other environment value must be a natural number.
   - `verbose:` activating debug info (default: 0)
   - `only-smt-lib`: only translating unsolved goals to smt-lib without invoking the backend solver (default: 0)
   - `only-optimize`: only perform optimization on lean specification and do not translate to smt-lib (default: 0)
   - `dump-smt-lib`: display the smt lib query to stdout (default: 0)
   - `random-seed`: seed for the random number generator (default: none)
-  - `solver`: backend SMT solver, `z3` or `cvc5` (default: `BLASTER_SOLVER`, then `z3`)
-  - `cvc5-allow-undetermined`: allow an explicitly identified cvc5 case to return
-                                `Undetermined` without weakening decided-result expectations
+  - `solver`: backend SMT solver (`z3` or `cvc5`). Precedence is the explicit option,
+              then `BLASTER_SOLVER`, then `z3`. Surrounding whitespace in the
+              environment value is ignored, but names are case-sensitive lowercase;
+              any other value is rejected with the valid choices.
   - `gen-cex`: generate counterexample for falsified theorems (default: 1)
   - `solve-result`: specify the expected result from the #blaster command, i.e.,
                     0 for 'Valid', 1 for 'Falsified' and 2 for 'Undetermined'. (default: 0)
@@ -285,29 +310,37 @@ def sizeOfTerm (t : Term α) : Nat :=
 
 ❌ Falsified
 Counterexample:
- - x: (let ((a!1 (Test.SmtPredQualifier.Term.Annotated
-             (Test.SmtPredQualifier.Term.Annotated
-               (Test.SmtPredQualifier.Term.Annotated
-                 (Test.SmtPredQualifier.Term.Ident "!a!")
-                 (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))
-               (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))
-             (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))))
-(let ((a!2 (Test.SmtPredQualifier.Term.Annotated
-             (Test.SmtPredQualifier.Term.Annotated
-               (Test.SmtPredQualifier.Term.Annotated
-                 (Test.SmtPredQualifier.Term.Annotated
-                   a!1
-                   (as List.nil
-                       (@List (@Test.SmtPredQualifier.Attribute @@Type))))
-                 (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))
-               (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))
-             (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))))
-  (Test.SmtPredQualifier.Term.Annotated
-    (Test.SmtPredQualifier.Term.Annotated
-      a!2
-      (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))
-    (as List.nil (@List (@Test.SmtPredQualifier.Attribute @@Type))))))
+ - x: Test.SmtPredQualifier.Term.Annotated (Test.SmtPredQualifier.Term.Annotated
+   (Test.SmtPredQualifier.Term.Annotated (... (Test.SmtPredQualifier.Term.Ident "!9!") []) ...) []) []
 ```
+(exact model values vary with the backend solver and its version)
+
+##### Counterexample display rendering
+
+Counterexample values are read back from the solver through `(get-value …)`
+and normalized into Lean-flavored display text; Blaster does not reconstruct
+typed Lean values. For supported value shapes, the renderer smooths
+backend-specific formatting differences: `let`-shared subterms are expanded,
+cvc5's `as` constructor qualifiers are dropped, negative integers are
+rendered `-n`, SMT-LIB string escapes are decoded back to Lean string
+literals, and `List`/`Prod` values use Lean's `[x, y]` and `(x, y)` notations.
+
+Two distinct failure layers are surfaced differently and should not be
+confused:
+
+- **The solver produced a value, but it has no Lean counterpart** — e.g.
+  elements of uninterpreted sorts standing for abstracted `Type` parameters,
+  or function-typed variables (SMT arrays/lambdas). The value is displayed as
+  a raw solver term rather than rejected. This is a rendering fallback, not a
+  missing model.
+- **The solver did not produce a value at all** — e.g. it reports an error
+  for `(get-value …)` (partial model, unsupported construct) or for the raw
+  `(get-model)` dump. This is reported inline as `<no value: …>` (per
+  variable) or `<no model available: …>` (whole model), carrying the solver's
+  own error message. A solver that answers `unknown` (including on a
+  per-check timeout) is never queried for a model: the result is reported as
+  `Undetermined` without a counterexample.
+
 #### State-Machine Formalization
 ```lean
 instance counterStateMachine : StateMachine Request CounterState where
@@ -436,6 +469,58 @@ Blaster has been benchmarked against a variety of well-known benchmarks to evalu
 The evaluation can be found on this public repository: [Blaster-benchmarking](https://github.com/input-output-hk/Blaster-benchmarking)
 
 <details>
+<summary><b>Backend solver comparison (z3 vs cvc5)</b></summary>
+
+Historical measurement recorded when the cvc5 backend was introduced, using
+the then-current local builds: Z3 4.15.4 and cvc5 1.3.4. This table is retained
+as a historical snapshot; this branch's CI does not regenerate it. The
+measurement collected the 425 `#blaster` queries in the two suites below and
+ran each in batch mode through both solvers with a 15s wall clock; *match*
+means the solver's verdict agrees with the test's expected result
+(`solve-result:`).
+
+| Suite | Queries | z3 | cvc5 |
+|---|---|---|---|
+| Tests/FixedIssues | 71 | 69 | 59 |
+| Tests/Smt | 354 | 351 | 313 |
+| **Total** | **425** | **420 (98.8%)** | **372 (87.5%)** |
+
+The measurement records agreement with the expected result for 420 of 425
+queries under z3 and 372 of 425 under cvc5. The accompanying cvc5 result
+records include `Undetermined` outcomes with `unknown`/timeout diagnostics;
+neither the table nor those diagnostics establishes a solver-strategy cause.
+Successful `(get-value …)` responses from either backend pass through the same
+Lean-flavored text renderer (see
+[Counterexample display rendering](#counterexample-display-rendering)).
+
+##### Known cvc5 backend limitations
+
+These describe current backend-facing behavior visible to Blaster, separate
+from model-value normalization and display rendering:
+
+- **Timeout behavior**: the `timeout:` option maps to cvc5's `tlimit-per`,
+  which bounds each `check-sat` call individually (z3's `timeout` applies
+  per context). Suite-wide bounding via `BLASTER_TIMEOUT` is recommended for
+  cvc5 runs. The strict cvc5-only CI leg uses 120s; the local target defaults
+  to 30s.
+- **`unknown` yields no model**: after `unknown` (including per-check
+  timeouts), Blaster does not query a model, so no counterexample is shown.
+- **Nested recursive datatypes** rely on cvc5's experimental
+  `--dt-nested-rec` support (z3 accepts them natively).
+
+Known display-rendering limitations, common to both solvers:
+
+- goals without top-level quantified variables fall back to a raw
+  `(get-model)` dump, which is displayed as produced by the solver (a solver
+  error on that dump is reported inline as `<no model available: …>`);
+- function-typed variables and abstracted `Type` parameters are modeled by
+  SMT arrays/lambdas and uninterpreted-sort elements, which have no Lean
+  counterpart and are displayed as raw solver terms
+  (e.g. z3's `U!val!0`, cvc5's `@U_0`).
+
+</details>
+
+<details>
 <summary><b>Lean Natural Number Game</b></summary>
   
 - **Repository:** [NNG4](https://github.com/leanprover-community/NNG4)
@@ -546,7 +631,7 @@ The translation step is handled in `Blaster/Smt/Translate.lean`. This process in
 
 ### Final step: SMT Solver Interaction
 
-Once an expression has been translated, Blaster interacts with an external SMT solver (i.e.,  Z3) to verify the SMT-LIB formula. This is done by asserting  the negation of the formula to determine its satisfiability. The results are interpreted as follows:
+Once an expression has been translated, Blaster interacts with an external SMT solver (Z3 by default, or cvc5 when selected through the `solver:` option) to verify the SMT-LIB formula. This is done by asserting  the negation of the formula to determine its satisfiability. The results are interpreted as follows:
 
 - **unsat**: The original expression is valid.
 - **sat**: The original expression is falsified, and a counterexample may be generated.
@@ -556,7 +641,7 @@ Once an expression has been translated, Blaster interacts with an external SMT s
 
 ## Installing the Z3 Solver
 
-Blaster requires Z3 version 4.15.2.  To install that, you need to
+The Z3 backend's supported minimum is version 4.15.2. To install it, you need to
 
 1. **Check out** the 4.15.2 tagged branch of the Z3 repo;
 2. **Install** Z3 in a location that doesn't conflict with possible existing versions

--- a/SolverCheck.lean
+++ b/SolverCheck.lean
@@ -1,0 +1,60 @@
+/-
+  This program checks that the backend SMT solvers supported by Blaster
+  are installed correctly and prints their versions.
+
+  To run this program, ensure that the solver(s) are installed and accessible
+  from your system's PATH (see the instructions in the README); then, compile
+  and execute this Lean code as follows:
+
+     lake build solvercheck
+     lake exe solvercheck          # checks every supported solver
+     lake exe solvercheck z3       # checks z3 only
+     lake exe solvercheck cvc5     # checks cvc5 only
+
+  If a solver is installed correctly, you will see output like:
+
+     ✅ Successfully ran cvc5:
+     <cvc5 first-line version banner>
+
+  otherwise, it will print an error message and exit with a non-zero code.
+-/
+
+import Blaster
+
+open Blaster.Options Blaster.Smt IO
+
+def checkSolver (solver : SmtSolver) : IO Bool := do
+  let desc := solver.descriptor
+  let mut attemptLogs := #[]
+  for candidate in desc.candidates do
+    -- shares the discovery acceptance policy (version parsing, minimal
+    -- version, fail-closed on unparseable banners) with Blaster itself
+    let outcome ← probeSolverCandidate desc candidate
+    match evalCandidateProbe desc candidate outcome with
+    | .ok () =>
+        IO.println s!"✅ Successfully ran {candidate.display}:"
+        -- only the first line: cvc5 --version is followed by a long license notice
+        IO.println outcome.banner
+        return true
+    | .error log => attemptLogs := attemptLogs.push log
+  IO.eprintln s!"❌ Could not find a working {desc.name} ≥ {desc.minVersion}. Tried:"
+  attemptLogs.forM (IO.eprintln s!"   {·}")
+  return false
+
+def main (args : List String) : IO UInt32 := do
+  let solvers ←
+    match args with
+    | [] => pure #[SmtSolver.z3, SmtSolver.cvc5]
+    | [s] =>
+        match SmtSolver.ofString? s with
+        | some solver => pure #[solver]
+        | none => do
+            IO.eprintln s!"Unknown solver '{s}' (expected 'z3' or 'cvc5')."
+            return 1
+    | _ => do
+        IO.eprintln "usage: solvercheck [z3|cvc5]"
+        return 1
+  let mut allFound := true
+  for solver in solvers do
+    allFound := (← checkSolver solver) && allFound
+  return (if allFound then 0 else 1)

--- a/Tests/AllSolvers.lean
+++ b/Tests/AllSolvers.lean
@@ -1,0 +1,4 @@
+import Tests
+import Tests.Cvc5
+import Tests.Smt.SolverSelection
+import Tests.Smt.StrictResultPolicy

--- a/Tests/AllSolvers.lean
+++ b/Tests/AllSolvers.lean
@@ -1,4 +1,3 @@
 import Tests
 import Tests.Cvc5
 import Tests.Smt.SolverSelection
-import Tests.Smt.StrictResultPolicy

--- a/Tests/Backend.lean
+++ b/Tests/Backend.lean
@@ -1,0 +1,4 @@
+import Tests.FixedIssues
+import Tests.Optimize
+import Tests.Smt.Backend
+import Tests.StateMachine

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -1,6 +1,2 @@
-
-import Tests.FixedIssues
-import Tests.Optimize
 import Tests.Smt
-import Tests.StateMachine
-
+import Tests.Z3

--- a/Tests/Cvc5.lean
+++ b/Tests/Cvc5.lean
@@ -1,0 +1,1 @@
+import Tests.Smt.SmtSolverCvc5

--- a/Tests/Cvc5.lean
+++ b/Tests/Cvc5.lean
@@ -1,1 +1,3 @@
+import Tests.Backend
+import Tests.Smt.Cvc5Floor
 import Tests.Smt.SmtSolverCvc5

--- a/Tests/FixedIssues/Issue16.lean
+++ b/Tests/FixedIssues/Issue16.lean
@@ -26,12 +26,12 @@ end
          (∀  (x y : Int) (f : Int → Nat), f x + f y > 20)
        ]
 
-#blaster (gen-cex:0) (solve-result: 1) (random-seed: 1)
+#blaster (gen-cex:0) (solve-result: 1) (random-seed: 1) (cvc5-allow-undetermined: 1)
        [ (∀ (β : Type) (x : Term (List β)) (f : Term (List β) → Nat), f x > 0) →
          (∀ (α : Type) (x y : Term (List α)) (f : Term (List α) → Nat), f x + f y > 20)
        ]
 
-#blaster (gen-cex:0) (solve-result: 1) (random-seed: 1)
+#blaster (gen-cex:0) (solve-result: 1) (random-seed: 1) (cvc5-allow-undetermined: 1)
        [ (∀ (β : Type) (x : Term (List β)) (g : Term (List β) → Nat), g x > 10) →
          (∀ (α : Type) (x y : Term (List α)) (f : Term (List α) → Nat), f x + f y > 30)
        ]

--- a/Tests/FixedIssues/Issue17.lean
+++ b/Tests/FixedIssues/Issue17.lean
@@ -29,9 +29,9 @@ def sizeOfNatGroup (x : NatGroup) : Nat :=
 
 #blaster [∃ (x : NatGroup), sizeOfNatGroup x > 100]
 
-#blaster [∃ (x : NatGroup), sizeOfNatGroup x > 200]
+#blaster (cvc5-allow-undetermined: 1) [∃ (x : NatGroup), sizeOfNatGroup x > 200]
 
-#blaster [∃ (x : NatGroup), sizeOfNatGroup x < 20]
+#blaster (cvc5-allow-undetermined: 1) [∃ (x : NatGroup), sizeOfNatGroup x < 20]
 
 -- Expecting a counterexample
 -- Remove solver options when supporting proof by induction

--- a/Tests/FixedIssues/Issue18.lean
+++ b/Tests/FixedIssues/Issue18.lean
@@ -7,15 +7,15 @@ import Blaster
 
 namespace Tests.Issue18
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
        [ ∀ (xs : List Nat), !(List.isEmpty xs) → List.head! (List.map Int.ofNat xs) ≥ 10 ]
 
 #blaster [ ∀ (x : Nat) (xs : List Nat), !(List.isEmpty xs) → List.head! (List.map (Nat.add x) xs) ≥ x ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ ∀ (xs : List Nat) (f : List Nat → Nat) (c : Bool), f xs < 10 → (if c then f else List.length) xs < 10 ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ ∀ (xs : List (List Nat)), !(List.isEmpty xs) → List.head! (List.map List.length xs) < 0 ]
 
 def addOptionList (x : Option Nat) (xs : List Nat) : List Nat :=
@@ -32,7 +32,7 @@ def addOptionPoly [LE α] [DecidableLE α] (x : Option α) (xs : List α) : List
   | some x' => List.map (λ y => if x' ≤ y then x' else y) xs
 
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
        [ ∀ (α : Type) (x : Option α) (xs : List α), [LE α] → [DecidableLE α] → [Inhabited α] →
           !(List.isEmpty xs) → (List.head! (addOptionPoly x xs)) ≤ x
        ]

--- a/Tests/FixedIssues/Issue20.lean
+++ b/Tests/FixedIssues/Issue20.lean
@@ -13,7 +13,7 @@ theorem funextEq_poly {α β : Type} (f g : α → β) : (f = g) = ∀ x, f x = 
       { intro h ; simp only [h, implies_true] }
       { intro h ; apply funext h }
 
-#blaster [funextEq_poly]
+#blaster (cvc5-allow-undetermined: 1) [funextEq_poly]
 
 theorem funextEq_one_inst {β : Type} (f g : Nat → β) : (f = g) = ∀ x, f x = g x := by
       apply propext

--- a/Tests/FixedIssues/Issue33.lean
+++ b/Tests/FixedIssues/Issue33.lean
@@ -3,43 +3,27 @@ import Blaster
 namespace Tests.Issue33
 
 -- Issue: Unexpected Valid
--- Diagnosis: Functional extensionality axiom has incorrect quantifier structure,
---            causing unsoundness.
+-- Diagnosis: lambda definition axioms ranged over every value of an SMT
+-- carrier instead of only values represented by the corresponding Lean type.
+-- This is unsound for refined encodings such as `Nat`, whose SMT carrier is
+-- `Int` and whose valid domain is selected by `@isNat`.
 
--- Blaster emits the following axiom in the SMT-LIB translation:
+-- For the closure-converted equality lambda `fun x y : Nat => x = y`, the
+-- unguarded definition constrained its behavior even at negative integers.
+-- The closures obtained at `x = -1` and `x = -2` agree on every valid `Nat`,
+-- so valid-domain function extensionality equates them. Their unguarded
+-- definitions nevertheless disagree at `y = -1`, making the SMT theory
+-- inconsistent. Guarding the monomorphic captured values and explicit lambda
+-- arguments with their domain predicates prevents this contradiction.
 
--- (assert (forall ((@x0 Nat) (@f (@@ArrowT2 Nat Bool)) (@g (@@ArrowT2 Nat Bool)))
---   (!(=> (= (@apply_uniq @f @x0) (@apply_uniq @g @x0)) (= @f @g))
---   :pattern ( (= (@apply_uniq @f @x0) (@apply_uniq @g @x0)))
---   :qid @apply_uniq_ext_fun)
--- ))
-
--- This is intended to be functional extensionality:
---   ∀ f g, (∀ x, f(x) = g(x)) → f = g
-
--- But the quantifier structure is wrong. It says:
---   ∀ x f g, f(x) = g(x) → f = g
-
--- In the buggy version, f and g agreeing on any single point implies equality.
--- In the correct version, f and g must agree on all points.
-
--- This makes the theory inconsistent. For example, let:
---   f = (λ x => x == 0)   -- true only at 0
---   g = (λ x => x == 1)   -- true only at 1
-
--- f and g agree at 42: f(42) = false = g(42).
--- So the buggy axiom concludes f = g. But f(0) = true ≠ false = g(0).
--- Contradiction. The theory is inconsistent and can prove anything.
-
--- Minimal reproduction: Blaster incorrectly proves that any two functions
--- agreeing at 0 must be equal everywhere.
+-- Minimal soundness check: agreement at one point does not imply equality.
 #blaster (gen-cex: 0) (solve-result: 1) [∀ (f g : Nat → Bool), f 0 = g 0 → f = g]
 
--- Real-world example: a multi-signature validator that Blaster incorrectly
--- deems always valid, regardless of the threshold.
--- validate_signatures should only return true when threshold is zero and
--- there are no verifiers. For threshold n > 0, it should return false.
--- Blaster proves it valid for arbitrary n, which is false.
+-- Real-world regression: the validator is true only when the threshold is
+-- zero and there are no verifiers. The universally quantified claim below is
+-- false for every positive threshold. Z3 4.15.2 does not find its model within
+-- the existing three-second limit, but it must never derive `Valid` from an
+-- inconsistent background theory.
 structure Verifier where
   payment_key : Nat
   is_mandatory : Bool

--- a/Tests/FixedIssues/Issue9.lean
+++ b/Tests/FixedIssues/Issue9.lean
@@ -18,9 +18,9 @@ def sizeOfGenericGroup [LE α] (a : GenericGroup α) : Nat :=
   | .first .. => 1
   | .next n => 1 + (sizeOfGenericGroup n)
 
-#blaster (gen-cex: 0) (solve-result: 1) [∀ (α : Type), [LE α] → ∀ (a : GenericGroup α), sizeOfGenericGroup a ≥ 10]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [∀ (α : Type), [LE α] → ∀ (a : GenericGroup α), sizeOfGenericGroup a ≥ 10]
 
-#blaster (gen-cex: 0) (solve-result: 1) [∀ (α : Type), [LE α] → ∀ (a : GenericGroup α), sizeOfGenericGroup a < 10]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [∀ (α : Type), [LE α] → ∀ (a : GenericGroup α), sizeOfGenericGroup a < 10]
 
 mutual
  structure FunGroup (α : Type) [LE α] where
@@ -39,7 +39,7 @@ def sizeOfGenericGroupFun [LE α] [LE (GenericGroupFun α)] [DecidableLE (Generi
             1 + sizeOfGenericGroupFun n2
           else 2
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ ∀ (α : Type), [LE α] →
     [LE (GenericGroupFun α)] →
     [DecidableLE (GenericGroupFun α)] →

--- a/Tests/Pure.lean
+++ b/Tests/Pure.lean
@@ -1,0 +1,6 @@
+import Tests.Smt.Configuration
+import Tests.Smt.CrashLifecycle
+import Tests.Smt.ModelReconstruction
+import Tests.Smt.SmtSetupCommands
+import Tests.Smt.SolverVersion
+import Tests.Smt.StrictResultPolicy

--- a/Tests/Smt.lean
+++ b/Tests/Smt.lean
@@ -1,9 +1,1 @@
-
-import Tests.Smt.Benchmarks
-import Tests.Smt.SmtEqArith
-import Tests.Smt.SmtLtArith
-import Tests.Smt.SmtMatch
-import Tests.Smt.SmtNat
-import Tests.Smt.SmtPredQualifier
-import Tests.Smt.SmtRecFun
-
+import Tests.Smt.Backend

--- a/Tests/Smt.lean
+++ b/Tests/Smt.lean
@@ -1,1 +1,2 @@
+import Tests.Pure
 import Tests.Smt.Backend

--- a/Tests/Smt/Backend.lean
+++ b/Tests/Smt/Backend.lean
@@ -1,0 +1,7 @@
+import Tests.Smt.Benchmarks
+import Tests.Smt.SmtEqArith
+import Tests.Smt.SmtLtArith
+import Tests.Smt.SmtMatch
+import Tests.Smt.SmtNat
+import Tests.Smt.SmtPredQualifier
+import Tests.Smt.SmtRecFun

--- a/Tests/Smt/Benchmarks/ValidatorsExamples/Vesting/Vesting.lean
+++ b/Tests/Smt/Benchmarks/ValidatorsExamples/Vesting/Vesting.lean
@@ -117,6 +117,6 @@ theorem if_accepted_then_purpose_spend :
 
 #blaster [only_accept_if_signatory_and_time_elapsed]
 
-#blaster (gen-cex: 0) (solve-result: 1) [only_accept_if_signatory_and_time_elapsed_bugged]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [only_accept_if_signatory_and_time_elapsed_bugged]
 
 end Tests.ValidatorsExamples.Vesting

--- a/Tests/Smt/Configuration.lean
+++ b/Tests/Smt/Configuration.lean
@@ -1,0 +1,92 @@
+import Blaster.Smt.Env
+
+namespace Test.Configuration
+
+open Blaster.Options Blaster.Smt
+
+private def solverOptions (solver : SmtSolver) : BlasterOptions :=
+  { solver := some solver }
+
+private def timeoutOptions (timeout : Nat) : BlasterOptions :=
+  { timeout := some timeout }
+
+private def errorContains (fragment : String) : Except String α → Bool
+  | .ok _ => false
+  | .error message => (message.splitOn fragment).length > 1
+
+private def resolvesToSolver (expected : SmtSolver) : Except String SmtSolver → Bool
+  | .ok actual => actual == expected
+  | .error _ => false
+
+private def resolvesToTimeout (expected : Option Nat) : Except String (Option Nat) → Bool
+  | .ok actual => actual == expected
+  | .error _ => false
+
+/-! Solver precedence and parsing. Environment values accept surrounding
+    whitespace, while solver names remain case-sensitive. -/
+
+private def envUnsetSelectsZ3 : Bool :=
+  resolvesToSolver .z3 (resolveSolverConfig default none)
+
+private def cvc5EnvironmentSelectsCvc5 : Bool :=
+  resolvesToSolver .cvc5 (resolveSolverConfig default (some "cvc5"))
+
+private def explicitZ3OverridesCvc5Environment : Bool :=
+  resolvesToSolver .z3 (resolveSolverConfig (solverOptions .z3) (some "cvc5"))
+
+private def explicitSolverSkipsInvalidEnvironment : Bool :=
+  resolvesToSolver .z3 (resolveSolverConfig (solverOptions .z3) (some "yices"))
+
+private def surroundingSolverWhitespaceIsAccepted : Bool :=
+  resolvesToSolver .cvc5 (resolveSolverConfig default (some "  cvc5 \t"))
+
+private def mixedCaseSolverIsRejected : Bool :=
+  errorContains "CVC5" (resolveSolverConfig default (some "CVC5"))
+
+private def invalidSolverNamesValidChoices : Bool :=
+  let result := resolveSolverConfig default (some "yices")
+  errorContains "yices" result && errorContains "z3" result && errorContains "cvc5" result
+
+private def emptySolverIsRejected : Bool :=
+  errorContains "BLASTER_SOLVER" (resolveSolverConfig default (some "  "))
+
+#guard envUnsetSelectsZ3
+#guard cvc5EnvironmentSelectsCvc5
+#guard explicitZ3OverridesCvc5Environment
+#guard explicitSolverSkipsInvalidEnvironment
+#guard surroundingSolverWhitespaceIsAccepted
+#guard mixedCaseSolverIsRejected
+#guard invalidSolverNamesValidChoices
+#guard emptySolverIsRejected
+
+/-! Timeout precedence and parsing. Environment values are trimmed; unset,
+    empty, and whitespace-only values mean unlimited. Other values must be
+    natural numbers of seconds. -/
+
+private def unsetTimeoutIsUnlimited : Bool :=
+  resolvesToTimeout none (resolveTimeoutConfig default none)
+
+private def explicitTimeoutOverridesEnvironment : Bool :=
+  resolvesToTimeout (some 7) (resolveTimeoutConfig (timeoutOptions 7) (some "99"))
+
+private def explicitTimeoutSkipsInvalidEnvironment : Bool :=
+  resolvesToTimeout (some 7) (resolveTimeoutConfig (timeoutOptions 7) (some "forever"))
+
+private def surroundingTimeoutWhitespaceIsAccepted : Bool :=
+  resolvesToTimeout (some 30) (resolveTimeoutConfig default (some "  30 \t"))
+
+private def emptyTimeoutIsUnlimited : Bool :=
+  resolvesToTimeout none (resolveTimeoutConfig default (some " \t "))
+
+private def nonnumericTimeoutIsRejected : Bool :=
+  let result := resolveTimeoutConfig default (some "forever")
+  errorContains "forever" result && errorContains "number of seconds" result
+
+#guard unsetTimeoutIsUnlimited
+#guard explicitTimeoutOverridesEnvironment
+#guard explicitTimeoutSkipsInvalidEnvironment
+#guard surroundingTimeoutWhitespaceIsAccepted
+#guard emptyTimeoutIsUnlimited
+#guard nonnumericTimeoutIsRejected
+
+end Test.Configuration

--- a/Tests/Smt/CrashLifecycle.lean
+++ b/Tests/Smt/CrashLifecycle.lean
@@ -1,0 +1,69 @@
+import Blaster.Smt.Env
+
+namespace Test.CrashLifecycle
+
+open Lean Blaster.Optimize Blaster.Smt
+
+private abbrev PipedChild :=
+  IO.Process.Child ⟨.piped, .piped, .piped⟩
+
+private structure Observation where
+  message : String
+  processCleared : Bool
+
+private def contains (text fragment : String) : Bool :=
+  (text.splitOn fragment).length > 1
+
+private def spawnFakeChild (stderr : String) (stayAlive : Bool) : IO PipedChild :=
+  let script :=
+    if stayAlive then
+      s!"echo '{stderr}' >&2; exec 1>&-; exec sleep 10"
+    else
+      s!"echo '{stderr}' >&2; exit 17"
+  IO.Process.spawn {
+    cmd := "/bin/sh"
+    args := #["-c", script]
+    stdin := .piped
+    stdout := .piped
+    stderr := .piped
+  }
+
+private def observeClosedStdout (p : PipedChild) : MetaM Observation := do
+  let env : TranslateEnv := default
+  let env := { env with smtEnv.smtProc := some p }
+  let (observation, _) ← (do
+    let message ←
+      try
+        discard (getSatResult p)
+        pure "solver unexpectedly returned a result"
+      catch e : Exception =>
+        e.toMessageData.toString
+    let processCleared := (← get).smtEnv.smtProc.isNone
+    return (Observation.mk message processCleared)).run env
+  return observation
+
+private def assertCrash
+    (label stderr : String) (observation : Observation) : MetaM Unit := do
+  unless contains observation.message "solver closed its output stream" do
+    throwError "{label}: contextual solver EOF error was lost:\n{observation.message}"
+  unless contains observation.message stderr do
+    throwError "{label}: solver stderr was lost:\n{observation.message}"
+  if contains observation.message "no such process" ||
+      contains observation.message "No such process" then
+    throwError "{label}: duplicate cleanup masked the solver failure:\n{observation.message}"
+  unless observation.processCleared do
+    throwError "{label}: retired solver remained installed in smtProc"
+
+private def testCrashLifecycle : MetaM Unit := do
+  let liveStderr := "FAKE_LIVE_CHILD: deliberate stderr"
+  let live ← spawnFakeChild liveStderr true
+  assertCrash "live child" liveStderr (← observeClosedStdout live)
+
+  let deadStderr := "FAKE_DEAD_CHILD: deliberate stderr"
+  let dead ← spawnFakeChild deadStderr false
+  assertCrash "already-dead child" deadStderr (← observeClosedStdout dead)
+
+#guard_msgs in
+#eval testCrashLifecycle
+
+end Test.CrashLifecycle

--- a/Tests/Smt/Cvc5Floor.lean
+++ b/Tests/Smt/Cvc5Floor.lean
@@ -1,0 +1,25 @@
+import Blaster
+
+namespace Test.Cvc5Floor
+
+/-! Minimal cvc5 support-floor checks. This module intentionally contains one
+    satisfiable query, one unsatisfiable query, and one counterexample query. -/
+
+-- Satisfiable negated goal: backend must report Falsified.
+#blaster (solver: cvc5) (gen-cex: 0) (solve-result: 1) [∀ (x : Int), x = 0]
+
+-- Unsatisfiable negated goal: backend must report Valid.
+#blaster (solver: cvc5) [∀ (x : Int), x = x]
+
+-- Satisfiable negated goal with a unique model value, exercising get-value.
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - x: 3
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (x : Int), x ≠ 3]
+
+end Test.Cvc5Floor

--- a/Tests/Smt/ModelReconstruction.lean
+++ b/Tests/Smt/ModelReconstruction.lean
@@ -1,0 +1,202 @@
+import Blaster
+
+namespace Test.ModelReconstruction
+
+open Blaster.Smt
+
+/-! ## Test objectives to validate solver model-value reconstruction
+
+    These tests exercise the pure `get-value` response pipeline
+    (`Blaster.Smt.Model`): S-expression parsing, `let` expansion, `as`
+    ascription stripping and Lean-flavored textual rendering. Fixtures
+    explicitly labeled as captured are verbatim output from the named solver
+    version. Other strings are representative or constructed regression inputs
+    and make no claim of verbatim capture provenance.
+-/
+
+/-! # Primitive values (both solvers use the same format) -/
+
+#guard reconstructGetValue? "((x 3))\n" == some "3"
+#guard reconstructGetValue? "((x (- 6)))\n" == some "-6"
+#guard reconstructGetValue? "((b true))\n" == some "true"
+#guard reconstructGetValue? "((b false))\n" == some "false"
+
+/-! # Strings: `""` undoubling, `\u{…}` decoding, Lean re-quoting -/
+
+#guard reconstructGetValue? "((s \"hello\"))\n" == some "\"hello\""
+#guard reconstructGetValue? "((s \"\"))\n" == some "\"\""
+#guard reconstructGetValue? "((s \"a\"\"b\"))\n" == some "\"a\\\"b\""
+#guard reconstructGetValue? "((s \"a\\u{5c}b\"))\n" == some "\"a\\\\b\""
+#guard reconstructGetValue? "((s \"he\\u{1234}llo\"))\n" == some "\"heሴllo\""
+
+/-! # Parentheses inside atoms
+
+    The interactive response reader decides completeness by scanning parens
+    across lines; these pin the parser-level assumption that parens inside
+    string literals and quoted symbols never count as delimiters. -/
+
+#guard reconstructGetValue? "((s \"a(b\"))\n" == some "\"a(b\""
+#guard reconstructGetValue? "((s \"(x))((\"))\n" == some "\"(x))((\""
+-- quoted symbols admit parentheses and spaces
+#guard reconstructGetValue? "((x |foo (bar)|))\n" == some "foo (bar)"
+-- same value through the unwrapped (single-expression) entry point
+#guard reconstructValue? "|foo (bar)|" == some "foo (bar)"
+
+/-! # SMT-LIB string literal emission (mirror of the decoding above) -/
+
+#guard quoteSmtString "hello" == "\"hello\""
+#guard quoteSmtString "a\"b" == "\"a\"\"b\""
+#guard quoteSmtString "a\\b" == "\"a\\u{5c}b\""
+#guard quoteSmtString "a\nb" == "\"a\\u{a}b\""
+#guard quoteSmtString "(x))((" == "\"(x))((\"" -- parentheses travel unescaped
+-- Round trip: decode ∘ quote = id
+#guard Sexp.decodeStringLit? (quoteSmtString "a\"b\\c\nd") == some "a\"b\\c\nd"
+#guard Sexp.decodeStringLit? (quoteSmtString "(x))((") == some "(x))(("
+
+/-! # Datatype constructor applications -/
+
+-- z3: plain application, single line
+#guard reconstructGetValue? "((p (Point.mk (- 3) 0)))\n" == some "Point.mk (-3) 0"
+-- z3: line-wrapped application (values past ~80 columns span several lines)
+#guard reconstructGetValue?
+    "(($0 (Test.Counter06.CounterState.mk\n  Test.Counter06.State.Delay\n  2\n  Test.Counter06.State.Busy\n  Test.Counter06.Request.Tr\n  3)))\n"
+  == some "Test.Counter06.CounterState.mk Test.Counter06.State.Delay 2 Test.Counter06.State.Busy Test.Counter06.Request.Tr 3"
+-- constructors with quoted symbols
+#guard reconstructGetValue? "((p (|Foo 1.mk| (- 3))))\n" == some "Foo 1.mk (-3)"
+
+/-! # Parametric datatypes: cvc5 `as` constructor qualifiers -/
+
+-- cvc5: nullary constructor
+#guard reconstructGetValue? "((o (as Option.none (@Option Int))))\n" == some "Option.none"
+-- z3 prints the same value unqualified
+#guard reconstructGetValue? "((o Option.none))\n" == some "Option.none"
+-- cvc5: qualified constructor application
+#guard reconstructGetValue? "((o ((as Option.some (@Option Int)) (- 2))))\n"
+  == some "Option.some (-2)"
+-- cvc5 1.2.1 (minimum supported version) omits the `@` prefix on the
+-- instantiated sort (captured verbatim from a real 1.2.1 run)
+#guard reconstructGetValue? "((o ((as Option.some (Option Int)) 7)))\n"
+  == some "Option.some 7"
+-- Ascriptions whose qualified term is itself an application still strip.
+#guard reconstructValue? "(as (_ bv1 8) (_ BitVec 8))" == some "(_ bv1 8)"
+#guard reconstructGetValue? "((t ((as Prod.mk (@Prod Int Bool)) (- 1) true)))\n"
+  == some "(-1, true)"
+
+/-! # Lists (rendered with Lean brackets) and cvc5 `let`-shared subterms -/
+
+-- z3
+#guard reconstructGetValue? "((l (List.cons (- 2) (List.cons 2 List.nil))))\n"
+  == some "[-2, 2]"
+#guard reconstructGetValue? "((l List.nil))\n" == some "[]"
+-- cvc5 shares the qualified constructor through a `let`
+#guard reconstructGetValue?
+    "((l (let ((_let_1 (as List.cons (@List Int)))) (_let_1 (- 2) (_let_1 0 (as List.nil (@List Int)))))))\n"
+  == some "[-2, 0]"
+-- cvc5 1.2.1 prints the same `let`-shared value without the `@` sort prefix
+-- (captured verbatim from a real 1.2.1 run)
+#guard reconstructGetValue?
+    "((l (let ((_let_1 (as List.cons (List Int)))) (_let_1 1 (_let_1 2 (as List.nil (List Int)))))))\n"
+  == some "[1, 2]"
+-- nested values: option inside a list
+#guard reconstructGetValue? "((l (List.cons Option.none List.nil)))\n"
+  == some "[Option.none]"
+
+/-! # Tuples: right-nested `Prod.mk` flattens like Lean's tuple notation -/
+
+#guard reconstructGetValue? "((t (Prod.mk 1 (Prod.mk 2 true))))\n" == some "(1, 2, true)"
+
+/-! # Values with no Lean counterpart fall back to raw S-expressions -/
+
+-- uninterpreted sort elements (abstracted `Type` parameters)
+#guard reconstructGetValue? "((u U!val!0))\n" == some "U!val!0" -- z3
+#guard reconstructGetValue? "((u (as @U_0 U)))\n" == some "@U_0" -- cvc5
+-- z3 constant-array value (function-typed variables)
+#guard reconstructGetValue? "((f ((as const (Array Int Int)) 0)))\n"
+  == some "((as const (Array Int Int)) 0)"
+-- constant array nested inside a constructor application: the application
+-- still renders Lean-style while the array argument falls back to raw form
+#guard reconstructGetValue? "((p (Pair.mk ((as const (Array Int Int)) 0) 1)))\n"
+  == some "Pair.mk ((as const (Array Int Int)) 0) 1"
+-- cvc5 lambda value
+#guard reconstructGetValue? "((f (lambda ((_x Int)) (+ _x 1))))\n"
+  == some "(lambda ((_x Int)) (+ _x 1))"
+
+/-! # Binder-aware `let` normalization -/
+
+-- A binder shadows an enclosing `let` substitution in both its declaration
+-- and its body (the review's original capture regression).
+#guard reconstructValue? "(let ((x 1)) (lambda ((x Int)) x))"
+  == some "(lambda ((x Int)) x)"
+-- Quoted binder names use the parser's preserved raw spelling consistently.
+#guard reconstructValue? "(let ((|x y| 1)) (lambda ((|x y| Int)) |x y|))"
+  == some "(lambda ((|x y| Int)) |x y|)"
+-- Simple and quoted spellings denote the same SMT symbol during substitution.
+#guard reconstructValue? "(let ((|x| 1)) x)" == some "1"
+-- Quoted symbols never collide with unquoted lexical or command reserved words.
+#guard reconstructValue? "(let ((|NUMERAL| 1)) (! |NUMERAL| :foo (NUMERAL)))"
+  == some "(! 1 :foo (NUMERAL))"
+#guard reconstructValue? "(let ((|assert| 1)) (! |assert| :foo (assert)))"
+  == some "(! 1 :foo (assert))"
+-- Binding declarations are opaque to term substitution, including their sort.
+#guard reconstructValue? "(let ((S Int)) (lambda ((x S)) x))"
+  == some "(lambda ((x S)) x)"
+-- Nested `let` bindings are parallel: inner `y` sees the outer `x`, while the
+-- inner `x` shadows it in the body.
+#guard reconstructValue? "(let ((x 1)) (let ((x 2) (y x)) (+ x y)))"
+  == some "(+ 2 1)"
+-- The free occurrence is substituted while the lambda-bound occurrence of
+-- the same spelling remains bound.
+#guard reconstructValue? "(let ((x 1)) (Pair.mk x (lambda ((x Int)) x)))"
+  == some "Pair.mk 1 (lambda ((x Int)) x)"
+-- Quantifier declarations also shadow substitutions, while genuinely free
+-- names in the quantified body are still normalized.
+#guard reconstructValue? "(let ((x 1) (y 2)) (forall ((x Int)) (= x y)))"
+  == some "(forall ((x Int)) (= x 2))"
+-- Alpha-renaming prevents a free atom introduced by substitution from being
+-- captured by an inner binder.
+#guard reconstructValue? "(let ((y x)) (exists ((x Int)) (= x y)))"
+  == some "(exists ((_blaster_bound_0 Int)) (= _blaster_bound_0 x))"
+-- A quoted binder also captures the equivalent unquoted replacement atom, so
+-- the binder and its quoted occurrences must be alpha-renamed.
+#guard reconstructValue? "(let ((y x)) (forall ((|x| Int)) (= |x| y)))"
+  == some "(forall ((_blaster_bound_0 Int)) (= _blaster_bound_0 x))"
+-- Fresh names also avoid atoms nested inside the replacement term.
+#guard reconstructValue?
+    "(let ((y (Pair.mk x _blaster_bound_0))) (exists ((x Int)) (= x y)))"
+  == some "(exists ((_blaster_bound_1 Int)) (= _blaster_bound_1 (Pair.mk x _blaster_bound_0)))"
+-- Fresh names exclude equivalent quoted atoms already present in the body,
+-- while preserving that atom's original spelling.
+#guard reconstructValue?
+    "(let ((y x)) (forall ((x Int)) (= |_blaster_bound_0| y)))"
+  == some "(forall ((_blaster_bound_1 Int)) (= |_blaster_bound_0| x))"
+-- Alpha-renaming is term-only and never rewrites a sort position.
+#guard reconstructValue?
+    "(let ((y S)) (lambda ((S Int)) (Pair.mk y ((as const (Array S Int)) 0))))"
+  == some "(lambda ((_blaster_bound_0 Int)) (Pair.mk S ((as const (Array S Int)) 0)))"
+
+/-! # Unsupported binder preservation -/
+
+-- SMT-LIB match patterns bind variables in their branch terms. Until that
+-- scope is implemented, preserve the complete enclosing value: substituting
+-- the outer `x` into either the `(C x)` pattern or its branch changes meaning.
+#guard reconstructValue? "(let ((x 1)) (match v (((C x) x))))"
+  == some "(let ((x 1)) (match v (((C x) x))))"
+-- Preservation must include the enclosing `let`, not just the match subtree;
+-- otherwise genuinely free occurrences would be left dangling after expansion.
+#guard reconstructValue? "(let ((x 1)) (Pair.mk x (match x (((C y) x)))))"
+  == some "(let ((x 1)) (Pair.mk x (match x (((C y) x)))))"
+
+/-! # Solver errors and malformed responses -/
+
+#guard solverErrorMsg? "(error \"cannot get value\")\n" == some "cannot get value"
+#guard reconstructGetValue? "(error \"cannot get value\")\n" == none
+-- SMT-LIB `""` escapes in the message are undoubled …
+#guard solverErrorMsg? "(error \"line 1 \"\"quoted\"\" msg\")\n" == some "line 1 \"quoted\" msg"
+-- … and an `(error …)` response is never mistaken for a model
+#guard reconstructGetValue? "(error \"line 1 \"\"quoted\"\" msg\")\n" == none
+#guard reconstructGetValue? "((x (- 6))" == none -- truncated response
+#guard reconstructGetValue? "unsupported\n" == none
+#guard reconstructGetValue? "" == none
+#guard solverErrorMsg? "((x 3))\n" == none
+
+end Test.ModelReconstruction

--- a/Tests/Smt/SmtMatch.lean
+++ b/Tests/Smt/SmtMatch.lean
@@ -320,7 +320,7 @@ def isGreen (c : Color) : Bool :=
     x = 1 ∨ x = 0 ∨ y.isNone ∨ (y = some t ∧ t ≠ 1) → namedPatternInt x y = Int.toNat x + 3
   ]
 
-#blaster (gen-cex: 0) (solve-result: 1) [∀ (xs : List Nat), ¬ isNil xs → List.length xs = 0]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [∀ (xs : List Nat), ¬ isNil xs → List.length xs = 0]
 
 #blaster (gen-cex: 0) (solve-result: 1) [∀ (x y : POSIXTime), x == y → y ≠ x]
 
@@ -359,79 +359,79 @@ def isGreen (c : Color) : Bool :=
 #blaster (gen-cex: 0) (solve-result: 1)
   [∀ (x y : ScriptContext), x == y → x.purpose == Purpose.Rewarding → y.purpose != Purpose.Rewarding]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → x == Color.transparent → y != Color.transparent ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.transparent → y == Color.red z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.transparent → y == Color.blue z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.transparent → y == Color.yellow z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.red z → y == Color.transparent ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.red z → y == Color.black ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.red z → y == Color.white ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.red z → y == Color.blue z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.red z → y == Color.yellow z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.blue z → y == Color.transparent ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.blue z → y == Color.black ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.blue z → y == Color.white ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.blue z → y == Color.red z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.blue z → y == Color.yellow z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.yellow z → y == Color.transparent ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.yellow z → y == Color.black ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.yellow z → y == Color.white ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.yellow z → y == Color.red z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y z : Color), x == y → x == Color.yellow z → y == Color.blue z ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → isRed x → ¬ isRed y]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → isBlue x → ¬ isBlue y]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → isYellow x → ¬ isYellow y]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → x != Color.black ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → x != Color.white ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [∀ (x y : Color), x == y → x != Color.transparent ]
 
 end Test.SmtMatch

--- a/Tests/Smt/SmtNat/SmtNatDiv.lean
+++ b/Tests/Smt/SmtNat/SmtNatDiv.lean
@@ -26,7 +26,7 @@ namespace Test.SmtNatDiv
 
 #blaster [∀ (x y z : Nat), 0 < z → (x ≤ y / z ↔ x * z ≤ y)]
 
-#blaster [∀ (x y z : Nat), x / y / z = x / (y * z)]
+#blaster (cvc5-allow-undetermined: 1) [∀ (x y z : Nat), x / y / z = x / (y * z)]
 
 #blaster [∀ (x y : Nat), x / y * y ≤ x]
 
@@ -34,11 +34,11 @@ namespace Test.SmtNatDiv
 
 #blaster [∀ (x z : Nat), (0 < z) → (x + z) / z = (x / z) + 1]
 
-#blaster [∀ (x z y : Nat), (0 < y) → (x + y * z) / y = x / y + z]
+#blaster (cvc5-allow-undetermined: 1) [∀ (x z y : Nat), (0 < y) → (x + y * z) / y = x / y + z]
 
 #blaster [∀ (x y z : Nat), z * x ≤ y → y < (z + 1) * x → y / x = z]
 
-#blaster [∀ (x y z : Nat), (y*z ≤ x) → (x - y*z) / y = x / y - z]
+#blaster (cvc5-allow-undetermined: 1) [∀ (x y z : Nat), (y*z ≤ x) → (x - y*z) / y = x / y - z]
 
 #blaster [∀ (x y z : Nat), x < y*z → (y * z - (x + 1)) / y = z - ((x / y) + 1)]
 

--- a/Tests/Smt/SmtNat/SmtNatMod.lean
+++ b/Tests/Smt/SmtNat/SmtNatMod.lean
@@ -20,7 +20,7 @@ namespace Test.SmtNatMod
 
 #blaster [∀ (x : Nat), (0 = 1 % x ↔ x = 1)]
 
-#blaster [∀ (x y : Nat), x ≥ y → x % y = (x - y) % y]
+#blaster (cvc5-allow-undetermined: 1) [∀ (x y : Nat), x ≥ y → x % y = (x - y) % y]
 
 #blaster [∀ (x y : Nat), y > 0 → x % y < y]
 
@@ -38,7 +38,7 @@ namespace Test.SmtNatMod
 
 #blaster [∀ (x y : Nat), (x * y) % x = 0]
 
-#blaster (random-seed: 3) [∀ (x y z : Nat), (z * x) % (z * y) = z * (x % y)]
+#blaster (random-seed: 3) (cvc5-allow-undetermined: 1) [∀ (x y z : Nat), (z * x) % (z * y) = z * (x % y)]
 
 
 /-! # Test cases to ensure that counterexample are properly detected -/

--- a/Tests/Smt/SmtNat/SmtNatMul.lean
+++ b/Tests/Smt/SmtNat/SmtNatMul.lean
@@ -49,9 +49,9 @@ def square (x : Nat) : Nat := x * x
 
 /-! # Test cases to ensure that counterexample are properly detected -/
 
-#blaster (gen-cex: 0) (solve-result: 1) [isSurjective square]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [isSurjective square]
 
-#blaster (gen-cex: 0) (solve-result: 1) [isBijective square]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [isBijective square]
 
 #blaster (gen-cex: 0) (solve-result: 1) [∀ (x y : Nat), x * y ≠ y * x]
 

--- a/Tests/Smt/SmtNat/SmtNatPow.lean
+++ b/Tests/Smt/SmtNat/SmtNatPow.lean
@@ -38,8 +38,8 @@ namespace Test.SmtNatPow
 
 #blaster (gen-cex: 0) (solve-result: 1) [∀ (x : Nat), x^0 ≠ 1]
 
-#blaster (gen-cex: 0) (solve-result: 1) [∀ (x y : Nat), x^(Nat.succ y) = x^y]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [∀ (x y : Nat), x^(Nat.succ y) = x^y]
 
-#blaster (gen-cex: 0) (solve-result: 1) [∀ (x : Nat), 0 < x → 0^x > 0]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [∀ (x : Nat), 0 < x → 0^x > 0]
 
 end Test.SmtNatPow

--- a/Tests/Smt/SmtPredQualifier.lean
+++ b/Tests/Smt/SmtPredQualifier.lean
@@ -119,22 +119,22 @@ def sizeOfTerm (t : Term α) : Nat :=
   | .App _ args => List.length args
   | .Annotated t' _ => 1 + sizeOfTerm t'
 
-#blaster (gen-cex:0) (solve-result: 1) (random-seed: 1) [ ∀ (α : Type) (x : Term α), sizeOfTerm x < 10 ]
+#blaster (gen-cex:0) (solve-result: 1) (random-seed: 1) (cvc5-allow-undetermined: 1) [ ∀ (α : Type) (x : Term α), sizeOfTerm x < 10 ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ ∀ (xs : List Nat), !(List.isEmpty xs) → List.head! (List.map Int.ofNat xs) ≥ 10 ]
 
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ ∀ (x : NatGroup), isFirst x → let r := toFirst x; r > 20 ∧ r < 100 ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ ∀ (x : NatGroup), isSecond x → let r := toSecond x; r > 200 ∧ r < 300 ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ (∀ (x : NatGroup), isNextFirst x → let r := toNextFirst x; r > 20 ∧ r < 100) ]
 
-#blaster (gen-cex: 0) (solve-result: 1)
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1)
   [ (∀ (α : Type) (x y : Term (List α)) (f : Term (List α) → Nat), f x + f y > 10) ]
 
 #blaster (gen-cex: 0) (solve-result: 1)

--- a/Tests/Smt/SmtRecFun.lean
+++ b/Tests/Smt/SmtRecFun.lean
@@ -69,8 +69,8 @@ theorem A_self_size (a : A) : (A.self a).sizeA = a.sizeA + 1 := by blaster
 #blaster (gen-cex: 0) (solve-result: 1)
   [ ∀ (s1 s2 : String), String.length s1 + String.length s2 > String.length (String.append s1 s2) ]
 
-#blaster (gen-cex: 0) (solve-result: 1) [ ∀ (n : Nat), isEven (n+1) = ¬ isOdd n ]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [ ∀ (n : Nat), isEven (n+1) = ¬ isOdd n ]
 
-#blaster (gen-cex: 0) (solve-result: 1) [ ∀ (n : Nat), isEven (n+2) → ¬ isEven n ]
+#blaster (gen-cex: 0) (solve-result: 1) (cvc5-allow-undetermined: 1) [ ∀ (n : Nat), isEven (n+2) → ¬ isEven n ]
 
 end Test.SmtRecFun

--- a/Tests/Smt/SmtSetupCommands.lean
+++ b/Tests/Smt/SmtSetupCommands.lean
@@ -1,0 +1,82 @@
+import Blaster
+
+namespace Test.SmtSetupCommands
+
+open Blaster.Options Blaster.Optimize Blaster.Smt
+
+/-! ## Test objectives to validate the emitted default solver setup commands
+
+    `setBlasterProcess` resolves the backend solver and emits the default
+    setup commands through `setDefaultSmtOptions` — the same code path for
+    normal runs and `only-smt-lib` runs. These tests run it in `only-smt-lib`
+    mode (no solver process is spawned) and pin the exact command sequence
+    recorded for each solver, guarding:
+     - the default options every query relies on (`print-success` handshake,
+       model/proof production, quantifier instantiation, macro elimination);
+     - solver-specific option spellings and the seconds → milliseconds
+       timeout mapping (z3 `:timeout` vs cvc5 `:tlimit-per`);
+     - Blaster's pinned command ordering: cvc5's `(set-logic ALL)` comes
+       after all options, while z3 gets no `set-logic` at all.
+
+    `solver:` and `timeout:` are set explicitly so the runs are independent
+    of the `BLASTER_SOLVER` / `BLASTER_TIMEOUT` environment variables.
+-/
+
+/-- Run the solver setup (`setBlasterProcess`) in `only-smt-lib` mode on a
+    fresh translation environment and return the recorded setup commands,
+    rendered exactly as they would be sent to the solver. -/
+def setupCommands (solver : SmtSolver) : Lean.MetaM (Array String) := do
+  let sOpts : BlasterOptions :=
+    { onlySmtLib := true, dumpSmtLib := true, solver := some solver, timeout := some 7 }
+  let env : TranslateEnv := default
+  let env := { env with optEnv.options.solverOptions := sOpts }
+  let (_, env) ← setBlasterProcess.run env
+  return env.smtEnv.smtCommands.map toString
+
+/-- Print the setup commands one per line (pinned with `#guard_msgs`). -/
+def printSetupCommands (solver : SmtSolver) : Lean.MetaM Unit := do
+  for c in (← setupCommands solver) do
+    IO.println c
+
+/-! # z3: default setup sequence (no `set-logic`: z3 solves in `ALL` mode
+     when no logic is set) -/
+
+/--
+info: (set-option :print-success true)
+(set-option :produce-models true)
+(set-option :produce-proofs true)
+(set-option :smt.pull-nested-quantifiers true)
+(set-option :smt.mbqi true)
+(set-option :auto_config false)
+(set-option :smt.macro_finder true)
+(set-option :timeout 7000)
+-/
+#guard_msgs in
+#eval printSetupCommands .z3
+
+/-! # cvc5: default setup sequence, `(set-logic ALL)` last -/
+
+/--
+info: (set-option :print-success true)
+(set-option :produce-models true)
+(set-option :produce-proofs true)
+(set-option :mbqi true)
+(set-option :macros-quant true)
+(set-option :tlimit-per 7000)
+(set-logic ALL)
+-/
+#guard_msgs in
+#eval printSetupCommands .cvc5
+
+/-! # Blaster-pinned cvc5 ordering invariant, independent of option spellings:
+     the setup ends with exactly one `set-logic`, and everything before it
+     is a `set-option`. -/
+
+/-- info: true -/
+#guard_msgs in
+#eval show Lean.MetaM Bool from do
+  let cmds ← setupCommands .cvc5
+  return cmds.back? == some "(set-logic ALL)"
+      && cmds.pop.all (·.startsWith "(set-option ")
+
+end Test.SmtSetupCommands

--- a/Tests/Smt/SmtSolverCvc5.lean
+++ b/Tests/Smt/SmtSolverCvc5.lean
@@ -1,0 +1,62 @@
+import Blaster
+
+namespace Test.SmtSolverCvc5
+
+/-! ## Test objectives to validate the cvc5 backend (`solver:` option)
+
+    These tests exercise the cvc5 solver adapter end-to-end: process spawning,
+    option translation, result parsing, and counterexample retrieval through
+    standard SMT-LIB `get-value`. They require a `cvc5` executable on `PATH`.
+-/
+
+/-! # Valid goals (unsat queries) -/
+
+#blaster (solver: cvc5) [∀ (x : Nat), 0 < x → 0^x = 0]
+
+#blaster (solver: cvc5) [∀ (x y : Int), x + y = y + x]
+
+#blaster (solver: cvc5) [∀ (b : Bool), b = true ∨ b = false]
+
+#blaster (solver: cvc5) [∀ (s : String), s ++ "" = s]
+
+/-! # Falsified goals (sat queries) with scalar counterexamples -/
+
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (x : Int), x + 3 > 7]
+
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (x y : Nat), x ≤ y]
+
+/-! # Falsified goals with inductive datatype counterexamples -/
+
+structure Point where
+  x : Int
+  y : Int
+
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (p : Point), p.x + p.y > 0]
+
+
+/-! # Recursive function definitions (define-fun-rec) -/
+
+#blaster (solver: cvc5) [∀ (x : Nat), x^1 = x]
+
+/-! # Undetermined goal through the per-check time limit (tlimit-per) -/
+
+-- The tested cvc5 configurations are expected to return Undetermined for this
+-- quantified goal under the 5s per-check limit. Solver heuristics and timing
+-- can vary across machines and versions, so this is a bounded regression
+-- expectation rather than a general semantic guarantee.
+-- NOTE: remove solve option when induction schema implemented
+#blaster (solver: cvc5) (timeout: 5) (solve-result: 2) [∀ (x : Nat), 0 < 2^x]
+
+/-! # Model production without a Lean counterpart
+
+     These checks assert the verdict without pinning solver-generated values,
+     whose spelling is solver- and version-dependent. -/
+
+-- uninterpreted-sort element values (e.g. cvc5 1.3.4: `@@Instance_uniq.…_0`)
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) (timeout: 10) [∀ (α : Type) (x y : α), x = y]
+
+-- uninterpreted function value (e.g. cvc5 1.3.4: `@(@@ArrowT2 Int Int)_0`)
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) (timeout: 10) [∀ (f : Int → Int) (x : Int), f x = f (x + 1)]
+
+
+end Test.SmtSolverCvc5

--- a/Tests/Smt/SmtSolverCvc5.lean
+++ b/Tests/Smt/SmtSolverCvc5.lean
@@ -5,8 +5,15 @@ namespace Test.SmtSolverCvc5
 /-! ## Test objectives to validate the cvc5 backend (`solver:` option)
 
     These tests exercise the cvc5 solver adapter end-to-end: process spawning,
-    option translation, result parsing, and counterexample retrieval through
-    standard SMT-LIB `get-value`. They require a `cvc5` executable on `PATH`.
+    default option translation, the `print-success` handshake, `check-sat`
+    result parsing, counterexample retrieval through `get-value` and model
+    reconstruction as Lean-flavored display strings (see `Blaster.Smt.Model`).
+    They require a `cvc5` executable (≥ 1.2.1) in the PATH.
+
+    NOTE: the reconstruction tests pin their counterexample display strings
+    with `#guard_msgs`. Each negated goal forces the displayed counterexample
+    assignment, and the pins define the expected rendering for the cvc5
+    configurations exercised by this suite.
 -/
 
 /-! # Valid goals (unsat queries) -/
@@ -25,7 +32,9 @@ namespace Test.SmtSolverCvc5
 
 #blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (x y : Nat), x ≤ y]
 
-/-! # Falsified goals with inductive datatype counterexamples -/
+/-! # Falsified goals with inductive datatype counterexamples
+     (cvc5 emits `as`-qualified constructor terms; z3 wraps long values over
+      several lines — both are reconstructed by `Blaster.Smt.Model`) -/
 
 structure Point where
   x : Int
@@ -33,6 +42,85 @@ structure Point where
 
 #blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (p : Point), p.x + p.y > 0]
 
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - o: Option.none
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (o : Option Int), o ≠ none]
+
+/-! # Model reconstruction: forced counterexamples pinned as display strings
+
+     Each negated goal has a single concrete witness, whose Lean-flavored
+     display is pinned below. -/
+
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - x: 3
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (x : Int), x ≠ 3]
+
+-- Constructor application with a negative field
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - p: Test.SmtSolverCvc5.Point.mk 1 (-2)
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (p : Point), p ≠ Point.mk 1 (-2)]
+
+-- Parametric constructor application (cvc5: `((as Option.some (@Option Int)) 5)`)
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - o: Option.some 5
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (o : Option Int), o ≠ some 5]
+
+-- Tuple (cvc5: `((as Prod.mk (@Prod Int Bool)) 5 true)`)
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - t: (5, true)
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (t : Int × Bool), t ≠ (5, true)]
+
+-- List (cvc5 shares the `as`-qualified cons through a `let` binding)
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - l: [1, 2]
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (l : List Int), l ≠ [1, 2]]
+
+-- String (SMT-LIB escaping round trip: emitted as `"a""b"`, displayed Lean-quoted)
+/--
+info: ✅ Expected Falsified
+---
+info: Counterexample:
+---
+info:  - s: "a\"b"
+-/
+#guard_msgs in
+#blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) [∀ (s : String), s ≠ "a\"b"]
 
 /-! # Recursive function definitions (define-fun-rec) -/
 
@@ -49,8 +137,14 @@ structure Point where
 
 /-! # Model production without a Lean counterpart
 
-     These checks assert the verdict without pinning solver-generated values,
-     whose spelling is solver- and version-dependent. -/
+     The negated goals below are satisfiable only with values that have no
+     Lean rendering (uninterpreted-sort elements, uninterpreted functions), so
+     `get-value` answers with solver-invented constants that fall back to raw
+     display. No `#guard_msgs` here: the spelling of those constants is
+     solver- and version-dependent (it even embeds elaboration-unique name
+     indices), so pinning it would break on harmless upgrades. The regression
+     value is: translation succeeds, no crash, no hang, and the Falsified
+     verdict is asserted through `solve-result: 1`. -/
 
 -- uninterpreted-sort element values (e.g. cvc5 1.3.4: `@@Instance_uniq.…_0`)
 #blaster (solver: cvc5) (gen-cex: 1) (solve-result: 1) (timeout: 10) [∀ (α : Type) (x y : α), x = y]

--- a/Tests/Smt/SolverSelection.lean
+++ b/Tests/Smt/SolverSelection.lean
@@ -1,0 +1,12 @@
+import Blaster
+
+namespace Test.SolverSelection
+
+/-! The two explicit selections run in one Lean process. This target requires both
+    solver executables and verifies that selecting one backend does not disturb
+    subsequent selection of the other. -/
+
+#blaster (solver: cvc5) [∀ (x : Nat), 0 < x → 0^x = 0]
+#blaster (solver: z3) [∀ (x : Nat), 0 < x → 0^x = 0]
+
+end Test.SolverSelection

--- a/Tests/Smt/SolverVersion.lean
+++ b/Tests/Smt/SolverVersion.lean
@@ -1,0 +1,175 @@
+import Blaster
+
+namespace Test.SolverVersion
+
+open Blaster.Smt Blaster.Options
+
+/-! ## Test objectives to validate solver version parsing and enforcement
+
+    These tests exercise the pure version policy of `Blaster.Smt.Env`:
+    version-token extraction from solver banners (`parseVersionNumbers`),
+    dotted-version comparison (`versionAtLeast`), the fail-closed banner
+    check (`checkVersionBanner`) and the per-candidate acceptance policy
+    (`evalCandidateProbe`) shared by solver discovery and the `solvercheck`
+    executable. Probe outcomes are pure data (`ProbeOutcome`), so no process
+    is spawned: the banners below are synthetic fixtures representing supported
+    z3/cvc5 banner shapes. Rejection reasons are asserted by selected prefixes
+    and substrings rather than whole sentences, keeping each guard focused while
+    intentionally pinning its actionable wording.
+-/
+
+/-! # `parseVersionNumbers`: version-token extraction from banners -/
+
+-- A bare dotted version (the shape of `SolverDescriptor.minVersion`)
+#guard parseVersionNumbers "4.15.2" == some [4, 15, 2]
+-- Synthetic z3 banner fixture in a supported release shape
+#guard parseVersionNumbers "Z3 version 4.15.2 - 64 bit" == some [4, 15, 2]
+-- Synthetic cvc5 release-banner fixture (the `[git …]` suffix must not confuse parsing)
+#guard parseVersionNumbers "cvc5 version 1.2.1 [git abc on branch HEAD]" == some [1, 2, 1]
+-- Synthetic cvc5 dev/nightly fixture: parsing stops before the `-dev…` suffix
+#guard parseVersionNumbers "cvc5 version 1.3.5-dev.105.abcdef" == some [1, 3, 5]
+-- The version token may be preceded by arbitrary words
+#guard parseVersionNumbers "some solver wrapper reporting 9.8.7 here" == some [9, 8, 7]
+-- No dotted version anywhere → `none` (feeds the fail-closed policy below)
+#guard parseVersionNumbers "unknown build" == none
+#guard parseVersionNumbers "" == none
+-- A lone integer is not a version token: a dot is required
+#guard parseVersionNumbers "version 4" == none
+
+/-! # `versionAtLeast`: dotted-version comparison -/
+
+-- A version satisfies itself
+#guard versionAtLeast [4, 15, 2] [4, 15, 2]
+-- Strictly newer in major / minor / patch position
+#guard versionAtLeast [5, 0, 0] [4, 15, 2]
+#guard versionAtLeast [4, 16, 0] [4, 15, 2]
+#guard versionAtLeast [4, 15, 3] [4, 15, 2]
+-- Strictly older in major / minor / patch position (large later components
+-- cannot compensate for a smaller earlier one)
+#guard !versionAtLeast [3, 99, 99] [4, 15, 2]
+#guard !versionAtLeast [4, 14, 99] [4, 15, 2]
+#guard !versionAtLeast [4, 15, 1] [4, 15, 2]
+-- Missing components count as zero: `1.2` and `1.2.0` are equal both ways
+#guard versionAtLeast [1, 2] [1, 2, 0]
+#guard versionAtLeast [1, 2, 0] [1, 2]
+-- Longer vs shorter beyond the zero-padding case
+#guard versionAtLeast [1, 2, 1] [1, 2]
+#guard !versionAtLeast [1, 2] [1, 2, 1]
+
+/-! # `checkVersionBanner`: fail-closed banner check -/
+
+-- Exactly the minimal version is accepted
+#guard checkVersionBanner "4.15.2" "Z3 version 4.15.2 - 64 bit" == .ok
+-- Newer than the minimal version is accepted
+#guard checkVersionBanner "1.2.1" "cvc5 version 1.3.4 [git tag 1.3.4]" == .ok
+-- Below the minimal version: rejected, carrying the components found
+#guard checkVersionBanner "4.15.2" "Z3 version 4.8.10 - 64 bit" == .tooOld [4, 8, 10]
+-- Fail closed: a banner without a parseable version is rejected…
+#guard checkVersionBanner "4.15.2" "unknown build" == .unparseable
+-- …but an unparseable `minVersion` (a Blaster bug, not a user error) imposes
+-- no lower bound instead of rejecting every solver
+#guard checkVersionBanner "unset" "Z3 version 0.1.0 - 64 bit" == .ok
+
+/-! # `evalCandidateProbe`: the candidate acceptance policy
+
+     Probe outcomes are replayed as pure data against the real z3/cvc5
+     descriptors, so the actual minimal supported versions are enforced. -/
+
+/-- The rejection reason of a probe verdict, `""` when accepted. -/
+private def rejectionOf : Except String Unit → String
+  | .ok () => ""
+  | .error reason => reason
+
+/-- `true` iff the verdict is a rejection whose reason mentions `part`. -/
+private def rejectedMentioning (part : String) (verdict : Except String Unit) : Bool :=
+  ((rejectionOf verdict).splitOn part).length > 1
+
+/-- `true` iff the candidate is accepted. -/
+private def accepted : Except String Unit → Bool
+  | .ok () => true
+  | .error _ => false
+
+private def z3Desc := SmtSolver.z3.descriptor
+private def cvc5Desc := SmtSolver.cvc5.descriptor
+
+-- Pin cvc5's production floor at the exact supported boundary. These guards
+-- deliberately use the real descriptor rather than repeating the floor as the
+-- minimum argument: lowering `cvc5Desc.minVersion` makes the second guard fail.
+#guard checkVersionBanner cvc5Desc.minVersion
+  "cvc5 version 1.2.1 [git tag 1.2.1]" == .ok
+#guard checkVersionBanner cvc5Desc.minVersion
+  "cvc5 version 1.2.0 [git tag 1.2.0]" == .tooOld [1, 2, 0]
+
+/-! # `SolverCandidate`: exact native and WSL process invocations -/
+
+private def nativeZ3 := z3Desc.candidates[0]!
+private def wslZ3 := z3Desc.candidates[1]!
+private def nativeCvc5 := cvc5Desc.candidates[0]!
+private def wslCvc5 := cvc5Desc.candidates[1]!
+
+private def nativeZ3ProbeInvocation : Bool :=
+  z3Desc.probeInvocation nativeZ3 == ("z3", #["-version"])
+private def nativeZ3SpawnInvocation : Bool :=
+  z3Desc.spawnInvocation nativeZ3 == ("z3", #["-in", "-smt2"])
+private def nativeCvc5ProbeInvocation : Bool :=
+  cvc5Desc.probeInvocation nativeCvc5 == ("cvc5", #["--version"])
+private def nativeCvc5SpawnInvocation : Bool :=
+  cvc5Desc.spawnInvocation nativeCvc5 ==
+    ("cvc5", #["--lang", "smt2", "--incremental", "--parsing-mode=lenient", "--dt-nested-rec"])
+private def wslZ3ProbeInvocation : Bool :=
+  z3Desc.probeInvocation wslZ3 == ("wsl", #["z3", "-version"])
+private def wslZ3SpawnInvocation : Bool :=
+  z3Desc.spawnInvocation wslZ3 == ("wsl", #["z3", "-in", "-smt2"])
+private def wslCvc5ProbeInvocation : Bool :=
+  cvc5Desc.probeInvocation wslCvc5 == ("wsl", #["cvc5", "--version"])
+private def wslCvc5SpawnInvocation : Bool :=
+  cvc5Desc.spawnInvocation wslCvc5 ==
+    ("wsl", #["cvc5", "--lang", "smt2", "--incremental", "--parsing-mode=lenient", "--dt-nested-rec"])
+
+#guard nativeZ3ProbeInvocation
+#guard nativeZ3SpawnInvocation
+#guard nativeCvc5ProbeInvocation
+#guard nativeCvc5SpawnInvocation
+#guard wslZ3ProbeInvocation
+#guard wslZ3SpawnInvocation
+#guard wslCvc5ProbeInvocation
+#guard wslCvc5SpawnInvocation
+
+-- A probe that could not run at all is reported as an IO error…
+#guard rejectedMentioning "IO error"
+  (evalCandidateProbe z3Desc nativeZ3 (.failed "no such file or directory"))
+-- …and every report line names the exact candidate that was probed
+#guard "Candidate 'wsl z3'".isPrefixOf
+  (rejectionOf (evalCandidateProbe z3Desc wslZ3 (.failed "wsl: not found")))
+-- A probe that ran but exited non-zero is rejected with its exit code
+#guard rejectedMentioning "exit code" (evalCandidateProbe z3Desc nativeZ3 (.ran 1 ""))
+-- Synthetic healthy-banner fixtures are accepted (z3 at exactly the minimal
+-- version and cvc5 above it, with an additional output line)
+#guard accepted (evalCandidateProbe z3Desc nativeZ3 (.ran 0 "Z3 version 4.15.2 - 64 bit\n"))
+#guard accepted (evalCandidateProbe cvc5Desc nativeCvc5
+  (.ran 0 "cvc5 version 1.3.4 [git tag 1.3.4]\nThis is cvc5.\n"))
+-- An outdated solver is rejected, telling the user the minimal supported version
+#guard rejectedMentioning z3Desc.minVersion
+  (evalCandidateProbe z3Desc nativeZ3 (.ran 0 "Z3 version 4.8.10 - 64 bit\n"))
+#guard rejectedMentioning cvc5Desc.minVersion
+  (evalCandidateProbe cvc5Desc nativeCvc5 (.ran 0 "cvc5 version 1.0.8 [git abc]\n"))
+-- Garbage stdout is rejected because no version can be parsed (fail closed)
+#guard rejectedMentioning "parse"
+  (evalCandidateProbe cvc5Desc nativeCvc5 (.ran 0 "Segmentation fault\n"))
+-- A later dotted notice cannot rescue an unparseable first-line banner.
+#guard rejectedMentioning "parse"
+  (evalCandidateProbe cvc5Desc nativeCvc5
+    (.ran 0 "unknown build\nlinked library 9.8.7\n"))
+
+/-! # `ProbeOutcome.banner`: first-line extraction -/
+
+-- Synthetic multiline cvc5 output: only the first line is treated as the banner
+#guard ProbeOutcome.banner
+    (.ran 0 "cvc5 version 1.3.4 [git tag 1.3.4]\nThis is cvc5.\nCopyright notice.\n")
+  == "cvc5 version 1.3.4 [git tag 1.3.4]"
+-- Windows-style line endings: the trailing `\r` is trimmed away
+#guard ProbeOutcome.banner (.ran 0 "Z3 version 4.15.2 - 64 bit\r\n") == "Z3 version 4.15.2 - 64 bit"
+-- A probe that never ran has no banner
+#guard ProbeOutcome.banner (.failed "spawn failure") == ""
+
+end Test.SolverVersion

--- a/Tests/Smt/StrictResultPolicy.lean
+++ b/Tests/Smt/StrictResultPolicy.lean
@@ -1,0 +1,78 @@
+import Blaster.Smt.Env
+
+namespace Test.StrictResultPolicy
+
+open Blaster.Options Blaster.Smt
+
+private def expectedUndetermined : BlasterOptions :=
+  { solveResult := .ExpectedUndetermined }
+
+private def cvc5Allowance : BlasterOptions :=
+  { allowCvc5Undetermined := true }
+
+private def expectedWithCvc5Allowance : BlasterOptions :=
+  { solveResult := .ExpectedUndetermined, allowCvc5Undetermined := true }
+
+private def strictCvc5RejectsUnexpected : Bool :=
+  undeterminedAction default .cvc5 true == .strictError
+
+private def nonstrictCvc5WarnsOnUnexpected : Bool :=
+  undeterminedAction default .cvc5 false == .warning
+
+private def strictFlagDoesNotAffectZ3 : Bool :=
+  undeterminedAction default .z3 true == .warning
+
+private def declaredUndeterminedWinsInStrictMode : Bool :=
+  undeterminedAction expectedUndetermined .cvc5 true == .expected
+
+private def cvc5AllowanceWinsInStrictMode : Bool :=
+  undeterminedAction cvc5Allowance .cvc5 true == .allowed
+
+private def cvc5AllowanceDoesNotApplyToZ3 : Bool :=
+  undeterminedAction cvc5Allowance .z3 true == .warning
+
+private def declaredUndeterminedAppliesToZ3 : Bool :=
+  undeterminedAction expectedUndetermined .z3 true == .expected
+
+private def nonstrictCvc5AllowanceIsAccepted : Bool :=
+  undeterminedAction cvc5Allowance .cvc5 false == .allowed
+
+private def declarationPrecedesCvc5Allowance : Bool :=
+  undeterminedAction expectedWithCvc5Allowance .cvc5 true == .expected
+
+#guard strictCvc5RejectsUnexpected
+#guard nonstrictCvc5WarnsOnUnexpected
+#guard strictFlagDoesNotAffectZ3
+#guard declaredUndeterminedWinsInStrictMode
+#guard cvc5AllowanceWinsInStrictMode
+#guard cvc5AllowanceDoesNotApplyToZ3
+#guard declaredUndeterminedAppliesToZ3
+#guard nonstrictCvc5AllowanceIsAccepted
+#guard declarationPrecedesCvc5Allowance
+
+private def strictTacticIntegrationSource : String :=
+  "import Blaster.Command.Tactic\n\n" ++
+  "open Blaster.Tactic\n\n" ++
+  "/--\n" ++
+  "error: ❌ Unexpected Undetermined\n" ++
+  "-/\n" ++
+  "#guard_msgs in\n" ++
+  "example (α : Type) (xs : List α) : xs = List.map (fun x => x) xs := by\n" ++
+  "  blaster (solver: cvc5) (only-optimize: 1) <;> simp\n"
+
+private def strictTacticIntegrationGuard : IO Unit :=
+  IO.FS.withTempFile fun handle path => do
+    handle.putStr strictTacticIntegrationSource
+    handle.flush
+    let output ← IO.Process.output {
+      cmd := (← IO.appPath).toString
+      args := #[path.toString]
+      env := #[("BLASTER_STRICT_CVC5_RESULTS", some "1")]
+    }
+    unless output.exitCode == 0 do
+      throw <| IO.userError <|
+        "strict tactic integration guard failed\n" ++ output.stdout ++ output.stderr
+
+#eval strictTacticIntegrationGuard
+
+end Test.StrictResultPolicy

--- a/Tests/StateMachine/Counter06.lean
+++ b/Tests/StateMachine/Counter06.lean
@@ -46,59 +46,5 @@ instance counterStateMachine : StateMachine Request CounterState where
 
 #bmc (max-depth: 8) [counterStateMachine]
 
-/--
-info: ⚠️ Induction failed at Depth 1
----
-info: Counterexample to Induction:
----
-info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
----
-info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
-  Test.Counter06.State.Delay
-  2
-  Test.Counter06.State.Busy
-  Test.Counter06.Request.Tr
-  3)
----
-info: ⚠️ Induction failed at Depth 2
----
-info: Counterexample to Induction:
----
-info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
----
-info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
-  Test.Counter06.State.Ready
-  2
-  Test.Counter06.State.Busy
-  Test.Counter06.Request.Tr
-  3)
----
-info:  - «Test.Counter06.counterStateMachine.input@1»: Test.Counter06.Request.Tr
----
-info:  - «Test.Counter06.counterStateMachine.input@2»: Test.Counter06.Request.Tr
----
-info: ⚠️ Induction failed at Depth 3
----
-info: Counterexample to Induction:
----
-info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
----
-info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
-  Test.Counter06.State.Ready
-  2
-  Test.Counter06.State.Busy
-  Test.Counter06.Request.Tr
-  3)
----
-info:  - «Test.Counter06.counterStateMachine.input@1»: Test.Counter06.Request.Fa
----
-info:  - «Test.Counter06.counterStateMachine.input@2»: Test.Counter06.Request.Tr
----
-info:  - «Test.Counter06.counterStateMachine.input@3»: Test.Counter06.Request.Tr
----
-warning: ⚠️ Failed to establish induction up to Depth 3
--/
-#guard_msgs in
-#kind (max-depth: 3) [counterStateMachine]
 
 end Test.Counter06

--- a/Tests/StateMachine/Counter06Z3.lean
+++ b/Tests/StateMachine/Counter06Z3.lean
@@ -9,12 +9,7 @@ info: Counterexample to Induction:
 ---
 info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
 ---
-info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
-  Test.Counter06.State.Delay
-  2
-  Test.Counter06.State.Busy
-  Test.Counter06.Request.Tr
-  3)
+info:  - «Test.Counter06.counterStateMachine.state@0»: Test.Counter06.CounterState.mk Test.Counter06.State.Delay 2 Test.Counter06.State.Busy Test.Counter06.Request.Tr 3
 ---
 info: ⚠️ Induction failed at Depth 2
 ---
@@ -22,12 +17,7 @@ info: Counterexample to Induction:
 ---
 info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
 ---
-info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
-  Test.Counter06.State.Ready
-  2
-  Test.Counter06.State.Busy
-  Test.Counter06.Request.Tr
-  3)
+info:  - «Test.Counter06.counterStateMachine.state@0»: Test.Counter06.CounterState.mk Test.Counter06.State.Ready 2 Test.Counter06.State.Busy Test.Counter06.Request.Tr 3
 ---
 info:  - «Test.Counter06.counterStateMachine.input@1»: Test.Counter06.Request.Tr
 ---
@@ -39,12 +29,7 @@ info: Counterexample to Induction:
 ---
 info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
 ---
-info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
-  Test.Counter06.State.Ready
-  2
-  Test.Counter06.State.Busy
-  Test.Counter06.Request.Tr
-  3)
+info:  - «Test.Counter06.counterStateMachine.state@0»: Test.Counter06.CounterState.mk Test.Counter06.State.Ready 2 Test.Counter06.State.Busy Test.Counter06.Request.Tr 3
 ---
 info:  - «Test.Counter06.counterStateMachine.input@1»: Test.Counter06.Request.Fa
 ---

--- a/Tests/StateMachine/Counter06Z3.lean
+++ b/Tests/StateMachine/Counter06Z3.lean
@@ -1,0 +1,62 @@
+import Tests.StateMachine.Counter06
+
+namespace Test.Counter06
+
+/--
+info: ⚠️ Induction failed at Depth 1
+---
+info: Counterexample to Induction:
+---
+info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
+---
+info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
+  Test.Counter06.State.Delay
+  2
+  Test.Counter06.State.Busy
+  Test.Counter06.Request.Tr
+  3)
+---
+info: ⚠️ Induction failed at Depth 2
+---
+info: Counterexample to Induction:
+---
+info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
+---
+info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
+  Test.Counter06.State.Ready
+  2
+  Test.Counter06.State.Busy
+  Test.Counter06.Request.Tr
+  3)
+---
+info:  - «Test.Counter06.counterStateMachine.input@1»: Test.Counter06.Request.Tr
+---
+info:  - «Test.Counter06.counterStateMachine.input@2»: Test.Counter06.Request.Tr
+---
+info: ⚠️ Induction failed at Depth 3
+---
+info: Counterexample to Induction:
+---
+info:  - «Test.Counter06.counterStateMachine.input@0»: Test.Counter06.Request.Tr
+---
+info:  - «Test.Counter06.counterStateMachine.state@0»: (Test.Counter06.CounterState.mk
+  Test.Counter06.State.Ready
+  2
+  Test.Counter06.State.Busy
+  Test.Counter06.Request.Tr
+  3)
+---
+info:  - «Test.Counter06.counterStateMachine.input@1»: Test.Counter06.Request.Fa
+---
+info:  - «Test.Counter06.counterStateMachine.input@2»: Test.Counter06.Request.Tr
+---
+info:  - «Test.Counter06.counterStateMachine.input@3»: Test.Counter06.Request.Tr
+---
+warning: ⚠️ Failed to establish induction up to Depth 3
+-/
+-- Pinned to z3: the docstring above records exact counterexample-to-induction
+-- models, and model values are solver-specific (cvc5 returns different valid CTIs).
+#guard_msgs in
+#kind (solver: z3) (max-depth: 3) [counterStateMachine]
+
+end Test.Counter06

--- a/Tests/Z3.lean
+++ b/Tests/Z3.lean
@@ -1,0 +1,3 @@
+import Tests.Backend
+import Tests.StateMachine.Counter06Z3
+import Tests.Smt.StrictResultPolicy

--- a/Tests/Z3.lean
+++ b/Tests/Z3.lean
@@ -1,3 +1,2 @@
 import Tests.Backend
 import Tests.StateMachine.Counter06Z3
-import Tests.Smt.StrictResultPolicy

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -17,3 +17,6 @@ lean_lib «Tests» where
 lean_exe z3check where
   -- add executable configuration options here
   root := `Z3Check
+
+lean_exe solvercheck where
+  root := `SolverCheck

--- a/scripts/check_lean_project_compilation.sh
+++ b/scripts/check_lean_project_compilation.sh
@@ -1,14 +1,27 @@
 #!/usr/bin/env bash
 
+set -o pipefail
+
 exec_found=0
-if [[ $# -eq 1 ]]
+if [[ $# -ge 1 && $# -le 2 ]]
 then
   PROJECT_NAME=$1
-  LEAN_FILES=`find $PROJECT_NAME -name '*.lean' 2>/dev/null`
+  BUILD_TARGET=${2:-$PROJECT_NAME}
+  if [ ! -d "$PROJECT_NAME" ]
+  then
+    echo "Lean source tree '$PROJECT_NAME' is not a directory." >&2
+    exit 1
+  fi
+  LEAN_FILES=`find "$PROJECT_NAME" -type f -name '*.lean' 2>/dev/null`
+  if [ -z "$LEAN_FILES" ]
+  then
+    echo "Lean source tree '$PROJECT_NAME' contains no .lean files." >&2
+    exit 1
+  fi
   EXEC_FILES=`cat lakefile.lean | grep root | sed 's/root := .//g'`
   # build lean project with log
-  echo "Building Lean project $PROJECT_NAME ..."
-  lake build $PROJECT_NAME 2>&1 | tee build.log
+  echo "Building Lean target $BUILD_TARGET (source tree: $PROJECT_NAME) ..."
+  lake build "$BUILD_TARGET" 2>&1 | tee build.log
   if [[ $? -ne 0 ]]
   then
     cat build.log
@@ -17,7 +30,7 @@ then
   for i in $LEAN_FILES
   do
    LEAN_MODULE=`echo $i | sed 's/\.\///g' | sed 's/\//./g' | sed 's/.lean//g'`
-   RES=`cat build.log | grep -o "Built $LEAN_MODULE"`
+   RES=`grep -F "Built $LEAN_MODULE (" build.log`
    for j in $EXEC_FILES
     do
      if [[ $LEAN_MODULE = $j ]]
@@ -36,6 +49,7 @@ then
   rm -rf build.log
 else
 cat <<EOF
- usage: check_lean_project_compilation.sh <PROJECT NAME>
+ usage: check_lean_project_compilation.sh <PROJECT NAME> [BUILD TARGET]
 EOF
+exit 1
 fi


### PR DESCRIPTION
## Description

This PR adds initial cvc5 backend support to Blaster while preserving Z3 as the default SMT solver.

The change introduces solver selection through both tactic options and environment configuration, adds solver-specific process/version handling, updates counterexample/model retrieval to use a more portable SMT-LIB command, extends CI to exercise both supported solvers, and adds cvc5-focused tests and documentation.

Z3 remains the default backend for existing `#blaster` usage.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Test updates

## Related Issue

<!-- Replace with the relevant issue once available. -->

- Fixes #<issue number>

## Changes Made

- Added support for selecting the SMT backend via a new solver option: `#blaster (solver: z3)` or `#blaster (solver: cvc5)`.
- Added support for selecting the default solver through the `BLASTER_SOLVER` environment variable.
- Introduced a solver abstraction for backend-specific behavior, including command candidates, version probing, minimum supported version checks, process arguments, and default SMT options.
- Added initial cvc5 process support with cvc5-specific command-line arguments and SMT options.
- Preserved Z3 as the default solver to avoid changing existing user behavior.
- Updated counterexample/model value retrieval from Z3-specific `(eval ...)` usage to SMT-LIB-style `(get-value (...))` handling.
- Added response parsing support for `get-value` output.
- Added a `solvercheck` executable for validating local solver availability and supported versions.
- Added cvc5-oriented test coverage for solver selection, expected success cases, expected failure/counterexample cases, and known backend differences.
- Updated CI to run solver-specific test jobs for both Z3 and cvc5.
- Updated documentation with solver selection examples, cvc5 installation notes, `BLASTER_SOLVER` usage, `solvercheck` usage, and current backend limitations.

## Testing

The intended validation for this PR is:

- [ ] `lake build Blaster`
- [ ] `lake exe solvercheck z3`
- [ ] `lake exe solvercheck cvc5`
- [ ] `BLASTER_SOLVER=z3 lake test`
- [ ] `BLASTER_SOLVER=cvc5 BLASTER_TIMEOUT=30 lake test`
- [ ] CI passes for the Z3 solver job
- [ ] CI passes for the cvc5 solver job
- [ ] Manual smoke test with explicit Z3 selection: `#blaster (solver: z3) ...`
- [ ] Manual smoke test with explicit cvc5 selection: `#blaster (solver: cvc5) ...`
- [ ] Manual smoke test with `BLASTER_SOLVER` unset, confirming Z3 remains the default

Remaining items before marking ready:

- [ ] Remove the leftover debug/compile-failure line from `SolverCheck.lean`: `#eval thisIdentifierDoesNotExist`
- [ ] Confirm whether the `only-smt-lib` path should emit the same default solver setup commands used by the normal solver path.
- [ ] Confirm version parsing behavior for supported solvers when the version banner cannot be parsed.
- [ ] Verify WSL fallback behavior for both Z3 and cvc5.
- [ ] Add direct unit coverage for `get-value` response parsing.
- [ ] Add direct unit coverage for solver version parsing and minimum-version checks.
- [ ] Review timeout-sensitive cvc5 tests for potential CI flakiness.
- [ ] Confirm that the selected cvc5 options are accepted across the documented minimum supported cvc5 version range.
- [ ] Decide how to track known cvc5 limitations around quantifiers, recursive definitions, model behavior, and timeout behavior.
### Test Coverage

- [ ] Added new tests for new functionality
- [ ] Updated existing tests
- [ ] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder

<!-- If breaking changes, provide details here -->

## Documentation

- [ ] README updated (if applicable)
- [ ] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules
<!-- - [ ] CONTRIBUTING.md updated (if workflow changes) -> 

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes using `make check_all`
- [ ] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number

## Additional Notes

<!-- Add any additional notes, context, or screenshots here -->
