### PR TITLE
Preserve SMT sharing with scope-safe let emission

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,0 +1,25 @@
+# Shared SMT emission benchmark
+
+Build Blaster, then compare exactly the same executable with sharing disabled and enabled:
+
+```sh
+lake build Blaster
+python3 Benchmarks/shared_emission.py --depths 16 20 --repeat 3
+python3 Benchmarks/shared_emission.py --depths 24 --repeat 1 --skip-dump --output Benchmarks/shared-emission-depth24.json
+```
+
+`SharedEmission.lean` generates an Int let-chain whose shared expression graph grows linearly while its expanded text doubles at every level. Each sample starts a fresh Lean process and must return `Valid`. Dump-only runs are separate from timing. Negative cases and binder-scope cases live in `Tests/FixedIssues/Issue231.lean` and `Issue232.lean`.
+
+Recorded environment: Apple M2 Max, Lean 4.24.0, Z3 4.15.4. These measurements compare the candidate built on `4ae4d4fe` with its sharing option off/on. The JSON records individual samples, stage times and medians.
+
+| Depth | Off, wall time | On, wall time | Off, dumped query | On, dumped query |
+|---|---:|---:|---:|---:|
+| 16 | 1.83 s | 1.29 s | 459,121 bytes | 811 bytes |
+| 20 | 9.78 s | 1.31 s | 7,340,401 bytes | 931 bytes |
+| 24 | 132.69 s | 1.28 s | Not measured | Not measured |
+
+Depths 16 and 20 use medians of three samples. Depth 24 is a single-run comparison. At depth 20, median submission time falls from 8.417 s to 0.002 s; solver time stays around 0.03 s. At depth 24, submission falls from 131.462 s to 0.002 s. These cases isolate serialization rather than solver search.
+
+The first depth-24 dump-only run exceeded its 180-second limit. Its earlier uncheckpointed timing samples were lost and are excluded. The recorded depth-24 run was repeated with dumping disabled; no byte count or three-run median is claimed for that depth. The runner now checkpoints completed samples and terminates its process group on timeout.
+
+This synthetic result does not measure Cardano validator preparation or establish a general 104× speedup. It demonstrates that repeated SMT text is avoidable for a shared residual expression. The full test suite was separately checked with Z3 4.15.2 and a uniform 30-second process cap.

--- a/Benchmarks/SharedEmission.lean
+++ b/Benchmarks/SharedEmission.lean
@@ -1,0 +1,15 @@
+import Blaster
+
+/-! Large, reproducible let-chain queries. Run the companion Python script for
+    isolated processes, phase timings and exact serialized query sizes. -/
+open Lean in
+macro "emissionChain%" n:num seed:term : term => do
+  let depth := n.getNat
+  if depth == 0 then Macro.throwError "depth must be positive"
+  let ids := (Array.range depth).map fun i => mkIdent (Name.mkSimple s!"a{i}")
+  let mut e : Term ← `(0 ≤ $(ids[depth-1]!))
+  for i in (List.range depth).reverse do
+    let v : Term ← if i == 0 then `(($seed : Int) + $seed)
+      else `($(ids[i-1]!) + $(ids[i-1]!))
+    e ← `(let $(ids[i]!) := $v; $e)
+  return e

--- a/Benchmarks/shared-emission-depth24.json
+++ b/Benchmarks/shared-emission-depth24.json
@@ -1,0 +1,50 @@
+{
+  "base_commit": "4ae4d4fef48b9afd305cd2ea1c66d6a4460b138a",
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "z3": "Z3 version 4.15.4 - 64 bit",
+  "repeat": 1,
+  "rows": [
+    {
+      "depth": 24,
+      "share_smt": 0,
+      "query_dump_bytes": null,
+      "samples": [
+        {
+          "wall_s": 132.687820749823,
+          "Optimization": 0.143,
+          "Translation": 0.009,
+          "Submitting Smt Query": 131.462,
+          "Solve": 0.026
+        }
+      ],
+      "median": {
+        "wall_s": 132.687820749823,
+        "Optimization": 0.143,
+        "Translation": 0.009,
+        "Submitting Smt Query": 131.462,
+        "Solve": 0.026
+      }
+    },
+    {
+      "depth": 24,
+      "share_smt": 1,
+      "query_dump_bytes": null,
+      "samples": [
+        {
+          "wall_s": 1.2750339999329299,
+          "Optimization": 0.155,
+          "Translation": 0.009,
+          "Submitting Smt Query": 0.002,
+          "Solve": 0.025
+        }
+      ],
+      "median": {
+        "wall_s": 1.2750339999329299,
+        "Optimization": 0.155,
+        "Translation": 0.009,
+        "Submitting Smt Query": 0.002,
+        "Solve": 0.025
+      }
+    }
+  ]
+}

