### PR TITLE
Fix: andBoolReduction? returns Prop.False instead of Bool.false

### DIFF
--- a/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeBoolBinary.lean
@@ -23,7 +23,7 @@ namespace Blaster.Optimize
   if hyps.contains (← mkEqBool a true) then return b
   if hyps.contains (← mkEqBool b true) then return a
   if hyps.contains (← mkEqBool a false) then return (← mkBoolFalse)
-  if hyps.contains (← mkEqBool b false) then return (← mkPropFalse)
+  if hyps.contains (← mkEqBool b false) then return (← mkBoolFalse)
   return none
 
 /-- Apply the following simplification/normalization rules on `and` :

--- a/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
+++ b/Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean
@@ -232,4 +232,13 @@ variable (c : Bool)
 #testOptimize [ "BoolAndReduce_6"] ((!a || ((b || c) && !(c || b))) || a) && (!(b && a) || (a && b)) ===> true
 
 
+/-! Test cases for simplification rule `e1 && e2 ==> false (if false = e1 ∨ false = e2 ∈ hypothesisMap)`. -/
+
+-- false = b → (a && b) = false ===> True
+#testOptimize [ "BoolAndFalseHyp_1" ] ∀ (a b : Bool), false = b → ((a && b) = false) ===> True
+
+-- false = a → (a && b) = false ===> True
+#testOptimize [ "BoolAndFalseHyp_2" ] ∀ (a b : Bool), false = a → ((a && b) = false) ===> True
+
+
 end Test.OptimizeBoolAnd


### PR DESCRIPTION
## Description

The `false = b` branch of `andBoolReduction?` (`OptimizeBoolBinary.lean`) returned a Prop `False (mkPropFalse)` inside a `Bool &&`, where the sibling `false = a` branch correctly returns Bool `false (mkBoolFalse)`. Rewriting `a && b` to a Prop `False` produces an ill-typed term.

In the cases I tested, this doesn't change any Blaster result. The fix keeps the optimizer's rewrites type-correct.

**Test:** the regression guard is a `#testOptimize` case in `Tests/Optimize/OptimizeBool/OptimizeBoolAnd.lean`, not a FixedIssues entry. The bug only affects the optimizer's output term and isn't observable via `#blaster`. The `#testOptimize` guard fails before the fix and passes after.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Related Issue

<!-- Link to the issue this PR addresses-->

Use any of the following for our ticket management to know which tickets to move to `Done` when PR is merged:

- Fixes #176
- Closes #176 

## Changes Made

<!-- Provide a detailed list of changes -->

- 
- 
- 

## Testing

<!-- Describe the testing you have performed -->

### Test Coverage

- [x] Added new tests for new functionality
- [ ] Updated existing tests
- [x] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder

<!-- If breaking changes, provide details here -->

## Documentation

- [ ] README updated (if applicable)
- [ ] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules
<!-- - [ ] CONTRIBUTING.md updated (if workflow changes) -> 

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes using `make check_all`
- [ ] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number

## Additional Notes

<!-- Add any additional notes, context, or screenshots here -->
