### PR TITLE
Fix string literal translation to smt lib

### DIFF
--- a/Blaster/Smt/Term.lean
+++ b/Blaster/Smt/Term.lean
@@ -399,8 +399,24 @@ def intLitSmt (n : Int) : SmtTerm :=
 /-! Convert an Nat literal to an Smt representation. -/
 def natLitSmt (n : Nat) : SmtTerm := .NumTerm n
 
-/-! Convert an String literal to an Smt representation. -/
-def strLitSmt (s : String) : SmtTerm := .StrTerm s!"\"{s}\""
+/-! Escape a Lean string into the body of an Smt-Lib 2.6 string literal.
+    Per the standard only printable ASCII (0x20-0x7E) may appear verbatim, and a `"` is
+    written by doubling it; every other character uses the `\u{d}`..`\u{ddddd}` form. A
+    literal backslash is escaped as well, so that it can never open a spurious `\u{..}`
+    sequence. Without this, a Lean string carrying any character outside printable ASCII
+    -- a byte string wrapped over `String`, say -- reaches the solver verbatim and the
+    entire query is rejected with `unexpected character`. -/
+private def escapeSmtStringLit (s : String) : String :=
+  s.foldl (init := "") (λ acc c =>
+    let n := c.toNat
+         if c == '"'             then acc ++ "\"\""
+    else if c == '\\'            then acc ++ "\\u{5c}"
+    else if n ≥ 0x20 && n ≤ 0x7e then acc.push c
+    else acc ++ "\\u{" ++ (Nat.toDigits 16 n).asString ++ "}"
+  )
+
+/-! Convert a String literal to an Smt representation. -/
+def strLitSmt (s : String) : SmtTerm := .StrTerm s!"\"{escapeSmtStringLit s}\""
 
 /-! Create an Smt variable identifier. -/
 def smtSimpleVarId (nm : SmtSymbol) : SmtTerm := .SmtIdent (.SimpleIdent nm)

--- a/Blaster/Smt/Term.lean
+++ b/Blaster/Smt/Term.lean
@@ -399,24 +399,63 @@ def intLitSmt (n : Int) : SmtTerm :=
 /-! Convert an Nat literal to an Smt representation. -/
 def natLitSmt (n : Nat) : SmtTerm := .NumTerm n
 
