### PR TITLE
Fix shared substitution slices and open-variable capture

### DIFF
--- a/Blaster/Optimize/Env/Instantiate.lean
+++ b/Blaster/Optimize/Env/Instantiate.lean
@@ -66,8 +66,7 @@ private unsafe def instantiateSharedRevRangeAux (e : Expr) (offset s n : USize) 
       else return r
   else
       let e := cur
-      let s' := s + offset
-      if s'.toNat >= e.looseBVarRange
+      if offset.toNat >= e.looseBVarRange
       then go e true offset stk cache
       else
         let cached := cache.getD (mkInstKey e offset) instCacheMiss
@@ -76,9 +75,12 @@ private unsafe def instantiateSharedRevRangeAux (e : Expr) (offset s n : USize) 
            match e with
            | .bvar idx =>
                let idx' := idx.toUSize
-               if idx' >= s' then
+               if idx' >= offset then
                  if idx' < offset + n then
-                    let r := subst.uget (n - (idx' - offset) - 1) lcProof
+                    let arg := subst.uget (s + n - (idx' - offset) - 1) lcProof
+                    -- Substitution under a binder must not capture open arguments.
+                    let r ← if offset == 0 || !arg.hasLooseBVars then pure arg
+                            else hashcons (arg.liftLooseBVars 0 offset.toNat)
                     go r true offset stk (cache.insert (mkInstKey e offset) r)
                  else
                    let r ← mkBVarExpr (idx - n.toNat)
@@ -113,6 +115,7 @@ Assume `beginIdx ≤ endIdx` and `endIdx ≤ subst.size`
 def instantiateSharedRevRange (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr) : TranslateEnvT Expr :=
   if _ : beginIdx > endIdx then unreachable! else
   if _ : endIdx > subst.size then unreachable! else
+  if beginIdx == endIdx then return e else
   let s := beginIdx.toUSize
   let n := endIdx.toUSize - s
   unsafe instantiateSharedRevRangeAux e 0 s n subst
@@ -171,7 +174,7 @@ partial def betaForAll (e : Expr) (args : Array Expr) : TranslateEnvT Expr :=
 def betaLambdaSharedRange (e : Expr) (beginIdx : Nat) (endIdx : Nat) (args : Array Expr) : TranslateEnvT Expr :=
   let finish (e : Expr) (i : Nat) : TranslateEnvT Expr :=
     if !e.hasLooseBVars then return e
-    else instantiateSharedRevRange e 0 i args
+    else instantiateSharedRevRange e beginIdx i args
   let rec visit (e : Expr) (i : Nat) : TranslateEnvT Expr := do
     if i < endIdx then
       match e with

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -35,3 +35,4 @@ import Tests.FixedIssues.Issue35
 import Tests.FixedIssues.Issue36
 import Tests.FixedIssues.Issue225
 import Tests.FixedIssues.Issue226
+import Tests.FixedIssues.Issue227

--- a/Tests/FixedIssues/Issue227.lean
+++ b/Tests/FixedIssues/Issue227.lean
@@ -1,0 +1,58 @@
+import Blaster.Optimize.Env.Instantiate
+import Tests.Utils
+
+open Lean Meta Elab Command Blaster.Optimize
+
+namespace Tests.Issue227
+
+-- Compare with Lean's native substitution, including open terms, unused/outer
+-- variables, empty and nonzero ranges, and the same node at different depths.
+run_cmd liftTermElabM do
+  let check : TranslateEnvT Unit := do
+    let nat ← hashcons (mkConst ``Nat)
+    let closed ← (#[10, 20, 30] : Array Nat).mapM fun n => hashcons (mkRawNatLit n)
+    let openArgs ← (#[.bvar 0, .bvar 2, .app (mkConst ``Nat.succ) (.bvar 1)] : Array Expr).mapM hashcons
+    for args in #[closed, openArgs] do
+      for start in [:args.size + 1] do
+        for stop in [start:args.size + 1] do
+          for idx in [:6] do
+            let v ← mkBVarExpr idx
+            let mut e := v
+            for depth in [:5] do
+              let inputs := #[e, Expr.app e v,
+                Expr.forallE `x nat e .default,
+                Expr.letE `x nat v e false,
+                Expr.mdata {} e, Expr.proj ``Prod 0 e]
+              for input in inputs do
+                let input ← hashcons input
+                let actual ← instantiateSharedRevRange input start stop args
+                let expected := input.instantiateRevRange start stop args
+                unless actual == expected do
+                  throwError "shared substitution disagrees with Lean at range [{start}, {stop}), index {idx}, depth {depth}:\nactual: {repr actual}\nexpected: {repr expected}"
+              e ← mkLambdaExpr `x .default nat e
+    -- Beta reduction must consume only the requested argument slice, including
+    -- when there are fewer lambdas than arguments (remaining arguments apply).
+    let v ← mkBVarExpr 0
+    let id ← mkLambdaExpr `x .default nat v
+    let const ← mkLambdaExpr `x .default nat (← mkLambdaExpr `y .default nat (← mkBVarExpr 1))
+    for f in #[id, const] do
+      for args in #[closed, openArgs] do
+        for start in [:args.size + 1] do
+          for stop in [start:args.size + 1] do
+            let actual ← betaLambdaSharedRange f start stop args
+            let expected := f.beta (args.extract start stop)
+            unless actual == expected do
+              throwError "shared beta reduction disagrees with Lean at range [{start}, {stop}):\nactual: {repr actual}\nexpected: {repr expected}"
+  check.run' (default : TranslateEnv)
+
+#testOptimize ["BetaUnderBinders"]
+  (fun x y : Nat => (fun a b : Nat => a + b) y x) ===>
+  (fun x y : Nat => Nat.add x y)
+
+#testOptimize ["BetaPreservesOuterVariable"]
+  (fun x : Nat => (fun _y : Nat => fun _z : Nat => x) 10) ===>
+  (fun x _z : Nat => x)
+
+#blaster [∀ x y : Nat, (fun a b : Nat => a + b) y x = x + y]
+
+end Tests.Issue227


### PR DESCRIPTION
Shared substitution disagrees with Lean's native implementation when the argument slice begins after zero, and it captures open replacement variables under binders. For example, substituting slice `[1, 2)` of `[10, 20]` into `bvar 0` returns `bvar 0` instead of `20`.

Use the slice offset only when indexing the replacement array, lift open replacements by the binder depth, and pass the requested slice through shared beta reduction. Closed arguments keep their existing fast path; empty slices return immediately.

Fixes #227. `Tests/FixedIssues/Issue227.lean` compares 3,600 substitution cases and 40 beta cases with Lean's native implementation, and includes two optimizer regressions and a Blaster call. `lake build Tests.FixedIssues.Issue227` passes.

This is a helper correctness fix; the reported cases have not been shown to produce a false top-level Blaster theorem. Stacked on #224.