--- a/Benchmarks/shared-emission-results.json
+++ b/Benchmarks/shared-emission-results.json
@@ -1,0 +1,150 @@
+{
+  "base_commit": "4ae4d4fe",
+  "lean": "Lean 4.24.0",
+  "z3": "Z3 version 4.15.4 - 64 bit",
+  "machine": "Apple M2 Max",
+  "repeat": 3,
+  "rows": [
+    {
+      "depth": 16,
+      "share_smt": 0,
+      "query_dump_bytes": 459121,
+      "median": {
+        "wall_s": 1.8313705420587212,
+        "Optimization": 0.147,
+        "Translation": 0.008,
+        "Submitting Smt Query": 0.535,
+        "Solve": 0.029
+      },
+      "samples": [
+        {
+          "wall_s": 1.8422324999701232,
+          "Optimization": 0.147,
+          "Translation": 0.008,
+          "Submitting Smt Query": 0.544,
+          "Solve": 0.029
+        },
+        {
+          "wall_s": 1.8313705420587212,
+          "Optimization": 0.144,
+          "Translation": 0.008,
+          "Submitting Smt Query": 0.535,
+          "Solve": 0.022
+        },
+        {
+          "wall_s": 1.7977093749213964,
+          "Optimization": 0.15,
+          "Translation": 0.008,
+          "Submitting Smt Query": 0.532,
+          "Solve": 0.03
+        }
+      ]
+    },
+    {
+      "depth": 16,
+      "share_smt": 1,
+      "query_dump_bytes": 811,
+      "median": {
+        "wall_s": 1.2883592501748353,
+        "Optimization": 0.152,
+        "Translation": 0.008,
+        "Submitting Smt Query": 0.002,
+        "Solve": 0.028
+      },
+      "samples": [
+        {
+          "wall_s": 1.2425428330898285,
+          "Optimization": 0.152,
+          "Translation": 0.008,
+          "Submitting Smt Query": 0.003,
+          "Solve": 0.021
+        },
+        {
+          "wall_s": 1.3116948341485113,
+          "Optimization": 0.146,
+          "Translation": 0.008,
+          "Submitting Smt Query": 0.002,
+          "Solve": 0.028
+        },
+        {
+          "wall_s": 1.2883592501748353,
+          "Optimization": 0.16,
+          "Translation": 0.009,
+          "Submitting Smt Query": 0.002,
+          "Solve": 0.03
+        }
+      ]
+    },
+    {
+      "depth": 20,
+      "share_smt": 0,
+      "query_dump_bytes": 7340401,
+      "median": {
+        "wall_s": 9.780570749891922,
+        "Optimization": 0.155,
+        "Translation": 0.008,
+        "Submitting Smt Query": 8.417,
+        "Solve": 0.027
+      },
+      "samples": [
+        {
+          "wall_s": 9.780570749891922,
+          "Optimization": 0.155,
+          "Translation": 0.008,
+          "Submitting Smt Query": 8.417,
+          "Solve": 0.023
+        },
+        {
+          "wall_s": 9.801313583971933,
+          "Optimization": 0.159,
+          "Translation": 0.008,
+          "Submitting Smt Query": 8.495,
+          "Solve": 0.03
+        },
+        {
+          "wall_s": 9.708712833933532,
+          "Optimization": 0.146,
+          "Translation": 0.008,
+          "Submitting Smt Query": 8.412,
+          "Solve": 0.027
+        }
+      ]
+    },
+    {
+      "depth": 20,
+      "share_smt": 1,
+      "query_dump_bytes": 931,
+      "median": {
+        "wall_s": 1.3075218331068754,
+        "Optimization": 0.15,
+        "Translation": 0.009,
+        "Submitting Smt Query": 0.002,
+        "Solve": 0.03
+      },
+      "samples": [
+        {
+          "wall_s": 1.3236734168604016,
+          "Optimization": 0.149,
+          "Translation": 0.008,
+          "Submitting Smt Query": 0.003,
+          "Solve": 0.03
+        },
+        {
+          "wall_s": 1.3075218331068754,
+          "Optimization": 0.153,
+          "Translation": 0.009,
+          "Submitting Smt Query": 0.002,
+          "Solve": 0.029
+        },
+        {
+          "wall_s": 1.3059171251952648,
+          "Optimization": 0.15,
+          "Translation": 0.009,
+          "Submitting Smt Query": 0.002,
+          "Solve": 0.031
+        }
+      ]
+    }
+  ],
+  "notes": "Depths 16 and 20 completed. The separate depth-24 dump timed out after 180 seconds; its unrecorded timing samples are excluded."
+}