-/-! Escape a Lean string into the body of an Smt-Lib 2.6 string literal.
-    Per the standard only printable ASCII (0x20-0x7E) may appear verbatim, and a `"` is
-    written by doubling it; every other character uses the `\u{d}`..`\u{ddddd}` form. A
-    literal backslash is escaped as well, so that it can never open a spurious `\u{..}`
-    sequence. Without this, a Lean string carrying any character outside printable ASCII
-    -- a byte string wrapped over `String`, say -- reaches the solver verbatim and the
-    entire query is rejected with `unexpected character`. -/
-private def escapeSmtStringLit (s : String) : String :=
-  s.foldl (init := "") (λ acc c =>
+/-! Highest code point denotable in an Smt string.
+
+    The Smt-Lib Unicode Strings theory fixes the string alphabet to
+    "the set UC of all integers from 0x00000 to 0x2FFFF, representing the set of all code
+    points for Unicode characters in Planes 0-2".
+    Lean's `Char` ranges over the whole Unicode scalar range up to `0x10FFFF`, so not every
+    Lean string is denotable -- see `escapeSmtStringLit`. -/
+def maxSmtCodePoint : Nat := 0x2FFFF
+
+/-! Escape a Lean string into the body of an Smt string literal.
+
+    Two separate documents govern this, and only the first is the standard itself:
+
+    * SMT-LIB Standard v2.6, §3.1 (Lexicon). A string literal is "any sequence of characters
+      from ⟨printable_char⟩ or ⟨white_space_char⟩ delimited by the double quote character",
+      where a ⟨printable_char⟩ is "any character from 32dec to 126dec (US-ASCII) and from
+      128dec on". Its *only* escape sequence is `""`, denoting one `"`. The standard is
+      explicit that the base language has no backslash escapes: within a literal the
+      sequences `\n`, `\012`, `\x0A` and `\u0008` "are not escape sequences ... but regular
+      sequences denoting their individual characters".
+
+    * The Smt-Lib Unicode Strings theory (https://smt-lib.org/theories-UnicodeStrings.shtml,
+      Tinelli/Barrett/Fontaine, 2020-02-01), published alongside the standard rather than in
+      it, is what gives `\u{...}` its meaning. It recognises exactly `\ud₃d₂d₁d₀` and
+      `\u{d₀}`..`\u{d₄d₃d₂d₁d₀}`, the five-digit form being restricted to `d₄ ∈ {0,1,2}` by
+      the alphabet bound above. Every other backslash is taken literally.
+
+    So `"` is doubled, `0x20`-`0x7E` is emitted verbatim, and everything else uses `\u{...}`.
+
+    Characters from 128dec on would in fact be *lexically* legal verbatim, but §3.1 leaves the
+    source encoding unspecified -- it "should be a compatible 8-bit extension of the 7-bit
+    US-ASCII set, such as UTF-8" -- and z3 counts the raw UTF-8 bytes of such a character
+    individually, turning a one-character Lean string into a multi-character Smt string.
+    Escaping them removes the dependency on the encoding. Whitespace is likewise legal
+    verbatim and escaped only for uniformity.
+
+    The backslash is escaped as `\u{5c}` even though a lone backslash is legal, so that a Lean
+    string containing the *text* `\u{41}` can never be re-read by the solver as the escape for
+    `A`. Decoding is a single left-to-right pass with no rescanning, so `\u{5c}u{41}` denotes
+    the six characters `\u{41}` as intended.
+
+    Fails with the offending character when it is above `maxSmtCodePoint`: the theory has no
+    such character and no escape denotes one, so there is nothing correct to emit. -/
+private def escapeSmtStringLit (s : String) : Except Char String :=
+  s.data.foldlM (init := "") (λ acc c =>
     let n := c.toNat
-         if c == '"'             then acc ++ "\"\""
-    else if c == '\\'            then acc ++ "\\u{5c}"
-    else if n ≥ 0x20 && n ≤ 0x7e then acc.push c
-    else acc ++ "\\u{" ++ (Nat.toDigits 16 n).asString ++ "}"
+         if c == '"'             then .ok (acc ++ "\"\"")
+    else if c == '\\'            then .ok (acc ++ "\\u{5c}")
+    else if n ≥ 0x20 && n ≤ 0x7e then .ok (acc.push c)
+    else if n ≤ maxSmtCodePoint  then .ok (acc ++ "\\u{" ++ (Nat.toDigits 16 n).asString ++ "}")
+    else .error c
   )
 
-/-! Convert a String literal to an Smt representation. -/
-def strLitSmt (s : String) : SmtTerm := .StrTerm s!"\"{escapeSmtStringLit s}\""
+/-! Convert a String literal to an Smt representation.
+    Fails with the offending character when `s` holds one outside the Smt string alphabet. -/
+def strLitSmt (s : String) : Except Char SmtTerm :=
+  (escapeSmtStringLit s).map (λ body => .StrTerm s!"\"{body}\"")
 
 /-! Create an Smt variable identifier. -/
 def smtSimpleVarId (nm : SmtSymbol) : SmtTerm := .SmtIdent (.SimpleIdent nm)

--- a/Blaster/Smt/Translate.lean
+++ b/Blaster/Smt/Translate.lean
@@ -17,7 +17,12 @@ partial def translateExpr (e : Expr) (topLevel := true) : TranslateEnvT SmtTerm 
     logReprExpr "Translate:" e
     if let some n := isIntValue? e then return intLitSmt n
     if let some n := isNatValue? e then return natLitSmt n
-    if let some s := isStrValue? e then return strLitSmt s
+    if let some s := isStrValue? e then
+      match strLitSmt s with
+      | .ok t => return t
+      | .error c =>
+          throwEnvError "translateExpr: string literal holds the character with code point \
+                         {c.toNat}, above the Smt string alphabet bound {maxSmtCodePoint}"
     -- TODO: consider other sort once supported (e.g., BitVec, Char, etc)
     match e with
      | Expr.fvar .. => translateFreeVar e visit

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -31,3 +31,4 @@ import Tests.FixedIssues.Issue31
 import Tests.FixedIssues.Issue32
 import Tests.FixedIssues.Issue33
 import Tests.FixedIssues.Issue34
+import Tests.FixedIssues.Issue35

--- a/Tests/FixedIssues/Issue35.lean
+++ b/Tests/FixedIssues/Issue35.lean
@@ -4,15 +4,22 @@ namespace Tests.Issue35
 
 -- Issue: Unexpected smt error / Unexpected Valid on String literals.
 -- Diagnosis: `strLitSmt` wrapped the Lean string verbatim in double quotes instead of
---            escaping it for an Smt-Lib 2.6 string literal. In Smt-Lib 2.6 only printable
---            ASCII (0x20-0x7E) may appear verbatim inside a string literal, a `"` is written
---            by doubling it, and every other character uses the `\u{d}`..`\u{ddddd}` form.
+--            escaping it for an Smt string literal.
+--            Two documents govern the escaping; `escapeSmtStringLit` in Blaster/Smt/Term.lean
+--            carries the full quotes:
+--              * SMT-LIB Standard v2.6 §3.1 gives a string literal exactly one escape
+--                sequence, `""` for a single `"`, and no backslash escapes at all;
+--              * the Smt-Lib Unicode Strings theory -- published alongside the standard,
+--                not in it -- is what defines `\u{d}`..`\u{ddddd}`, over the code point
+--                alphabet 0x00000-0x2FFFF.
 --            Passing the Lean bytes through unchanged breaks in three different ways:
 --              1. an embedded `"` closes the literal early and the whole query is rejected;
 --              2. an embedded `""` or `\u{..}` is silently re-read by the solver as a
 --                 *different, shorter* string, so blaster answers about the wrong string;
 --              3. a non-ASCII character reaches the solver as its raw UTF-8 bytes, so a
---                 one-character Lean string becomes a multi-character Smt string.
+--                 one-character Lean string becomes a multi-character Smt string. Such a
+--                 character is lexically legal -- §3.1 admits code 128dec on -- but 2.6
+--                 leaves the source encoding unspecified, and z3 counts the bytes singly.
 --            Cases 2 and 3 are the dangerous ones: no error is reported, blaster just
 --            proves false statements Valid.
 
@@ -49,10 +56,44 @@ namespace Tests.Issue35
 #blaster [∀ s : String, s = "é" → s ++ "!" = "é!"]
 #blaster [∀ s t : String, s = "é" → t = "!" → (s ++ t).length = 2]
 
-/-! 5. Control characters are not printable ASCII either and must be escaped. -/
+/-! 5. Whitespace is legal verbatim -- §3.1 admits ⟨white_space_char⟩ inside a literal, and
+       the standard even shows one spanning a line break -- so these already worked.
+       Regression coverage for the `\u{a}` / `\u{9}` escapes now emitted for them. -/
 
 #blaster [∀ s : String, s = "a\nb" → s.length = 3]
 #blaster [∀ s : String, s = "a\tb" → s.length = 3]
 #blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "a\nb" → s = "ab"]
+
+/-! 6. Code points above the 0x2FFFF alphabet bound have no Smt representation at all.
+
+       `Nat.toDigits 16` yields six hex digits above 0xFFFFF, and the braced escape takes at
+       most five (the fifth restricted to 0-2). z3 agrees with the theory exactly:
+       `\u{2ffff}` is one character, `\u{30000}` is nine and `\u{10ffff}` is ten. Emitting
+       such an escape produced a *false counterexample on a true goal*, so translation now
+       refuses the literal instead. -/
+
+-- U+2FFFF is the last denotable code point.
+def lastDenotable : String := ⟨[Char.ofNat 0x2FFFF]⟩
+#blaster [∀ s : String, s = lastDenotable → s.length = 1]
+
+-- An emoji is well inside the bound (U+1F600).
+#blaster [∀ s : String, s = "😀" → s.length = 1]
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "😀" → s.length = 2]
+
+-- One past the bound, and the top of Lean's Char range, are both rejected outright.
+def firstUndenotable : String := ⟨[Char.ofNat 0x30000]⟩
+def maxLeanChar : String := ⟨[Char.ofNat 0x10FFFF]⟩
+
+/--
+error: translateExpr: string literal holds the character with code point 196608, above the Smt string alphabet bound 196607
+-/
+#guard_msgs in
+#blaster [∀ s : String, s = firstUndenotable → s.length = 1]
+
+/--
+error: translateExpr: string literal holds the character with code point 1114111, above the Smt string alphabet bound 196607
+-/
+#guard_msgs in
+#blaster [∀ s : String, s = maxLeanChar → s.length = 1]
 
 end Tests.Issue35

