### PR TITLE
Fix false Valid results from constructor proof fields

### DIFF
--- a/Blaster/Optimize/Rewriting/OptimizeEq.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeEq.lean
@@ -42,6 +42,10 @@ partial def structEq? (op1 : Expr) (op2: Expr) : TranslateEnvT (Option Bool) := 
        -- return `none` for all other cases if physically equality fails
        pure none
  if exprEq op1 op2 then return true
+ -- Constructor fields may be proofs. Their constructor tags and arguments
+ -- are computationally irrelevant: e.g. `Or.inl h` and `Or.inr h'` must
+ -- never establish disequality of two enclosing structure values.
+ if ← isPropEnv (← inferTypeEnv op1) then return true
  visit op1 op2
 
  where
@@ -365,7 +369,7 @@ def optimizeEq (f : Expr) (args: Array Expr) : TranslateEnvT Expr := do
  if let Expr.const ``True _ := op1 then return op2
  if isNotExprOf op2 op1 || isBoolNotExprOf op2 op1 then return ← mkPropFalse
  if exprEq op1 op2 then return ← mkPropTrue
- if let some false ← structEq? op1 op2 then return ← mkPropFalse
+ if let some equal ← structEq? op1 op2 then return ← mkPropLit equal
  if let some (e1, e2) ← notNegEqSimp? op1 op2 then return ← mkApp3Expr f eqType e1 e2
  if let some r ← zeroEqNegReduce? op1 op2 eqType then return r
  if let some r ← intCtorEqReduce? op1 op2 then return r

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -33,4 +33,4 @@ import Tests.FixedIssues.Issue33
 import Tests.FixedIssues.Issue34
 import Tests.FixedIssues.Issue35
 import Tests.FixedIssues.Issue36
-import Tests.FixedIssues.ProofIrrelevance
+import Tests.FixedIssues.Issue225

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -33,3 +33,4 @@ import Tests.FixedIssues.Issue33
 import Tests.FixedIssues.Issue34
 import Tests.FixedIssues.Issue35
 import Tests.FixedIssues.Issue36
+import Tests.FixedIssues.ProofIrrelevance

--- a/Tests/FixedIssues/Issue225.lean
+++ b/Tests/FixedIssues/Issue225.lean
@@ -1,7 +1,7 @@
 import Blaster
 import Tests.Utils
 
-namespace Tests.ProofIrrelevance
+namespace Tests.Issue225
 
 structure ProofBox where
   value : Nat
@@ -29,4 +29,4 @@ theorem boxes_equal :
 #blaster (gen-cex: 0) (solve-result: 1)
   [[ProofBox.mk 7 (.inl .intro)] ≠ [ProofBox.mk 7 (.inr .intro)]]
 
-end Tests.ProofIrrelevance
+end Tests.Issue225

--- a/Tests/FixedIssues/ProofIrrelevance.lean
+++ b/Tests/FixedIssues/ProofIrrelevance.lean
@@ -1,0 +1,32 @@
+import Blaster
+import Tests.Utils
+
+namespace Tests.ProofIrrelevance
+
+structure ProofBox where
+  value : Nat
+  proof : True ∨ True
+
+-- The kernel checks this without Blaster or any axioms: proof fields do not
+-- distinguish constructor values, even when their proof constructors differ.
+theorem boxes_equal :
+    ProofBox.mk 7 (.inl .intro) = ProofBox.mk 7 (.inr .intro) := rfl
+
+#testOptimize ["ProofFieldsEqual"]
+  ProofBox.mk 7 (.inl .intro) = ProofBox.mk 7 (.inr .intro) ===> True
+#testOptimize ["ProofFieldsNotUnequal"]
+  ProofBox.mk 7 (.inl .intro) ≠ ProofBox.mk 7 (.inr .intro) ===> False
+#testOptimize ["ProofFieldsInsideList"]
+  [ProofBox.mk 7 (.inl .intro)] = [ProofBox.mk 7 (.inr .intro)] ===> True
+#testOptimize ["DataFieldsStillDistinct"]
+  ProofBox.mk 7 (.inl .intro) = ProofBox.mk 8 (.inr .intro) ===> False
+#testOptimize ["ProofEquality"]
+  (Or.inl True.intro : True ∨ True) = Or.inr True.intro ===> True
+
+-- Negative solver regressions must actually be falsified, not merely unknown.
+#blaster (only-optimize: 1) (gen-cex: 0) (solve-result: 1)
+  [ProofBox.mk 7 (.inl .intro) ≠ ProofBox.mk 7 (.inr .intro)]
+#blaster (gen-cex: 0) (solve-result: 1)
+  [[ProofBox.mk 7 (.inl .intro)] ≠ [ProofBox.mk 7 (.inr .intro)]]
+
+end Tests.ProofIrrelevance


### PR DESCRIPTION
Constructor equality can report a false theorem as `Valid` when structures have proof fields. For example, `ProofBox.mk 7 (Or.inl True.intro) ≠ ProofBox.mk 7 (Or.inr True.intro)` reduced to `True`, although Lean proves the equality by `rfl`.

Treat proof fields as equal before comparing constructor tags, and consume a successful structural comparison so values differing only in proofs simplify to equality. Ordinary data fields still distinguish constructors. The same issue is covered inside lists.

Validation:
- Reproduced the false `Valid` result on beta `bafdd4f7`.
- Added a kernel-checked `rfl` witness, five optimizer regressions, and two negative solver regressions requiring `Falsified`.
- `lake build Blaster Tests.FixedIssues.Issue225` passed.
- `lake build Tests.Optimize` passed (449 build jobs).

This PR targets `beta-lambda-cache-optimization` and is the first soundness fix from the branch review.

Fixes #225. Regression: `Tests/FixedIssues/Issue225.lean`.