--- a/Benchmarks/shared_emission.py
+++ b/Benchmarks/shared_emission.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Compare the same build with SMT sharing off/on; emit reproducible JSON.
+
+Run from the repository root after `lake build Blaster`:
+  python3 Benchmarks/shared_emission.py --depths 16 20 24 --repeat 3
+The wall time includes a fresh Lean process. Phase times exclude startup.
+Query sizes come from a separate dump-only run, so dumping is not timed.
+"""
+import argparse
+import json
+import os
+import signal
+from pathlib import Path
+import re
+import statistics
+import subprocess
+import tempfile
+import time
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--depths', nargs='+', type=int, default=[16, 20])
+parser.add_argument('--repeat', type=int, default=3)
+parser.add_argument('--skip-dump', action='store_true', help='Time large queries without generating a separate text dump')
+parser.add_argument('--share-smt', nargs='+', type=int, choices=[0, 1], default=[0, 1])
+parser.add_argument('--timeout', type=float, default=300)
+parser.add_argument('--output', type=Path, default=Path('Benchmarks/shared-emission-results.json'))
+args = parser.parse_args()
+if args.repeat < 1 or any(d < 1 for d in args.depths):
+    parser.error('repeat and depths must be positive')
+root = Path(__file__).resolve().parents[1]
+prefix = (root / 'Benchmarks/SharedEmission.lean').read_text()
+phase_re = re.compile(r'\[End\]: (.+?) \(([0-9.]+)s\)')
+def run(command, **kwargs):
+    """Bound the whole Lake/Lean/solver process tree, including on timeout."""
+    timeout = kwargs.pop('timeout')
+    capture = kwargs.pop('capture_output', False)
+    if capture:
+        kwargs['stdout'] = subprocess.PIPE
+        kwargs['stderr'] = subprocess.PIPE
+    with subprocess.Popen(command, start_new_session=True, **kwargs) as process:
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except BaseException:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+            raise
+        return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+metadata = {
+    'base_commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=root, text=True).strip(),
+    'lean': subprocess.check_output(['lake', 'env', 'lean', '--version'], cwd=root, text=True).strip(),
+    'z3': subprocess.check_output(['z3', '--version'], text=True).strip(),
+    'repeat': args.repeat,
+}
+rows = []
+def checkpoint():
+    args.output.write_text(json.dumps({**metadata, 'rows': rows}, indent=2) + '\n')
+
+with tempfile.TemporaryDirectory(prefix='blaster-emission-') as tmp:
+    source = Path(tmp) / 'Case.lean'
+    for depth in args.depths:
+        for shared in args.share_smt:
+            samples = []
+            row = {'depth': depth, 'share_smt': shared, 'query_dump_bytes': None,
+                   'samples': samples}
+            rows.append(row)
+            for _ in range(args.repeat):
+                source.write_text(prefix + f'\n#blaster (verbose: 1) (share-smt: {shared}) (timeout: 10)\n'
+                                  f'  [∀ x : Int, 0 ≤ x → emissionChain% {depth} x]\n')
+                start = time.monotonic()
+                result = run(['lake', 'env', 'lean', str(source)], cwd=root,
+                                        capture_output=True, text=True, timeout=args.timeout)
+                wall = time.monotonic() - start
+                output = result.stdout + result.stderr
+                if result.returncode or '✅ Valid' not in output:
+                    raise RuntimeError(output)
+                phases = {name: float(value) for name, value in phase_re.findall(output)}
+                samples.append({'wall_s': wall, **phases})
+                row['median'] = {key: statistics.median(sample[key] for sample in samples) for key in samples[0]}
+                checkpoint()
+            if args.skip_dump:
+                print(json.dumps(row), flush=True)
+                continue
+            source.write_text(prefix + f'\n#blaster (share-smt: {shared}) (only-smt-lib: 1) (dump-smt-lib: 1)\n'
+                              f'  [∀ x : Int, 0 ≤ x → emissionChain% {depth} x]\n')
+            dump_file = Path(tmp) / 'query.txt'
+            with dump_file.open('wb') as output:
+                result = run(['lake', 'env', 'lean', str(source)], cwd=root,
+                                        stdout=output, stderr=subprocess.PIPE, timeout=args.timeout)
+            if result.returncode:
+                raise RuntimeError(result.stderr.decode() + dump_file.read_text()[-2000:])
+            marker = b'Smt Query:\n'
+            with dump_file.open('rb') as dump:
+                while (line := dump.readline()) and line != marker:
+                    pass
+                if line != marker:
+                    raise RuntimeError('SMT dump marker missing')
+                query_bytes = dump_file.stat().st_size - dump.tell()
+            row['query_dump_bytes'] = query_bytes
+            checkpoint()
+            print(json.dumps(row), flush=True)

--- a/Blaster/Command/Options.lean
+++ b/Blaster/Command/Options.lean
@@ -57,6 +57,10 @@ structure BlasterOptions where
   /-- When set to `true`, dump the smt query to stdout. -/
   dumpSmtLib : Bool := false
 
+  /-- When set to `true`, emit duplicated subterms of large queries as SMT
+      `let` bindings instead of duplicated text (see `SmtTerm.shareLets`). -/
+  shareSmt : Bool := true
+
   /-- When set to `true`, generate the counterexample produced for a falsified theorem when
   the backend SMT solver is invoked. -/
   generateCex : Bool := true

--- a/Blaster/Command/Syntax.lean
+++ b/Blaster/Command/Syntax.lean
@@ -16,6 +16,7 @@ Options:
   - `only-smt-lib`: only translating unsolved goals to smt-lib without invoking the backend solver (default: 0)
   - `only-optimize`: only perform optimization on lean specification and do not translate to smt-lib (default: 0)
   - `dump-smt-lib`: display the smt lib query to stdout (default: 0)
+  - `share-smt`: emit duplicated subterms as SMT let bindings instead of duplicated text (default: 1)
   - `random-seed`: seed for the random number generator (default: none)
   - `gen-cex`: generate counterexample for falsified theorems (default: 1)
   - `solve-result`: specify the expected result from the #blaster command, i.e.,
@@ -34,6 +35,7 @@ syntax "(verbose:" num ")" : solveOption
 syntax "(only-smt-lib:" num ")" : solveOption
 syntax "(only-optimize:" num ")" : solveOption
 syntax "(dump-smt-lib:" num ")" : solveOption
+syntax "(share-smt:" num ")" : solveOption
 syntax "(gen-cex:" num ")" : solveOption
 syntax "(solve-result:" num ")" : solveOption
 syntax "(max-depth:" num ")" : solveOption
@@ -87,6 +89,14 @@ def parseDumpSmt (sOpts : BlasterOptions) : TSyntax `solveOption → m BlasterOp
       | _ => throwUnsupportedSyntax
   | _ => return sOpts
 
+def parseShareSmt (sOpts : BlasterOptions) : TSyntax `solveOption → m BlasterOptions
+  | `(solveOption| (share-smt: $n:num)) =>
+      match n.getNat with
+      | 0 => return { sOpts with shareSmt := false }
+      | 1 => return { sOpts with shareSmt := true }
+      | _ => throwUnsupportedSyntax
+  | _ => return sOpts
+
 def parseGenCex (sOpts : BlasterOptions) : TSyntax `solveOption → m BlasterOptions
   | `(solveOption| (gen-cex: $n:num)) =>
       match n.getNat with
@@ -119,6 +129,7 @@ def parseSolveOption (sOpts : BlasterOptions) (opt : TSyntax `solveOption) : m B
   let sOpts ← parseSmtLib sOpts opt
   let sOpts ← parseOptimize sOpts opt
   let sOpts ← parseDumpSmt sOpts opt
+  let sOpts ← parseShareSmt sOpts opt
   let sOpts ← parseGenCex sOpts opt
   let sOpts ← parseSolveResult sOpts opt
   let sOpts ← parseMaxDepth sOpts opt

--- a/Blaster/Smt/Env.lean
+++ b/Blaster/Smt/Env.lean
@@ -2,6 +2,7 @@ import Lean
 import Blaster.Command.Options
 import Blaster.Optimize.Env
 import Blaster.Smt.EmitCommand
+import Blaster.Smt.ShareLet
 
 open Lean Meta Blaster.Optimize Blaster.Options
 
@@ -211,6 +212,7 @@ def isSmtProcSet : TranslateEnvT Bool :=
     are NOT expected to produce any output.
 -/
 partial def trySubmitCommand! (c : SmtCommand) (checkSuccess := true) : TranslateEnvT Unit := do
+  let c := if (← get).optEnv.options.solverOptions.shareSmt then c.shareLets else c
   storeCommand c
   if !(← isSmtProcSet) then return ()
   c.emit

--- a/Blaster/Smt/ShareLet.lean
+++ b/Blaster/Smt/ShareLet.lean
@@ -1,0 +1,230 @@
+import Lean.Util.ShareCommon
+import Blaster.Smt.Syntax
+
+/-!
+# Sharing-preserving SMT emission (SharingBlowup Pathology A)
+
+`SmtTerm` values are DAGs in memory (`translateCache` dedups), but the
+printers (`toString`/`emit`) walk the TREE: query text doubles per sharing
+level. `SmtTerm.shareLets` binds every subterm that occurs ≥ 2 times (by
+pointer identity, after `Lean.ShareCommon.shareCommon`) and prints as
+≥ `minSize` nodes in an SMT `(let ((s e)) …)` prefix. Z3 parses `let` by
+substitution into its internally hash-consed AST, so the solver side is
+unaffected (measured flat Solve times in Tests/IssuesToSolve/SharingBlowup.lean).
+
+v1 scoping rule (conservative): a subterm mentioning ANY symbol bound
+anywhere inside the term (forall/exists/lambda/let binders) is never lifted —
+it might not be closed at the root. Goals are skolemized before translation,
+so the validator/BMC shapes are quantifier-free where the blowup lives.
+
+All walks are pointer-keyed (`ptrAddrUnsafe`): structural hashing/equality on
+`SmtTerm` would itself walk the tree and reintroduce the exponential cost.
+-/
+
+namespace Blaster.Smt
+
+/-- Default minimum print-size (in nodes) for a shared subterm to earn a
+    `let` binding — below it, duplicated text is cheaper than the binding. -/
+def shareLetsMinSize : Nat := 16
+
+/-- Saturation cap for subterm size accounting (sizes only gate the
+    `minSize` threshold; exact big values are useless). -/
+private def sizeCap : Nat := 100000
+
+private def identSymbol : SmtQualifiedIdent → SmtSymbol
+  | .SimpleIdent nm => nm
+  | .QualifiedIdent nm _ => nm
+
+/-- SMT identifier identity is independent of the Lean symbol constructor.
+    Both representations can print the same identifier (Issue232). -/
+private def symbolKey : SmtSymbol → String
+  | .NormalSymbol s => s
+  | .ReservedSymbol s =>
+      -- A quoted SMT token and its unquoted spelling denote the same name.
+      if s.startsWith "|" && s.endsWith "|" && s.length ≥ 2 then
+        String.mk ((s.toList.drop 1).dropLast)
+      else s
+
+/-! ## Pass 0 — collect binder symbols and all used symbol strings -/
+
+private structure ScanSt where
+  visited : Std.HashSet USize := ∅
+  bound   : Std.HashSet String := ∅
+  used    : Std.HashSet String := ∅
+
+private def scanSym (s : SmtSymbol) : StateM ScanSt Unit :=
+  modify fun st => { st with used := st.used.insert (symbolKey s) }
+
+private def scanBinder (s : SmtSymbol) : StateM ScanSt Unit := do
+  scanSym s
+  modify fun st => { st with bound := st.bound.insert (symbolKey s) }
+
+private unsafe def scanTerm : SmtTerm → StateM ScanSt Unit
+  | t => do
+    let p := ptrAddrUnsafe t
+    if (← get).visited.contains p then return ()
+    modify fun st => { st with visited := st.visited.insert p }
+    match t with
+    | .SmtIdent nm => scanSym (identSymbol nm)
+    | .AppTerm nm args => do
+        scanSym (identSymbol nm)
+        args.forM scanTerm
+    | .LetTerm bs body => do
+        bs.forM fun (n, val) => do scanBinder n; scanTerm val
+        scanTerm body
+    | .ForallTerm bs body | .ExistsTerm bs body | .LambdaTerm bs body => do
+        bs.forM fun (n, _) => scanBinder n
+        scanTerm body
+    | .AnnotatedTerm t' annot => do
+        scanTerm t'
+        -- Deliberate asymmetry: this pass DOES descend into `:pattern`
+        -- payloads (so their symbols land in `used`, keeping generated `$sN`
+        -- names from colliding with a trigger term), but `countTerm` and
+        -- `rebuildTerm` below never do — annotation payloads are never
+        -- counted, never lifted into a `let`, and never rewritten in place,
+        -- so a `$sN` reference can never end up inside a `:pattern`/`:named`.
+        annot.forM fun
+          | .Pattern ps => ps.forM scanTerm
+          | .Named n => scanSym n
+          | .Qid n => scanSym n
+    | _ => return ()
+
+/-! ## Pass 1 — per-pointer occurrence count, taint, saturating size -/
+
+private structure CountSt where
+  counts  : Std.HashMap USize Nat := ∅
+  tainted : Std.HashMap USize Bool := ∅
+  sizes   : Std.HashMap USize Nat := ∅
+
+/-- Returns `(tainted, size)`. Counts every arrival; recurses only on the
+    first — O(DAG). Binder nodes and annotated nodes are self-tainted (never
+    shared themselves); their untainted subterms remain shareable. -/
+private unsafe def countTerm (bound : Std.HashSet String) :
+    SmtTerm → StateM CountSt (Bool × Nat)
+  | t => do
+    let p := ptrAddrUnsafe t
+    if let some n := (← get).counts.get? p then
+      modify fun st => { st with counts := st.counts.insert p (n + 1) }
+      let st ← get
+      return (st.tainted.getD p true, st.sizes.getD p 1)
+    modify fun st => { st with counts := st.counts.insert p 1 }
+    let (tainted, size) ← do
+      match t with
+      | .NumTerm _ | .DecTerm _ | .BoolTerm _ | .BinTerm _ | .HexTerm _ | .StrTerm _ =>
+          pure (false, 1)
+      | .SmtIdent nm => pure (bound.contains (symbolKey (identSymbol nm)), 1)
+      | .AppTerm nm args => do
+          let mut tainted := bound.contains (symbolKey (identSymbol nm))
+          let mut size := 1
+          for a in args do
+            let (ta, sa) ← countTerm bound a
+            tainted := tainted || ta
+            size := Nat.min sizeCap (size + sa)
+          pure (tainted, size)
+      | .LetTerm bs body => do
+          let mut size := 1
+          for (_, val) in bs do
+            let (_, sv) ← countTerm bound val
+            size := Nat.min sizeCap (size + sv)
+          let (_, sb) ← countTerm bound body
+          pure (true, Nat.min sizeCap (size + sb))
+      | .ForallTerm _ body | .ExistsTerm _ body | .LambdaTerm _ body => do
+          let (_, sb) ← countTerm bound body
+          pure (true, Nat.min sizeCap (sb + 1))
+      | .AnnotatedTerm t' _ => do
+          let (_, st') ← countTerm bound t'
+          pure (true, Nat.min sizeCap (st' + 1))
+    modify fun st =>
+      { st with tainted := st.tainted.insert p tainted, sizes := st.sizes.insert p size }
+    return (tainted, size)
+
+/-! ## Pass 2 — rebuild with `let` references, bindings in dependency order -/
+
+private structure BuildSt where
+  built    : Std.HashMap USize SmtTerm := ∅
+  bindings : Array (SmtSymbol × SmtTerm) := #[]
+  nextIdx  : Nat := 0
+
+/-- Next `$sN` not colliding with any symbol already in the term. Bounded
+    probe: at most `used.size + 1` candidates can collide. -/
+private def freshSym (used : Std.HashSet String) : StateM BuildSt SmtSymbol := do
+  let start := (← get).nextIdx
+  for i in [start : start + used.size + 1] do
+    if !used.contains s!"$s{i}" then
+      modify fun st => { st with nextIdx := i + 1 }
+      return .NormalSymbol s!"$s{i}"
+  -- Unreachable by pigeonhole (at most `used.size` of the `used.size + 1`
+  -- candidates above can collide) — a total fallback would have to return a
+  -- name that might collide, which is worse than crashing on a broken invariant.
+  panic! "freshSym: pigeonhole exhausted"
+
+private unsafe def rebuildTerm (cst : CountSt) (used : Std.HashSet String)
+    (minSize : Nat) : SmtTerm → StateM BuildSt SmtTerm
+  | t => do
+    let p := ptrAddrUnsafe t
+    if let some r := (← get).built.get? p then return r
+    let node ← match t with
+      | .AppTerm nm args =>
+          pure (SmtTerm.AppTerm nm (← args.mapM (rebuildTerm cst used minSize)))
+      | .LetTerm bs body =>
+          pure (SmtTerm.LetTerm
+            (← bs.mapM fun (n, val) => do pure (n, ← rebuildTerm cst used minSize val))
+            (← rebuildTerm cst used minSize body))
+      | .ForallTerm bs body =>
+          pure (SmtTerm.ForallTerm bs (← rebuildTerm cst used minSize body))
+      | .ExistsTerm bs body =>
+          pure (SmtTerm.ExistsTerm bs (← rebuildTerm cst used minSize body))
+      | .LambdaTerm bs body =>
+          pure (SmtTerm.LambdaTerm bs (← rebuildTerm cst used minSize body))
+      | .AnnotatedTerm t' annot =>
+          pure (SmtTerm.AnnotatedTerm (← rebuildTerm cst used minSize t') annot)
+      | leaf => pure leaf
+    let share := cst.counts.getD p 0 ≥ 2
+              && !(cst.tainted.getD p true)
+              && cst.sizes.getD p 0 ≥ minSize
+    let r ← if share then do
+        let sym ← freshSym used
+        modify fun st => { st with bindings := st.bindings.push (sym, node) }
+        pure (SmtTerm.SmtIdent (.SimpleIdent sym))
+      else
+        pure node
+    modify fun st => { st with built := st.built.insert p r }
+    return r
+
+private unsafe def shareLetsUnsafe (t : SmtTerm) (minSize : Nat) : SmtTerm :=
+  -- shareCommon guarantees maximal pointer sharing even for structurally
+  -- equal subterms translation happened to build separately.
+  let t := Lean.ShareCommon.shareCommon t
+  let (_, scan) := (scanTerm t).run {}
+  let (_, cst) := (countTerm scan.bound t).run {}
+  let (body, bst) := (rebuildTerm cst scan.used minSize t).run {}
+  if bst.bindings.isEmpty then t
+  else
+    -- bindings are recorded in postorder (dependencies first). Each gets its
+    -- OWN single-binding `let` (nested, not one flat group), BECAUSE an SMT
+    -- `let` group is parallel — bindings in one group cannot reference each
+    -- other — so a later (shallower, dependent) binding must sit in the BODY
+    -- of an earlier (deeper, depended-upon) one's `let`, never alongside it.
+    bst.bindings.foldr (init := body) fun b acc => .LetTerm #[b] acc
+
+/-- Bind every subterm occurring ≥ 2 times (pointer identity after
+    `shareCommon`) and printing as ≥ `minSize` nodes in an SMT
+    `(let ((s e)) …)` prefix, so emitted text is DAG-sized, not tree-sized.
+    Subterms mentioning a symbol bound anywhere inside `t` are never lifted.
+    Sound because an SMT `let` is definitionally its substituted body — the
+    term-level `unsafe` below makes this safe constant OPAQUE to the kernel
+    (no unfolding), implemented by the `unsafe` walker; it does not change
+    what the function computes. -/
+def SmtTerm.shareLets (t : SmtTerm) (minSize : Nat := shareLetsMinSize) : SmtTerm :=
+  unsafe shareLetsUnsafe t minSize
+
+/-- Apply `SmtTerm.shareLets` to the commands whose term payloads can blow
+    up: asserts, define-fun bodies, and each body of a mutually recursive
+    define-funs-rec block. -/
+def SmtCommand.shareLets : SmtCommand → SmtCommand
+  | .assertTerm t => .assertTerm t.shareLets
+  | .defineFun isRec nm args rt body => .defineFun isRec nm args rt body.shareLets
+  | .defineFunsRec decls bodies => .defineFunsRec decls (bodies.map (·.shareLets))
+  | c => c
+
+end Blaster.Smt

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -37,3 +37,5 @@ import Tests.FixedIssues.Issue225
 import Tests.FixedIssues.Issue226
 import Tests.FixedIssues.Issue227
 import Tests.FixedIssues.Issue228
+import Tests.FixedIssues.Issue231
+import Tests.FixedIssues.Issue232

--- a/Tests/FixedIssues/Issue231.lean
+++ b/Tests/FixedIssues/Issue231.lean
@@ -1,0 +1,133 @@
+import Blaster
+
+/-!
+# Unit tests for SmtTerm.shareLets (SharingBlowup Pathology A)
+
+`shareLets` binds pointer-shared subterms as SMT `(let …)` prefixes so query
+TEXT is DAG-sized. Tests are structural (substring/length asserts), not full
+pinned dumps — printer whitespace must stay free to change.
+-/
+
+namespace Tests.Issue231
+
+open Blaster.Smt
+
+private def v (s : String) : SmtTerm := .SmtIdent (.SimpleIdent (.NormalSymbol s))
+private def add (a b : SmtTerm) : SmtTerm :=
+  .AppTerm (.SimpleIdent (.ReservedSymbol "+")) #[a, b]
+private def ge0 (a : SmtTerm) : SmtTerm :=
+  .AppTerm (.SimpleIdent (.ReservedSymbol "<=")) #[.NumTerm 0, a]
+
+/-- `chain n` = the dupChain shape: level 0 = x+x, level i+1 = level_i + level_i.
+    Linear as a DAG, `2^(n+1)` leaves as a tree. -/
+private def chain : Nat → SmtTerm
+  | 0 => add (v "x") (v "x")
+  | n + 1 => let c := chain n; add c c
+
+-- 1. Depth 20: tree text is ≥ 2^21 chars; shared text must be tiny and linear.
+#guard (toString ((ge0 (chain 20)).shareLets (minSize := 1))).length < 2000
+
+-- 1b. Same, at the DEFAULT minSize (16, not the artificially low 1 above) —
+--     measured 578 chars; bound gives ~2× headroom.
+#guard (toString ((ge0 (chain 20)).shareLets)).length < 1200
+
+-- 2. Sharing fires: bindings appear, with the generated `$s` prefix.
+#guard ((toString ((ge0 (chain 3)).shareLets (minSize := 1))).splitOn "(let ").length > 2
+#guard ((toString ((ge0 (chain 3)).shareLets (minSize := 1))).splitOn "$s0").length > 1
+
+-- 3. minSize threshold: duplicated-but-small subterms stay inline (chain 2's
+--    largest shareable node is 7 nodes < the default 16).
+#guard toString ((ge0 (chain 2)).shareLets) == toString (ge0 (chain 2))
+
+-- 4. Taint: a duplicated subterm mentioning a quantifier-bound symbol is NOT
+--    lifted — output is textually unchanged.
+private def y : SmtTerm := v "y"
+private def boundDup : SmtTerm :=
+  .ForallTerm #[(.NormalSymbol "y", .SymbolSort (.NormalSymbol "Int"))]
+    (add (add y y) (add y y))
+#guard toString (boundDup.shareLets (minSize := 1)) == toString boundDup
+
+-- 5. Untainted subterm UNDER a binder is lifted above it (it mentions no bound
+--    symbol, so binding it at the root is legal).
+private def freeDupUnderBinder : SmtTerm :=
+  .ForallTerm #[(.NormalSymbol "y", .SymbolSort (.NormalSymbol "Int"))]
+    (add (add (v "x") (v "x")) (add (v "x") (v "x")))
+#guard ((toString (freeDupUnderBinder.shareLets (minSize := 1))).splitOn "(let ").length > 1
+
+/-- Collect the binder symbols of the nested-`let` prefix, outermost first. -/
+private def letSpine : SmtTerm → Array SmtSymbol
+  | .LetTerm bs body => bs.map (·.1) ++ letSpine body
+  | _ => #[]
+
+-- 6. Freshness: an existing `$s0` symbol pushes generated names past it — no
+--    generated `let` may ever BIND the pre-existing `$s0` symbol. Checked
+--    structurally (via `letSpine`), independent of printer whitespace and of
+--    the single-binding-per-group shape `shareLets` happens to emit today.
+private def collide : SmtTerm := add (add (v "$s0") (v "$s0")) (add (v "$s0") (v "$s0"))
+#guard !((letSpine (collide.shareLets (minSize := 1))).contains (.NormalSymbol "$s0"))
+
+-- 7. SmtCommand.shareLets rewrites assert, define-fun, and define-funs-rec
+--    bodies (default minSize 16: chain 5's top two levels are 63- and
+--    31-node duplicates), and leaves other commands alone.
+#guard ((toString (SmtCommand.shareLets (.assertTerm (ge0 (chain 5))))).splitOn "(let ").length > 2
+
+private def defineFunCmd : SmtCommand :=
+  .defineFun false (.NormalSymbol "f") #[] (.SymbolSort (.NormalSymbol "Int")) (ge0 (chain 5))
+#guard ((toString (SmtCommand.shareLets defineFunCmd)).splitOn "(let ").length > 2
+
+-- Cross-body pointer aliasing of `sharedBody` is irrelevant here — each body
+-- is `shareLets`'d independently (its own `shareCommon` pass, its own
+-- counters), so one body's sharing can't leak into another's. What matters is
+-- that EACH body internally carries the 63-/31-node chain-5 duplicates, and
+-- that EVERY body in the array actually gets visited (not just the first).
+-- `#[]` decls are irrelevant to the transform itself — real emission
+-- requires `decls.size == bodies.size`, but this is a transform unit test.
+private def sharedBody : SmtTerm := ge0 (chain 5)
+private def defineFunsRecCmd : SmtCommand :=
+  .defineFunsRec #[] #[sharedBody, sharedBody]
+#guard match SmtCommand.shareLets defineFunsRecCmd with
+  | .defineFunsRec _ bs => bs.all (fun b => (letSpine b).size ≥ 2)
+  | _ => false
+
+#guard toString (SmtCommand.shareLets .checkSat) == toString SmtCommand.checkSat
+
+-- 8. Nesting order: `$s1`'s definition references `$s0`, so `$s0`'s `let` must
+--    be the OUTER one (i.e. earlier in the spine) — an inner binding's
+--    definition is evaluated outside its own let, so a reversed nesting
+--    leaves `$s0` unbound where `$s1` is defined. Checked structurally via
+--    `letSpine` position, independent of printer whitespace.
+private def chain3Spine : Array SmtSymbol := letSpine ((ge0 (chain 3)).shareLets (minSize := 1))
+private def s0Idx : Option Nat := chain3Spine.idxOf? (.NormalSymbol "$s0")
+private def s1Idx : Option Nat := chain3Spine.idxOf? (.NormalSymbol "$s1")
+#guard s0Idx.isSome && s1Idx.isSome
+#guard match s0Idx, s1Idx with
+  | some i0, some i1 => i0 < i1
+  | _, _ => false
+
+-- End-to-end checks keep the residual duplicated after Lean let expansion.
+-- The two settings must give the same verdict; the large rung exercises
+-- the default sharing path without emitting an exponential query in CI.
+open Lean in
+macro "issue231Chain%" n:num seed:term : term => do
+  let depth := n.getNat
+  if depth == 0 then Macro.throwError "depth must be positive"
+  let ids := (Array.range depth).map fun i => mkIdent (Name.mkSimple s!"a{i}")
+  let mut e : Term ← `(0 ≤ $(ids[depth-1]!))
+  for i in (List.range depth).reverse do
+    let v : Term ← if i == 0 then `(($seed : Int) + $seed)
+      else `($(ids[i-1]!) + $(ids[i-1]!))
+    e ← `(let $(ids[i]!) := $v; $e)
+  return e
+
+#blaster (share-smt: 0) (timeout: 5)
+  [∀ x : Int, 0 ≤ x → issue231Chain% 12 x]
+#blaster (share-smt: 1) (timeout: 5)
+  [∀ x : Int, 0 ≤ x → issue231Chain% 12 x]
+#blaster (share-smt: 1) (timeout: 5)
+  [∀ x : Int, 0 ≤ x → issue231Chain% 80 x]
+#blaster (share-smt: 0) (timeout: 5) (gen-cex: 0) (solve-result: 1)
+  [∀ x : Int, issue231Chain% 12 x]
+#blaster (share-smt: 1) (timeout: 5) (gen-cex: 0) (solve-result: 1)
+  [∀ x : Int, issue231Chain% 12 x]
+
+end Tests.Issue231

--- a/Tests/FixedIssues/Issue232.lean
+++ b/Tests/FixedIssues/Issue232.lean
@@ -1,0 +1,41 @@
+import Blaster
+
+namespace Tests.Issue232
+open Blaster.Smt
+
+private def add (a b : SmtTerm) : SmtTerm :=
+  .AppTerm (.SimpleIdent (.ReservedSymbol "+")) #[a, b]
+private def intSort : SortExpr := .SymbolSort (.ReservedSymbol "Int")
+private def ref (s : SmtSymbol) : SmtTerm := .SmtIdent (.SimpleIdent s)
+
+-- The two constructors print the same SMT identifier. Scope analysis must
+-- recognize both orientations for every binder, including let bodies.
+private def keepsScope (binder occurrence : SmtSymbol) : Bool := Id.run do
+  let y := ref occurrence
+  let body := add (add y y) (add y y)
+  let proposition := SmtTerm.AppTerm (.SimpleIdent (.ReservedSymbol "=")) #[body, .NumTerm 0]
+  let terms := #[SmtTerm.ForallTerm #[(binder, intSort)] proposition,
+    .ExistsTerm #[(binder, intSort)] proposition,
+    .LambdaTerm #[(binder, intSort)] body,
+    .LetTerm #[(binder, .NumTerm 1)] body]
+  return terms.all fun t => toString (t.shareLets (minSize := 1)) == toString t
+
+#guard keepsScope (.ReservedSymbol "y") (.NormalSymbol "y")
+#guard keepsScope (.NormalSymbol "y") (.ReservedSymbol "y")
+#guard keepsScope (.ReservedSymbol "|y|") (.NormalSymbol "y")
+#guard keepsScope (.NormalSymbol "y") (.ReservedSymbol "|y|")
+
+-- A quoted free identifier must also reserve the corresponding fresh name.
+private def quotedCollision : SmtTerm :=
+  let x := ref (.NormalSymbol "x")
+  let duplicate := add (add x x) (add x x)
+  add (ref (.ReservedSymbol "|$s0|")) (add duplicate duplicate)
+#guard ((toString (quotedCollision.shareLets (minSize := 1))).splitOn "(let (($s0").length == 1
+
+-- Exercise the default submission path with quantified function arguments.
+#blaster (share-smt: 1) (timeout: 5)
+  [∀ f : Int → Int, (∀ x, f x = x + x) → f 3 = 6]
+#blaster (share-smt: 1) (timeout: 5) (gen-cex: 0) (solve-result: 1)
+  [∀ f : Int → Int, (∀ x, f x = x + x) → f 3 = 7]
+
+end Tests.Issue232


### PR DESCRIPTION
SMT emission expands a shared expression DAG into a repeated text tree. A depth-20 let-chain currently spends about 8.4 seconds submitting a 7.3 MB query, although solving takes about 0.03 seconds.

Preserve repeated terms as dependency-ordered SMT `let` bindings, enabled by default and controlled with `(share-smt: 0|1)`. This adapts the existing local implementation from `de819c39` by RSoulatIOHK and Claude Fable 5. Binder-dependent expressions stay inside their scopes; scope and fresh-name checks canonicalize normal, reserved and quoted representations of the same SMT identifier.

`Tests/FixedIssues/Issue231.lean` covers scaling, binding order, freshness, and positive/negative Blaster results with sharing on/off. `Issue232.lean` covers forall/exists/lambda/let scopes, equivalent symbol representations, quoted-name collisions, and quantified Blaster results. The #232 defect was in the experimental sharing implementation, not the reviewed beta branch. Both issues were opened with minimal examples before these fixes.

Measurements on Apple M2 Max, Lean 4.24.0, Z3 4.15.4, fresh Lean process per sample:

| Depth | Sharing off | Sharing on | Evidence |
|---|---:|---:|---|
| 16 | 1.83 s / 459,121 bytes | 1.29 s / 811 bytes | Median of 3 timings; separate query dumps |
| 20 | 9.78 s / 7,340,401 bytes | 1.31 s / 931 bytes | Median of 3 timings; about 7.5× overall |
| 24 | 132.69 s | 1.28 s | One timing per setting; about 104× overall |

These are synthetic serialization-heavy examples, not a claim about Cardano end-to-end throughput. Timing excludes query dumping. The depth-24 dump timed out and its size is not reported. Raw timing samples and the runner are in `Benchmarks/`; both modes must return `Valid`.

Validation: `lake test` passed on this branch, and on the combined sharing/list stack, using Z3 4.15.2 with the same 30-second process cap as the baseline. Benchmark solver/version differs and is recorded above.

Fixes #231. Fixes #232.
