### PR TITLE
Reduce shared-factor Nat.mod goals before SMT solving

### DIFF
--- a/Blaster/Optimize/Rewriting/OptimizeNat.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeNat.lean
@@ -269,6 +269,23 @@ def natModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      return none
   | none => return none
 
+/-- Factor a shared multiplicand out of a remainder using
+    `Nat.mul_mod_mul_left`. The identity holds even for a zero factor or divisor.
+    Match either orientation because multiplication normalization can reorder it. -/
+private def natModCommonFactor? (f op1 op2 : Expr) : TranslateEnvT (Option Expr) := do
+  let some (a, b) := natMul? op1 | return none
+  let some (c, d) := natMul? op2 | return none
+  let factorAndRest :=
+    if exprEq a c then some (a, b, d)
+    else if exprEq a d then some (a, b, c)
+    else if exprEq b c then some (b, a, d)
+    else if exprEq b d then some (b, a, c)
+    else none
+  let some (factor, dividend, divisor) := factorAndRest | return none
+  setRestart
+  let remainder ← mkApp2Expr f dividend divisor
+  return some (← mkApp2Expr (← mkNatMulOp) factor remainder)
+
 /-- Apply the following simplification/normalization rules on `Nat.mod` :
      - n % 0 ==> n
      - n % 1 ==> 0
@@ -277,6 +294,7 @@ def natModToZeroExpr? (e1 : Expr) (e2 : Expr) : TranslateEnvT (Option Expr) := d
      - (N1 * n) % N2 ==> 0 (if N1 % N2 = 0)
      - n1 % n2 ==> 0 (if n1 =ₚₜᵣ n2)
      - (m * n) % m | (n * m) % m ==> 0
+     - (z * x) % (z * y) ==> z * (x % y) (in either product orientation)
    Assume that f = Expr.const ``Nat.mod.
    An error is triggered when args.size ≠ 2 (i.e., only fully applied `Nat.mod` expected at this stage)
 -/
@@ -293,6 +311,7 @@ def optimizeNatMod (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
  | _, nv2 =>
    if let some r ← cstModProp? op1 nv2 then return r
    if let some r ← natModToZeroExpr? op1 op2 then return r
+   if let some r ← natModCommonFactor? f op1 op2 then return r
    mkApp2Expr f op1 op2
 
  where

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -36,3 +36,4 @@ import Tests.FixedIssues.Issue36
 import Tests.FixedIssues.Issue225
 import Tests.FixedIssues.Issue226
 import Tests.FixedIssues.Issue227
+import Tests.FixedIssues.Issue228

--- a/Tests/FixedIssues/Issue228.lean
+++ b/Tests/FixedIssues/Issue228.lean
@@ -1,0 +1,29 @@
+import Tests.Utils
+
+namespace Tests.Issue228
+
+-- The rewrite identity is proved by Lean, including zero factors/divisors.
+example (z x y : Nat) : (z * x) % (z * y) = z * (x % y) :=
+  Nat.mul_mod_mul_left z x y
+
+#testOptimize ["ModCommonFactorLeftLeft"]
+  (∀ x y z : Nat, (z*x) % (z*y) = z*(x%y)) ===> True
+#testOptimize ["ModCommonFactorLeftRight"]
+  (∀ x y z : Nat, (z*x) % (y*z) = z*(x%y)) ===> True
+#testOptimize ["ModCommonFactorRightLeft"]
+  (∀ x y z : Nat, (x*z) % (z*y) = z*(x%y)) ===> True
+#testOptimize ["ModCommonFactorRightRight"]
+  (∀ x y z : Nat, (x*z) % (y*z) = z*(x%y)) ===> True
+#testOptimize ["ModCommonFactorZeroDivisor"]
+  (∀ x z : Nat, (z*x) % (z*0) = z*x) ===> True
+#testOptimize ["ModCommonFactorZeroFactor"]
+  (∀ x y : Nat, (0*x) % (0*y) = 0) ===> True
+#testOptimize ["ModCommonFactorNested"]
+  (∀ a b x y : Nat, (a*(b*x)) % (a*(b*y)) = a*(b*(x%y))) ===> True
+
+#blaster (only-optimize: 1)
+  [∀ x y z : Nat, (z*x) % (z*y) = z*(x%y)]
+#blaster (gen-cex: 0) (solve-result: 1)
+  [∀ x y z : Nat, (z*x) % (z*y) = x%y]
+
+end Tests.Issue228

--- a/Tests/Optimize/OptimizeNat/OptimizeNatMod.lean
+++ b/Tests/Optimize/OptimizeNat/OptimizeNatMod.lean
@@ -345,9 +345,9 @@ elab "natModIdentity_2" : term => return natModIdentity_2
 #testOptimize [ "NatModIdentityUnchanged_1" ] ∀ (x y z : Nat), x % y < z ===>
                                               ∀ (x y z : Nat), Nat.mod x y < z
 
--- (m * n) % (n * x) ===> Nat.mod (Nat.mul m n) (Nat.mul n x)
-#testOptimize [ "NatModIdentityUnchanged_2" ] ∀ (m n x y : Nat), (m * n) % (n * x) < y ===>
-                                              ∀ (m n x y : Nat), Nat.mod (Nat.mul m n) (Nat.mul n x) < y
+-- Factoring a common multiplicand preserves a nonzero remainder.
+#testOptimize [ "NatModCommonFactorNonzero" ] ∀ (m n x y : Nat), (m * n) % (n * x) < y ===>
+                                              ∀ (m n x y : Nat), Nat.mul n (Nat.mod m x) < y
 
 -- (y + (100 - (y + 250))) % x ===> Nat.mod y x
 #testOptimize [ "NatModIdentityUnchanged_3" ] ∀ (x y z : Nat), (y + (100 - (y + 250))) % x < z ===>


### PR DESCRIPTION
The existing shared-factor remainder theorem can spend minutes in nonlinear SMT arithmetic. Reduce `(z*x) % (z*y)` to `z*(x%y)` before translation, matching the common factor in either product orientation.

The rule is justified by Lean's `Nat.mul_mod_mul_left`; it remains valid for zero factors and zero divisors. A restart normalizes the smaller remainder and resulting product. No solver timeout or expected verdict is weakened.

Fixes #228. `Tests/FixedIssues/Issue228.lean` includes a kernel-checked identity, seven optimizer cases, an optimizer-only Blaster proof and a falsified near-miss. `lake build Tests.FixedIssues.Issue228 Tests.Smt.SmtNat.SmtNatMod` passes, including the previously solver-sensitive test at line 37. The identity now reports `Valid` during optimization alone (0.161 seconds in one local run).

Stacked on #229. Full-stack validation: `PATH=/tmp/lean-blaster-review-tools:$PATH lake test` passed with a uniform 30-second Z3 process cap. One existing optimizer expectation now records the factored remainder.