--- a/Tests/FixedIssues/Issue35.lean
+++ b/Tests/FixedIssues/Issue35.lean
@@ -1,0 +1,58 @@
+import Blaster
+
+namespace Tests.Issue35
+
+-- Issue: Unexpected smt error / Unexpected Valid on String literals.
+-- Diagnosis: `strLitSmt` wrapped the Lean string verbatim in double quotes instead of
+--            escaping it for an Smt-Lib 2.6 string literal. In Smt-Lib 2.6 only printable
+--            ASCII (0x20-0x7E) may appear verbatim inside a string literal, a `"` is written
+--            by doubling it, and every other character uses the `\u{d}`..`\u{ddddd}` form.
+--            Passing the Lean bytes through unchanged breaks in three different ways:
+--              1. an embedded `"` closes the literal early and the whole query is rejected;
+--              2. an embedded `""` or `\u{..}` is silently re-read by the solver as a
+--                 *different, shorter* string, so blaster answers about the wrong string;
+--              3. a non-ASCII character reaches the solver as its raw UTF-8 bytes, so a
+--                 one-character Lean string becomes a multi-character Smt string.
+--            Cases 2 and 3 are the dangerous ones: no error is reported, blaster just
+--            proves false statements Valid.
+
+/-! 1. An embedded `"` closes the Smt literal early. -/
+
+-- "a\"b" has 3 characters: 'a', '"', 'b'.
+#blaster [∀ s : String, s = "a\"b" → s.length = 3]
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "a\"b" → s.length = 2]
+
+/-! 2. `""` is the Smt-Lib escape for a single `"`, so a doubled quote silently shrinks. -/
+
+-- "a\"\"b" has 4 characters: 'a', '"', '"', 'b'.
+#blaster [∀ s : String, s = "a\"\"b" → s.length = 4]
+-- Proved Valid by the old translation, since the solver only saw 3 characters.
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "a\"\"b" → s.length = 3]
+
+/-! 3. A literal backslash is re-read by the solver as the start of a `\u{..}` escape. -/
+
+-- "\\u{41}" is the 6-character string `\u{41}`, not the letter `A`.
+#blaster [∀ s : String, s = "\\u{41}" → s.length = 6]
+#blaster [∀ s : String, s = "\\u{41}" → s ≠ "A"]
+-- Both proved Valid by the old translation, since the solver only saw `A`.
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "\\u{41}" → s.length = 1]
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "\\u{41}" → s = "A"]
+
+/-! 4. Non-ASCII characters reach the solver as their raw UTF-8 bytes. -/
+
+-- "é" is a single Lean character (U+00E9).
+#blaster [∀ s : String, s = "é" → s.length = 1]
+-- Proved Valid by the old translation, since the solver saw the two UTF-8 bytes.
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "é" → s.length = 2]
+
+-- Escaped literals still compose with the other String operations.
+#blaster [∀ s : String, s = "é" → s ++ "!" = "é!"]
+#blaster [∀ s t : String, s = "é" → t = "!" → (s ++ t).length = 2]
+
+/-! 5. Control characters are not printable ASCII either and must be escaped. -/
+
+#blaster [∀ s : String, s = "a\nb" → s.length = 3]
+#blaster [∀ s : String, s = "a\tb" → s.length = 3]
+#blaster (gen-cex: 0) (solve-result: 1) [∀ s : String, s = "a\nb" → s = "ab"]
+
+end Tests.Issue35


### PR DESCRIPTION
## Description

Fixes string literal translation issues:
- encoding double quotation marks (")
- encoding backslashes (\)
- encoding control characters

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Changes Made

- [x] updated string literal encoding in Smt/Term.lean
- [x] added test showcasing the issue

## Testing

Added tests for strings containing the special cases in description.

### Test Coverage

- [x] Added new tests for new functionality
- [x] Updated existing tests
- [x] All tests pass locally
- [x] For bug fixes: Added example to `Tests/Issues/` folder

## Documentation

- [ ] README updated (if applicable)
- [x] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`
- [x] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number