### PR TITLE
fix: guard isFun constraint's argument quantifiers with domain qualifiers (fixes #195)

### DIFF
--- a/Blaster/Smt/Translate/Quantifier.lean
+++ b/Blaster/Smt/Translate/Quantifier.lean
@@ -640,6 +640,27 @@ def createPredQualifierApp (smtSym : SmtSymbol) (t : Expr) (inPredQualifier := f
   createPredQualifierAppAux (smtSimpleVarId smtSym) t inPredQualifier
 
 
+/-- Helper for `generateFunInstDeclAux` (issue #195): return `true` when the domain
+    qualifier premise for an argument of type `t` may be emitted inside the isFun
+    membership constraint, i.e., when `t` involves no generic type parameter that would
+    materialize as an SMT variable (type-universe parameters, see
+    `genericArgsToSortedVars`). Two reasons force the restriction:
+     - a domain-only generic parameter would occur FREE in the constraint (it only
+       binds the return type's generics, matching `@is{instName}`'s arity);
+     - even when the parameter is bound (e.g. `α → α`), a qualifier premise over an
+       Instance sort (`(@isInstance @x @α)`) makes z3's model search diverge on the
+       sat side of the constraint's iff (measured: Tests/FixedIssues/Issue18's
+       `addOptionPoly` probe, expected Falsified, hangs MBQI indefinitely).
+    Polymorphic arguments therefore conservatively keep the pre-#195 (unguarded)
+    behaviour. -/
+def canGuardCoDomainArg (t : Expr) : TranslateEnvT Bool := do
+  let domGens ← retrieveGenericArgs #[t]
+  for v in domGens do
+    let fdecl ← getFVarLocalDecl v
+    if isTypeUniverse fdecl.type then
+      return false
+  return true
+
 /-- Given `t := α₁ → α₂ ... → αₙ` and `st` its corresponding smt representation (i.e., ArrowTN sα₁ sα₂ sαₙ),
     perform the following action:
       - let funInst ← getFunInstDecl t
@@ -695,9 +716,28 @@ def createPredQualifierApp (smtSym : SmtSymbol) (t : Expr) (inPredQualifier := f
                     :qid @apply{n}_ext_fun)))`
 
             - `(assert (forall ((@r₀ rt₀) ... (@rₖ rtₖ) (@f (ArrowTN sα₁ sα₂ ... sαₙ)))
-                (! (= (forall ((@x₁ sα₁) ... (@xₙ₋₁ sαₙ₋₁)) (@isTypeₙ (@apply{n} @f @x₁ ... @xₙ₋₁)))
+                (! (= (forall ((@x₁ sα₁) ... (@xₙ₋₁ sαₙ₋₁))
+                        (=> (@isType₁ @x₁)
+                        ...
+                        (=> (@isTypeₙ₋₁ @xₙ₋₁)
+                            (@isTypeₙ (@apply{n} @f @x₁ ... @xₙ₋₁)))))
                       (@is{instName} @r₀ ... @rₖ @f) )
                    :pattern ( (@is{instName} @r₀ ... @rₖ @f)) :qid @isFun{v}_cstr)))`
+
+              NOTE (issue #195): each argument @xᵢ is premised with its domain qualifier
+              `(@isTypeᵢ @xᵢ)` so that membership in the function sort only constrains the
+              function's behaviour on the QUALIFIED domain (matching Lean semantics), not on
+              the whole carrier sort. Without the premise, `@is{instName}` is unsatisfiable
+              for any concrete lambda whose SMT image leaves the codomain qualifier off the
+              qualified domain (e.g. `fun x : Nat => x + 1` over the Int carrier at x = -2),
+              which makes every congruence/extensionality axiom premised on it vacuous.
+              The premise for @xᵢ is only emitted when αᵢ involves NO generic type
+              parameter (see `canGuardCoDomainArg`): a domain-only generic would occur
+              free in this assertion (which, matching `@is{instName}`'s arity, only binds
+              the return type's generics — widening that arity is the follow-up), and even
+              a bound one (e.g. `α → α`) makes z3's model search diverge on the sat side
+              of the iff. Polymorphic arguments conservatively stay unguarded (pre-#195
+              behaviour).
 
             - with ∀ i ∈ [1..n] = s
          - return `{@is{instName}, st}`
@@ -746,6 +786,7 @@ def generateFunInstDeclAux (t : Expr) (st : SortExpr) : TranslateEnvT IndTypeDec
      let mut arg_quantifiers := sargs.push (fsym, st)
      let mut forallCFunBody := eqSmt f_applyTerm1 f_applyTerm2
      let mut innerForallBody := eqSmt f_applyTerm1 g_applyTerm
+     let mut coGuards : Array (Option SmtTerm) := Array.replicate nbTypes none
      for i in [:nbTypes] do
        let idx := nbTypes - i - 1
        let predAppX ← createPredQualifierAppAux xIds[idx]! funTypes[idx]! (inPredQualifier := true)
@@ -755,10 +796,17 @@ def generateFunInstDeclAux (t : Expr) (st : SortExpr) : TranslateEnvT IndTypeDec
        forallCFunBody := impliesSmt predAppY forallCFunBody
        forallCFunBody := impliesSmt predAppX forallCFunBody
        innerForallBody := impliesSmt predAppX innerForallBody
+       if (← canGuardCoDomainArg funTypes[idx]!) then
+         coGuards := coGuards.set! idx (some predAppX)
        co_quantifiers := co_quantifiers.push (xsyms[i]!, smtTypes[i]!)
        arg_quantifiers := (arg_quantifiers.push (xsyms[i]!, smtTypes[i]!)).push (ysyms[i]!, smtTypes[i]!)
      -- isFun constraint
-     let forallCoBody ← createPredQualifierAppAux f_applyTerm1 retType (inPredQualifier := true)
+     -- issue #195: quantify the arguments over the QUALIFIED domain (see docstring NOTE).
+     let mut forallCoBody ← createPredQualifierAppAux f_applyTerm1 retType (inPredQualifier := true)
+     for i in [:nbTypes] do
+       let idx := nbTypes - i - 1
+       if let some predAppX := coGuards[idx]! then
+         forallCoBody := impliesSmt predAppX forallCoBody
      let forallCoDomain := mkForallTerm none co_quantifiers forallCoBody none
      let rt_args_vIds := rt_args.map (λ s => smtSimpleVarId s.1)
      let f_funPredApp := mkSimpleSmtAppN decl.instName (rt_args_vIds.push fId)

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -32,3 +32,4 @@ import Tests.FixedIssues.Issue32
 import Tests.FixedIssues.Issue33
 import Tests.FixedIssues.Issue34
 import Tests.FixedIssues.Issue35
+import Tests.FixedIssues.Issue195

--- a/Tests/FixedIssues/Issue195.lean
+++ b/Tests/FixedIssues/Issue195.lean
@@ -1,0 +1,58 @@
+import Blaster
+
+namespace Tests.Issue195
+
+-- Issue: `@isFun` membership unsatisfiable for lambdas over qualified codomain arrows.
+-- Diagnosis: the `@isFun{v}_cstr` iff quantified the function's arguments over the whole
+--            carrier sort instead of the qualified domain: for `Nat → Nat` it read
+--              (= (forall ((@x0 Nat)) (@isNat (@apply @f @x0))) (@isFun @f))
+--            with `Nat` aliased to `Int`. A concrete lambda such as `fun x : Nat => x + 1`
+--            has a def_cstr that pins `@apply` off-domain too (`(@apply L -2) = -1`), so
+--            the unguarded forall was falsifiable and `(@isFun L)` was forced FALSE.
+--            Every congruence/extensionality axiom premised on `@isFun` was then vacuous
+--            for the lambda:
+--             - true funext goals were reported ❌ Falsified (bogus counterexample);
+--             - worse, arrow-typed hypotheses assert their membership positively
+--               (`(assert (@isFun $f))`), so a hypothesis `f = lambda` forced
+--               `(@isFun L)` TRUE and the context became inconsistent: blaster proved
+--               `False` ✅ Valid (see probe 3 below).
+-- Fix: guard each argument of the isFun constraint's inner forall with its domain
+--      qualifier (Quantifier.lean, generateApplyFunAndAssertions):
+--        (= (forall ((@x0 Nat)) (=> (@isNat @x0) (@isNat (@apply @f @x0)))) (@isFun @f))
+--      NOTE: a Bool codomain hides the bug (`@isBool` is trivially true); these probes
+--      must keep a non-trivial codomain qualifier such as `Nat`.
+
+-- 1. True by funext; needs `@apply_ext_fun`, whose `@isFun` premises were vacuous.
+--    Reported ❌ Falsified before the fix.
+#blaster [∀ (f : Nat → Nat), (∀ x, f x = x + 1) → f = fun x => x + 1]
+
+-- 2. Congruence through a hypothesis equality with a lambda; pins the guarded path.
+--    (Also "Valid" before the fix, but only because the context was inconsistent.)
+#blaster [∀ (f : Nat → Nat), f = (fun x => x + 1) → f 2 = 3]
+
+-- 3. The unsoundness vector: this statement is FALSE (take f := fun x => x + 1).
+--    Reported ✅ Valid before the fix: `(assert (@isFun $f))` + `$f = L` +
+--    unguarded cstr forced `∀ x:Int. @isNat (@apply L x)`, contradicting the
+--    def_cstr's off-domain value `(@apply L -2) = -1`. Falsified is the honest answer.
+/--
+error: ❌ Falsified
+---
+error: Tactic `blaster` failed: Goal was falsified (see counterexample above)
+
+f : Nat → Nat
+⊢ (f = fun x => x + 1) → False
+-/
+#guard_msgs in
+example (f : Nat → Nat) (h : f = fun x => x + 1) : False := by
+  blaster (gen-cex: 0)
+
+-- NOTE (#194 interaction): until the lambda def_cstr guard (PR #198) also lands,
+-- reviving `@isFun` re-exposes the off-domain values that unguarded def_cstrs pin: two
+-- lambdas that agree on Nat but whose SMT images differ at negative Ints (e.g.
+-- `fun x => x % (x + 1)` vs `fun x => x`) are forced equal by `@apply_ext_fun`, making
+-- the context inconsistent. This fix must therefore be merged together with / after
+-- PR #198. Once both are in, enable the following (verified on the combined tree):
+-- #blaster (gen-cex: 0) (solve-result: 1)
+--   [∀ (g : (Nat → Nat) → Nat), g (fun x => x % (x + 1)) + g (fun x => x) = 1000 → False]
+
+end Tests.Issue195


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge order: this PR must land together with or after #198** (the #194 lambda def_cstr guard). Reviving `@isFun` re-exposes the off-domain `@apply` values that unguarded def_cstrs pin — see "Interaction with #194/#198" below for a demonstrated false-Valid on this branch alone. It also textually neighbors #198 in the tree and should be rebased once #198 merges.

## Root cause

`generateApplyFunAndAssertions` (Blaster/Smt/Translate/Quantifier.lean) emitted the `@isFun{v}_cstr` membership iff with its inner forall over the function's arguments **unguarded** — quantifying over the whole carrier sort instead of the qualified domain, in contrast to the congruence/extensionality bodies right next to it, which do premise every argument with `(@isType @x)`.

For `Nat → Nat` (carrier `Int`):

```smt
; BEFORE (main @ 3a141c8)
(assert (forall ((@f (@@ArrowT2 Nat Nat)))
 (!(= (forall ((@x0 Nat))
        (@isNat (@apply_uniq.563 @f @x0)))          ; <-- @x0 ranges over ALL of Int
      (@isFun_uniq.563 @f))
   :pattern ((@isFun_uniq.563 @f)) :qid @isFun_uniq.563_cstr)))
```

A concrete lambda's def_cstr pins `@apply` on the whole carrier (`fun x : Nat => x + 1` gives `(@apply L -2) = -1`), so the unguarded forall is false and `(@isFun L)` is **forced FALSE** — every congruence/extensionality axiom premised on `@isFun` is vacuous for every such lambda. A Bool codomain hides this (`@isBool` is trivially true); it bites with any non-trivial codomain qualifier such as `Nat`.

### Severity: not just incompleteness — confirmed unsoundness on main

Arrow-typed hypotheses assert their membership **positively** (`(assert (@isFun $f))`). So on main @ 3a141c8:

```lean
-- reported ✅ Valid on main (False proved!):
theorem u (f : Nat → Nat) (h : f = fun x => x + 1) : False := by blaster
-- (@isFun $f) asserted + $f = L  ⇒ ∀x:Int. @isNat (@apply L x), contradicting (@apply L -2) = -1
```

and the true funext goal below was reported ❌ **Falsified** with a bogus counterexample (ext_fun vacuous for the lambda):

```lean
theorem r (f : Nat → Nat) (h : ∀ x, f x = x + 1) : f = fun x => x + 1 := by blaster
```

## Fix

Premise each argument of the isFun constraint's inner forall with its domain qualifier, reusing the same `predAppX` terms the congruence/extensionality bodies are built from:

```smt
; AFTER
(assert (forall ((@f (@@ArrowT2 Nat Nat)))
 (!(= (forall ((@x0 Nat))
        (=> (@isNat @x0) (@isNat (@apply_uniq.563 @f @x0))))
      (@isFun_uniq.563 @f))
   :pattern ((@isFun_uniq.563 @f)) :qid @isFun_uniq.563_cstr)))
```

The minimal SMT evidence from the issue flips as intended: asserting `(isFun L)` for the `x + 1` lambda goes **unsat → sat**, and asserting `(not (isFun L))` goes **sat → unsat** (membership is now forced true, so ext/congr are no longer vacuous).

### The `@isFun` arity question (why the guard is conditional)

The warning from the #194 session was accurate. The isFun constraint assertion (and `@is{instName}` itself) binds only the **return type's** generic type parameters (`rt_args`), while a domain qualifier premise may reference domain-only generics (`(@isInstance @x @α)` for `α → Nat`) — those would occur **free** in the assertion. Guarding those arguments correctly requires widening `@is{instName}`'s type-parameter arity to cover domain generics, which changes the declaration and every application site of every function sort — deliberately **not** done here.

Beyond the arity obstacle there is a measured operational one: even when the domain generic **is** bound (e.g. the `α → α` lambda in `Tests/FixedIssues/Issue18`'s `addOptionPoly` probe), emitting the guard `(=> (@isInstance @x0 @α) …)` sends z3's MBQI model search into indefinite divergence on the **sat side** of the iff (the probe expects Falsified; it hung > 11 min where main answers promptly, and terminates unchanged once the guard is withheld).

`canGuardCoDomainArg` therefore emits the premise only for arguments whose type involves **no** generic type parameter — which covers the entire reported class (monomorphic arrows like `Nat → Nat`). Polymorphic arguments conservatively keep the pre-#195 unguarded behaviour; the residual incompleteness is documented in the docstring and left as a follow-up together with the arity widening.

## Interaction with #194/#198 (merge-order requirement)

Any fix that makes `@isFun` satisfiable for lambdas revives `@apply_ext_fun` — which then interacts with the **unguarded def_cstrs** that #198 fixes: two lambdas agreeing on `Nat` whose SMT images differ at negative Ints get forced equal by ext while their def_cstrs pin different off-domain values ⇒ inconsistent context ⇒ anything proves Valid. Demonstrated (this branch without #198):

```lean
-- FALSE in Lean (both lambdas are funext-equal, g of each = 500 is possible):
theorem p5 (g : (Nat → Nat) → Nat) :
    g (fun x => x % (x + 1)) + g (fun x => x) = 1000 → False := by blaster
-- main:                Falsified (honest)
-- this branch alone:   Valid   (UNSOUND — do not merge before #198)
-- this branch + #198:  Falsified (honest; verified on the combined tree)
```

The combination was verified by cherry-picking #198's two commits onto this branch: `Tests/FixedIssues/Issue195.lean` and `Issue194.lean` both green, `p5` honest in both tactic and command form. The corresponding `#blaster (solve-result: 1)` probe is included commented-out in the test file, to be enabled once both PRs are in.

## Tests

`Tests/FixedIssues/Issue195.lean` (registered in `Tests/FixedIssues.lean`):
1. the true funext goal — ❌ Falsified before, ✅ Valid after (Lean-level witness of the recovered strength);
2. congruence through a hypothesis equality with a lambda — pins the guarded path (was "Valid" before too, but only via the inconsistent context);
3. the `False` probe under `#guard_msgs` — ✅ Valid (unsound) before, ❌ Falsified after;
4. commented-out combined probe for after #198 lands (see above).

## Measured flips (full `lake test`, main @ 3a141c8 vs this branch)

**None, in either direction.** Both runs green (rc=0, 0 warnings, 0 errors); all 3616 per-statement outcome lines are identical, the only additions being the two new Issue195 `✅ Valid` lines. In particular no `Valid → Undetermined` completeness cost anywhere; the recovered strength is captured by the new tests (Falsified/unsound-Valid on main).

One measurement incident worth recording: an earlier, broader version of the guard (emitting it whenever the domain generic was bound, e.g. `α → α`) hung the suite at `Tests/FixedIssues/Issue18.lean` — z3 spinning > 11 min on the `addOptionPoly` expected-Falsified probe. The shipped `canGuardCoDomainArg` restriction (no generic type parameters in the argument's type) was narrowed precisely from that measurement; with it, Issue18 answers all six probes promptly and the full suite completes with no hangs.

Fixes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
