### PR TITLE
Fix: Hardcoded Int.ediv and Int.emod in integer division and modulo helpers

### DIFF
--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -157,12 +157,12 @@ def mulIntDivReduceExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) :
                m < 0 := _ ∈ hypothesisContext.hypothesisMap)
 -/
 @[always_inline, inline]
-def optimizeIntDivCommon (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+def optimizeIntDivCommon (op1 : Expr) (op2 : Expr) (f: Int -> Int -> Int): TranslateEnvT (Option Expr) := do
  match isIntValue? op1, isIntValue? op2 with
  | _, some (Int.ofNat 0) => return op2
  | _, some (Int.ofNat 1)
  | some (Int.ofNat 0), _ => return op1
- | some n1, some n2 => evalBinIntOp Int.ediv n1 n2
+ | some n1, some n2 => evalBinIntOp f n1 n2
  | _, _ =>
    if let some r ← intDivSelfReduce? op1 op2 then return r
    if let some r ← mulIntDivReduceExpr? op1 op2 then return r
@@ -210,7 +210,7 @@ def optimizeIntEDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntEDiv: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntDivCommon op1 op2 then return r
+ if let some r ← optimizeIntDivCommon op1 op2 Int.ediv then return r
  if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.ediv then return mkApp2 f op1' op2'
  return (mkApp2 f op1 op2)
 
@@ -241,12 +241,12 @@ def intModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      - (m * n) % m | (n * m) % m ==> 0
 -/
 @[always_inline, inline]
-def optimizeIntModCommon (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) := do
+def optimizeIntModCommon (op1 : Expr) (op2 : Expr) (f: Int -> Int -> Int) : TranslateEnvT (Option Expr) := do
  match isIntValue? op1, isIntValue? op2 with
  | _, some (Int.ofNat 0) => return op1
  | _, some (Int.ofNat 1) => mkIntLitExpr (Int.ofNat 0)
  | some (Int.ofNat 0), _ => return op1
- | some n1, some n2 => evalBinIntOp Int.emod n1 n2
+ | some n1, some n2 => evalBinIntOp f n1 n2
  | _, nv2 =>
    if let some r ← cstModProp? op1 nv2 then return r
    if let some r ← intModToZeroExpr? op1 op2 then return r
@@ -284,7 +284,7 @@ def optimizeIntEMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntEMod: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntModCommon op1 op2 then return r
+ if let some r ← optimizeIntModCommon op1 op2 Int.emod then return r
  return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Int.tdiv`:
@@ -309,7 +309,7 @@ def optimizeIntTDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntTDiv: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntDivCommon op1 op2 then return r
+ if let some r ← optimizeIntDivCommon op1 op2 Int.tdiv then return r
  if let some r ← cstTDivProp? op1 op2 then return r
  if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.tdiv then return mkApp2 f op1' op2'
  else return (mkApp2 f op1 op2)
@@ -343,7 +343,7 @@ def optimizeIntTMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntTMod: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntModCommon op1 op2 then return r
+ if let some r ← optimizeIntModCommon op1 op2 Int.tmod then return r
  return (mkApp2 f op1 op2)
 
 /-- Apply the following simplification/normalization rules on `Int.fdiv`:
@@ -367,7 +367,7 @@ def optimizeIntFDiv (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntFDiv: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntDivCommon op1 op2 then return r
+ if let some r ← optimizeIntDivCommon op1 op2 Int.fdiv then return r
  if let some (op1', op2') ← cstCommonDivProp? op1 op2 Int.fdiv then return mkApp2 f op1' op2'
  return (mkApp2 f op1 op2)
 
@@ -387,7 +387,7 @@ def optimizeIntFMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 2 then throwEnvError "optimizeIntFMod: exactly two arguments expected"
  let op1 := args[0]!
  let op2 := args[1]!
- if let some r ← optimizeIntModCommon op1 op2 then return r
+ if let some r ← optimizeIntModCommon op1 op2 Int.fmod then return r
  return (mkApp2 f op1 op2)
 
 

--- a/Blaster/Optimize/Rewriting/OptimizeInt.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeInt.lean
@@ -142,6 +142,7 @@ def mulIntDivReduceExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) :
 
 
 /-- Given `op1` and `op2` corresponding to the operands for `Int.ediv`, `Int.tdiv` and `Int.fdiv`,
+    and `f_div` the corresponding divisor operator,
     try to apply the following simplification rules:
      - n / 0 ==> 0
      - n / 1 ==> n
@@ -157,12 +158,12 @@ def mulIntDivReduceExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) :
                m < 0 := _ ∈ hypothesisContext.hypothesisMap)
 -/
 @[always_inline, inline]
-def optimizeIntDivCommon (op1 : Expr) (op2 : Expr) (f: Int -> Int -> Int): TranslateEnvT (Option Expr) := do
+def optimizeIntDivCommon (op1 : Expr) (op2 : Expr) (f_div: Int -> Int -> Int): TranslateEnvT (Option Expr) := do
  match isIntValue? op1, isIntValue? op2 with
  | _, some (Int.ofNat 0) => return op2
  | _, some (Int.ofNat 1)
  | some (Int.ofNat 0), _ => return op1
- | some n1, some n2 => evalBinIntOp f n1 n2
+ | some n1, some n2 => evalBinIntOp f_div n1 n2
  | _, _ =>
    if let some r ← intDivSelfReduce? op1 op2 then return r
    if let some r ← mulIntDivReduceExpr? op1 op2 then return r
@@ -231,6 +232,7 @@ def intModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
   | none => return none
 
 /--  Given `op1` and `op2` corresponding to the operands for `Int.emod`, `Int.fmod` and `Int.tmod`,
+     and `f_mod` the corresponding modulo operator,
      try to apply the following simplification rules:
      - n % 0 ==> n
      - n % 1 ==> 0
@@ -241,12 +243,12 @@ def intModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      - (m * n) % m | (n * m) % m ==> 0
 -/
 @[always_inline, inline]
-def optimizeIntModCommon (op1 : Expr) (op2 : Expr) (f: Int -> Int -> Int) : TranslateEnvT (Option Expr) := do
+def optimizeIntModCommon (op1 : Expr) (op2 : Expr) (f_mod: Int -> Int -> Int) : TranslateEnvT (Option Expr) := do
  match isIntValue? op1, isIntValue? op2 with
  | _, some (Int.ofNat 0) => return op1
  | _, some (Int.ofNat 1) => mkIntLitExpr (Int.ofNat 0)
  | some (Int.ofNat 0), _ => return op1
- | some n1, some n2 => evalBinIntOp f n1 n2
+ | some n1, some n2 => evalBinIntOp f_mod n1 n2
  | _, nv2 =>
    if let some r ← cstModProp? op1 nv2 then return r
    if let some r ← intModToZeroExpr? op1 op2 then return r

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -30,3 +30,4 @@ import Tests.FixedIssues.Issue30
 import Tests.FixedIssues.Issue31
 import Tests.FixedIssues.Issue32
 import Tests.FixedIssues.Issue33
+import Tests.FixedIssues.Issue34

--- a/Tests/FixedIssues/Issue34.lean
+++ b/Tests/FixedIssues/Issue34.lean
@@ -3,30 +3,26 @@ import Blaster
 
 namespace Tests.Issue34
 
--- Issue 1: unexpected falsified
+-- Issue: unexpected falsified
 -- Diagnosis: The shared helpers that constant fold integer division and modulo hardcode Int.ediv and Int.emod.
 --            These helpers are also used by tdiv, fdiv, tmod, and fmod.
 --            On negative operands the rounding conventions disagree,
 --            so blaster folds to the wrong literal and returns an incorrect verdict.
 
 
--- Should be valid
-#blaster [(-7: Int).tdiv 2 = -3]
--- Should be falsified
-#blaster (solve-result: 1) [(-7: Int).tdiv 2 = -4]
+-- tdiv truncates toward zero: -7 / 2 = -3   (ediv folds to -4)
+#blaster [(-7 : Int).tdiv 2 = -3]
+#blaster (gen-cex: 0) (solve-result: 1) [(-7 : Int).tdiv 2 = -4]
 
--- Should be falsified
-#blaster (solve-result: 1) [(-7: Int).fdiv 2 = -3]
--- Should be valid
-#blaster [(-7: Int).fdiv 2 = -4]
+-- tmod takes the sign of the dividend: -7 % 2 = -1   (emod folds to 1)
+#blaster [(-7 : Int).tmod 2 = -1]
+#blaster (gen-cex: 0) (solve-result: 1) [(-7 : Int).tmod 2 = 1]
 
--- Should be valid
-#blaster [(-7: Int).tmod 2 = -1]
--- Should be falsified
-#blaster (solve-result: 1) [(-7: Int).tmod 2 = 1]
+-- fdiv floors toward -∞: 7 / -2 = -4   (ediv folds to -3)
+#blaster [(7 : Int).fdiv (-2) = -4]
+#blaster (gen-cex: 0) (solve-result: 1) [(7 : Int).fdiv (-2) = -3]
 
--- Should be falsified
-#blaster (solve-result: 1) [(-7: Int).fmod 2 = -1]
--- Should be valid
-#blaster [(-7: Int).fmod 2 = 1]
+-- fmod takes the sign of the divisor: 7 % -2 = -1   (emod folds to 1)
+#blaster [(7 : Int).fmod (-2) = -1]
+#blaster (gen-cex: 0) (solve-result: 1) [(7 : Int).fmod (-2) = 1]
 end Tests.Issue34

--- a/Tests/FixedIssues/Issue34.lean
+++ b/Tests/FixedIssues/Issue34.lean
@@ -1,0 +1,32 @@
+import Lean
+import Blaster
+
+namespace Tests.Issue34
+
+-- Issue 1: unexpected falsified
+-- Diagnosis: The shared helpers that constant fold integer division and modulo hardcode Int.ediv and Int.emod.
+--            These helpers are also used by tdiv, fdiv, tmod, and fmod.
+--            On negative operands the rounding conventions disagree,
+--            so blaster folds to the wrong literal and returns an incorrect verdict.
+
+
+-- Should be valid
+#blaster [(-7: Int).tdiv 2 = -3]
+-- Should be falsified
+#blaster (solve-result: 1) [(-7: Int).tdiv 2 = -4]
+
+-- Should be falsified
+#blaster (solve-result: 1) [(-7: Int).fdiv 2 = -3]
+-- Should be valid
+#blaster [(-7: Int).fdiv 2 = -4]
+
+-- Should be valid
+#blaster [(-7: Int).tmod 2 = -1]
+-- Should be falsified
+#blaster (solve-result: 1) [(-7: Int).tmod 2 = 1]
+
+-- Should be falsified
+#blaster (solve-result: 1) [(-7: Int).fmod 2 = -1]
+-- Should be valid
+#blaster [(-7: Int).fmod 2 = 1]
+end Tests.Issue34


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
This pull request fixes the hardcoded use of `Int.ediv` and `Int.emod` in both `optimizeIntDivCommon` and `optimizeIntModCommon`, replacing them with the corresponding operation used in each case.  The use of `Int.ediv` and `Int.emod` on negative operands caused Blaster to return an incorrect verdict because the rounding conventions differ between each operation.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Related Issue

<!-- Link to the issue this PR addresses-->

Use any of the following for our ticket management to know which tickets to move to `Done` when PR is merged:

- Fixes #162  
- Closes #162 

## Changes Made

<!-- Provide a detailed list of changes -->

- Replaced the hardcoded uses of Int.ediv and Int.emod with the corresponding division and modulo operators

## Testing

<!-- Describe the testing you have performed -->

### Test Coverage

- [ ] Added new tests for new functionality
- [ ] Updated existing tests
- [x] All tests pass locally
- [x] For bug fixes: Added example to `Tests/Issues/` folder

<!-- If breaking changes, provide details here -->

## Documentation

- [ ] README updated (if applicable)
- [x] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules
<!-- - [ ] CONTRIBUTING.md updated (if workflow changes) -> 

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes using `make check_all`
- [x] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number

## Additional Notes

<!-- Add any additional notes, context, or screenshots here -->
