### PR TITLE
Simplify list append and drop through symbolic tails

### DIFF
--- a/Blaster/Optimize/Rewriting/OptimizeList.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeList.lean
@@ -46,34 +46,34 @@ def optimizeListGet (f : Expr) (u : List Level) (args : Array Expr) : TranslateE
        else return none
      else return none
 
-/-- Apply the following simplification/normalization rules on `List.append` :
-     - List.append [e₁, e₂, ..., eₙ] [x₁, x₂, ..., xₙ] ===> `List.append` [e₁, e₂, ..., eₙ] [x₁, x₂, ..., xₙ]
-
-   Assume that f = Expr.const ``List.append.
-   Optimization are not applied when args.size ≠ 3 (e.g., List.append as HOF)
--/
+/-- Reduce append through its known constructor prefix, preserving the unknown
+    tail and sharing the entire right operand. Also eliminate either empty side.
+    Partially applied functions are left unchanged. -/
 def optimizeListAppend (f : Expr) (u : List Level) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 3 then return ← mkAppNExpr f args
- -- args[0] list sort
- -- args[1] list argument
- -- args[2] list argument
- let op1 := args[0]!
- let op2 := args[1]!
- let op3 := args[2]!
- if let some r ← cstListAppend op1 op2 op3 then return r
- mkApp3Expr f op1 op2 op3
-
-where
-   /-- Given `sort_type`, `op1` and `op2` corresponding to the operands for `List.append`
-        `return some ``List.append` [e₁, e₂, ..., eₙ] [x₁, x₂, ..., xₙ]` when `op1 := [e₁, e₂, ..., eₙ] ∧ op2 := [x₁, x₂, ..., xₙ]`
-   -/
-   @[always_inline, inline]
-   cstListAppend (sort_type : Expr) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :=
-     if let some l1 := isListCtor? op1 then
-       if let some l2 := isListCtor? op2 then
-         listToExpr (List.append l1 l2) u sort_type
-       else return none
-     else return none
+ let sortType := args[0]!
+ let xs := args[1]!
+ let ys := args[2]!
+ if ys.isAppOfArity ``List.nil 1 then return xs
+ let mut tail := xs
+ let mut heads : List Expr := []
+ repeat
+   match tail with
+   | .app (.app (.app (.const ``List.cons _) _) head) rest =>
+       heads := head :: heads
+       tail := rest
+   | _ => break
+ let isNil := tail.isAppOfArity ``List.nil 1
+ if heads.isEmpty then
+   if isNil then return ys
+   return ← mkApp3Expr f sortType xs ys
+ let mut out := ys
+ if !isNil then out ← mkApp3Expr f sortType tail ys
+ let cons ← mkAppExpr (← mkExpr (mkConst ``List.cons u)) sortType
+ for head in heads do
+   out ← mkApp2Expr cons head out
+ setRestart
+ return out
 
 /-- Apply the following simplification/normalization rules on `List.reverseAux` :
      - List.reverseAux [e₁, e₂, ..., eₙ] [x₁, x₂, ..., xₙ] ===> `List.reverseAux` [e₁, e₂, ..., eₙ] [x₁, x₂, ..., xₙ]
@@ -159,34 +159,29 @@ where
        else return none
      else return none
 
-/-- Apply the following simplification/normalization rules on `List.drop` :
-     - List.drop N [e₁, e₂, ..., eₙ] ===> `List.drop` N [e₁, e₂, ..., eₙ]
-
-   Assume that f = Expr.const ``List.drop.
-   Optimization are not applied when args.size ≠ 3 (e.g., List.drop as HOF)
--/
-def optimizeListDrop (f : Expr) (u : List Level) (args : Array Expr) : TranslateEnvT Expr := do
+/-- Drop a literal number of constructors, visiting at most that many nodes.
+    Once the known prefix ends, retain a residual drop over its symbolic tail.
+    Dropping from nil is nil even for a symbolic index. -/
+def optimizeListDrop (f : Expr) (_u : List Level) (args : Array Expr) : TranslateEnvT Expr := do
  if args.size != 3 then return ← mkAppNExpr f args
- -- args[0] list sort
- -- args[1] index argument
- -- args[2] list argument
- let op1 := args[0]!
- let op2 := args[1]!
- let op3 := args[2]!
- if let some r ← cstListDrop op1 op2 op3 then return r
- mkApp3Expr f op1 op2 op3
-
-where
-   /-- Given `sort_type`, `op1` and `op2` corresponding to the operands for `List.reverseAux`
-        `return some ``List.drop` N [e₁, e₂, ..., eₙ]` when `op1 := N ∧ op2 := [e₁, e₂, ..., eₙ]`
-   -/
-   @[always_inline, inline]
-   cstListDrop (sort_type : Expr) (op1 : Expr) (op2 : Expr) : TranslateEnvT (Option Expr) :=
-     if let some n := isNatValue? op1 then
-       if let some l := isListCtor? op2 then
-         listToExpr (List.drop n l) u sort_type
-       else return none
-     else return none
+ let sortType := args[0]!
+ let index := args[1]!
+ let xs := args[2]!
+ if xs.isAppOfArity ``List.nil 1 then return xs
+ let some n := isNatValue? index | return ← mkApp3Expr f sortType index xs
+ let mut remaining := n
+ let mut tail := xs
+ while remaining > 0 do
+   match tail with
+   | .app (.const ``List.nil _) _ => return tail
+   | .app (.app (.app (.const ``List.cons _) _) _) rest =>
+       remaining := remaining - 1
+       tail := rest
+   | _ =>
+       if remaining == n then return ← mkApp3Expr f sortType index xs
+       setRestart
+       return ← mkApp3Expr f sortType (← mkNatLitExpr remaining) tail
+ return tail
 
 /-- Apply the following simplification/normalization rules on `List.replicate` :
      - List.replicate N e ===> `List.replicate N e`

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -37,3 +37,4 @@ import Tests.FixedIssues.Issue225
 import Tests.FixedIssues.Issue226
 import Tests.FixedIssues.Issue227
 import Tests.FixedIssues.Issue228
+import Tests.FixedIssues.Issue233

--- a/Tests/FixedIssues/Issue233.lean
+++ b/Tests/FixedIssues/Issue233.lean
@@ -1,0 +1,36 @@
+import Tests.Utils
+
+namespace Tests.Issue233
+
+example (xs : List Nat) : [1, 2] ++ xs = 1 :: 2 :: xs := rfl
+example (xs : List Nat) : (1 :: 2 :: xs).drop 2 = xs := rfl
+
+#testOptimize ["AppendSymbolicTail"]
+  (∀ xs : List Nat, [1, 2] ++ xs = 1 :: 2 :: xs) ===> True
+#testOptimize ["AppendPartialPrefix"]
+  (∀ xs ys : List Nat, (1 :: 2 :: xs) ++ ys = 1 :: 2 :: (xs ++ ys)) ===> True
+#testOptimize ["AppendNilLeft"]
+  (∀ α : Type, ∀ xs : List α, [] ++ xs = xs) ===> True
+#testOptimize ["AppendNilRight"]
+  (∀ α : Type, ∀ xs : List α, xs ++ [] = xs) ===> True
+#testOptimize ["AppendPolymorphicPrefix"]
+  (∀ α : Type, ∀ x : α, ∀ xs ys : List α, (x :: xs) ++ ys = x :: (xs ++ ys)) ===> True
+#testOptimize ["DropSymbolicTail"]
+  (∀ xs : List Nat, (1 :: 2 :: xs).drop 2 = xs) ===> True
+#testOptimize ["DropPartialPrefix"]
+  (∀ xs : List Nat, (1 :: 2 :: xs).drop 3 = xs.drop 1) ===> True
+#testOptimize ["DropInsidePrefix"]
+  (∀ xs : List Nat, (1 :: 2 :: xs).drop 1 = 2 :: xs) ===> True
+#testOptimize ["DropZeroSymbolic"]
+  (∀ α : Type, ∀ xs : List α, xs.drop 0 = xs) ===> True
+#testOptimize ["DropNilSymbolicIndex"]
+  (∀ α : Type, ∀ n : Nat, ([] : List α).drop n = []) ===> True
+#testOptimize ["DropPastEnd"]
+  (([1, 2] : List Nat).drop 1000000 = []) ===> True
+
+#blaster (only-optimize: 1)
+  [∀ xs : List Nat, ([1, 2] ++ xs).drop 2 = xs]
+#blaster (gen-cex: 0) (solve-result: 1) (timeout: 5)
+  [∀ xs : List Nat, (1 :: 2 :: xs).drop 1 = xs]
+
+end Tests.Issue233

--- a/docs/reviews/beta-2026-09-09.md
+++ b/docs/reviews/beta-2026-09-09.md
@@ -1,0 +1,59 @@
+# Beta branch review — 9 September 2026
+
+Reviewed `beta-lambda-cache-optimization` at `bafdd4f7976037cd7bd8e443df04af096dc5b96e`. Work was done in isolated worktrees; the original checkout and its uncommitted performance experiments were preserved.
+
+Seven PRs are ready for review and one is a draft. The review demonstrated false `Valid` results from constructor proof fields, empty-domain quantifiers and opaque-function contracts. It also found shared-substitution defects and a scope defect in the experimental SMT-sharing code. Existing function-qualifier PRs contain useful fixes but leave polymorphic empty-domain cases unsound; the draft extends those fixes and documents the remaining solver regressions.
+
+Each bug has a minimal example in its issue and a numbered regression module. The first two issues were attached retroactively to PRs already opened before the numbered-test convention was requested; subsequent new issues preceded their fixes. Existing issues #195/#196 were extended with newly demonstrated counterexamples.
+
+| Finding | Evidence and change | PR |
+|---|---|---|
+| [#225](https://github.com/input-output-hk/Lean-blaster/issues/225): proof fields distinguish equal constructors | Lean proves the structure equality by `rfl`; beta validates its negation. Structural comparison now respects proof irrelevance. | [#223](https://github.com/input-output-hk/Lean-blaster/pull/223) |
+| [#226](https://github.com/input-output-hk/Lean-blaster/issues/226): unused quantifiers lose empty domains | `Empty`, `Unit → Empty` and `Inhabited Empty` give kernel-checked counterexamples. Erasure needs a witness; class binders retain membership when nonemptiness is unknown. Stale optimizer local instances are excluded as evidence. | [#224](https://github.com/input-output-hk/Lean-blaster/pull/224) |
+| [#227](https://github.com/input-output-hk/Lean-blaster/issues/227): shared substitution captures variables and ignores slices | 3,600 substitution cases and 40 beta cases are compared with native Lean substitution. Slice offsets and lifting are corrected. No top-level false theorem was established from these helper defects. | [#229](https://github.com/input-output-hk/Lean-blaster/pull/229) |
+| [#228](https://github.com/input-output-hk/Lean-blaster/issues/228): common-factor remainder reaches nonlinear SMT | `Nat.mul_mod_mul_left` justifies the rewrite, including zero cases. The common-factor identity now proves during optimization alone. | [#230](https://github.com/input-output-hk/Lean-blaster/pull/230) |
+| [#196](https://github.com/input-output-hk/Lean-blaster/issues/196): an opaque function fabricates inhabitants | Opaque identity on an empty type gives a kernel-checked counterexample. Result contracts now guard every argument and quantify all generic types, including when a cached function serves unrelated type instances. The separate coercion audit stays open. | [#236](https://github.com/input-output-hk/Lean-blaster/pull/236) |
+| [#231](https://github.com/input-output-hk/Lean-blaster/issues/231): shared SMT expressions expand during emission | Adapt the existing local sharing implementation, with scope regressions, an on/off option and reproducible large-query measurements. | [#234](https://github.com/input-output-hk/Lean-blaster/pull/234) |
+| [#232](https://github.com/input-output-hk/Lean-blaster/issues/232): equivalent SMT symbol representations evade scope checks | Scope and freshness checks compare identifier spelling, including quoted identifiers. This defect was in the experimental sharing implementation, not beta. | [#234](https://github.com/input-output-hk/Lean-blaster/pull/234) |
+| [#233](https://github.com/input-output-hk/Lean-blaster/issues/233): append/drop stop at symbolic tails | Consume known constructors, preserve unknown tails, and visit only the required prefix for drop. | [#235](https://github.com/input-output-hk/Lean-blaster/pull/235) |
+| [#194](https://github.com/input-output-hk/Lean-blaster/issues/194)/[#195](https://github.com/input-output-hk/Lean-blaster/issues/195): function membership and lambda definitions constrain wrong domains | Adapt existing #198/#199 and extend them to generic empty domains. Use forward membership contracts, explicit typing of introduced functions and qualified extensionality witnesses. Numbered regressions pass; older solver tests time out. | Draft [#237](https://github.com/input-output-hk/Lean-blaster/pull/237) |
+
+The stack starts with #223 → #224 → #229 → #230. From #230, #234 → #235 forms the performance stack, and #236 → draft #237 forms the additional SMT soundness stack. No PR has been merged by this review.
+
+## Existing PRs and the function draft
+
+[#198](https://github.com/input-output-hk/Lean-blaster/pull/198) and [#199](https://github.com/input-output-hk/Lean-blaster/pull/199) already address lambda/function qualifier bugs #194/#195. They target `main`, conflict with it, and need to land together or in that order. Their original fixes were adapted to beta's expression and context APIs instead of being independently reinvented.
+
+#199 skips generic argument guards. The review proved that this still fabricates an inhabitant of an empty type from its identity function. Simply restoring those guards is insufficient: a membership iff based only on function behavior is vacuously true on an empty domain, classifies the entire shared SMT arrow carrier as that function type, and lets extensionality collapse unrelated function values. Both new counterexamples are in #195 and `Issue195.lean`.
+
+Draft #237 makes membership a forward typing contract and asserts membership at lambda/closure introduction sites. Its extensionality witnesses depend on all generic type parameters and both functions, and must inhabit the qualified argument domains. This is standard Skolemization, not a claimed new theorem or breakthrough. Guarded recursive-result contracts recover `Issue26.getElem?_zipWith'` without #198's proof workaround. However, several older model-search and recursive-function cases time out. The draft retains their original expectations and proofs and is not ready to merge.
+
+The final full draft run under a 30-second solver-process cap reported timeouts in `Issue9`, `Issue17`, `Issue18`, `Issue26`, `SmtListAppend`, `SmtMatch`, `SmtPredQualifier`, and one `SmtNatMod` case. Not every full-run timeout has been independently attributed to the change. Its focused `Issue194`, `Issue195` and `Issue196` build passes. The next implementation step is to narrow recursive-result contract instantiation and improve model construction, then rerun the full suite.
+
+[#160](https://github.com/input-output-hk/Lean-blaster/pull/160) already provides ancestor-cache reuse, retention diagnostics and Cardano measurements. Its rewrite-cache optimization remains relevant: beta's `findLocalCache` probes only the current context, while hypothesis/equality maps already use the active ancestor set. That PR's numbers include later corrections for profiler overhead and were not treated as new measurements here. It needs a careful rebase onto the current context/cache layout. [#101](https://github.com/input-output-hk/Lean-blaster/pull/101) and [#103](https://github.com/input-output-hk/Lean-blaster/pull/103) cover other list and conditional rewrites; append/drop does not duplicate them.
+
+## Performance evidence
+
+Measurements use an Apple M2 Max, Lean 4.24.0 and Z3 4.15.4. The generated Int let-chain is linear as an in-memory DAG and doubles its printed tree at every level. Each sample starts a fresh Lean process. Query dumps are collected in separate runs, so dumping is excluded from timing. Both settings must report `Valid`; separate negative regressions must report `Falsified`.
+
+| Depth | Sharing off | Sharing on | Dumped query, off → on | Samples per setting |
+|---|---:|---:|---:|---:|
+| 16 | 1.83 s | 1.29 s | 459,121 → 811 bytes | 3; median shown |
+| 20 | 9.78 s | 1.31 s | 7,340,401 → 931 bytes | 3; median shown |
+| 24 | 132.69 s | 1.28 s | Not measured | 1 |
+
+Depth 20 improves about **7.5× overall**. Its median submission time falls from 8.417 s to 0.002 s, while solve time remains around 0.03 s. The depth-24 single-run comparison improves about **104×** overall; submission falls from 131.462 s to 0.002 s. A depth-24 dump-only attempt timed out, and earlier uncheckpointed samples from that attempt are excluded. No depth-24 byte count or three-run median is claimed.
+
+See [benchmark instructions](../../Benchmarks/README.md), [runner](../../Benchmarks/shared_emission.py), [three-run results](../../Benchmarks/shared-emission-results.json), and [depth-24 results](../../Benchmarks/shared-emission-depth24.json). The implementation adapts `de819c39` by RSoulatIOHK and Claude Fable 5 and adds scope/freshness repairs and regression coverage. Existing phase timing already isolated the bottleneck, so new instrumentation in hot optimizer loops was unnecessary.
+
+These measurements concern SMT serialization and do not establish a speedup for Cardano validator preparation, whose optimizer/context retention bottleneck is different. The synthetic depth ladder is a reproducible large-example benchmark, as allowed by the task. Production Cardano runs should use matched CEK budgets and identical dependency revisions, allocator settings and profiling settings.
+
+## Validation and remaining work
+
+`lake test` passes on the stack through #230, on #234, on the combined #234/#235 stack, and on #236. Those runs use Z3 4.15.2 with a uniform `-T:30` process cap, matching the baseline check. Benchmark measurements use Z3 4.15.4 as recorded above. GitHub CI was green for #223/#224/#229/#230 at the last recorded check; newly published PRs may still be running. Draft #237 has the explicitly listed failures above.
+
+The regression files combine ordinary Lean witnesses, positive optimization/proof cases and negative Blaster calls. They do not constitute a formal proof of the entire optimizer or SMT encoding. The coercion portion of #196 remains open, and proof-producing translation is still separate work.
+
+For the next Cardano performance experiment, reuse #160's instrumentation and record unique residual DAG nodes, rewrite-cache probes/hits by ancestor depth, repeated node/context visits and peak retained entries. Measure instrumentation overhead separately. A useful research hypothesis is to cache a rewrite together with the assumptions it actually used, then reuse it wherever those assumptions remain valid, with a kernel-checkable certificate. Ancestor reuse is the simpler first step already implemented in #160; cross-context dependency tracking remains a proposal.
+
+Proof-producing translation has relevant precedent in [Lean-SMT (2025)](https://arxiv.org/abs/2505.15796), which reconstructs SMT proofs as native Lean proofs. That direction fits the existing proof-reconstruction branch and its open PRs #220–#222. [egglog (PLDI 2023)](https://arxiv.org/abs/2304.04332) combines incremental reasoning with equality saturation and is relevant to incremental rewrite analyses, but a replacement optimizer would need separate evidence on memory use, dependent types and proof reconstruction. Neither paper is evidence that an unimplemented design is faster for Cardano.


### PR DESCRIPTION
List append and drop stop when the remaining list is symbolic, even if known constructors determine part or all of the answer. For example, `[1, 2] ++ xs` and `List.drop 2 (1 :: 2 :: xs)` remain unnecessarily opaque.

Consume the known prefix, preserve the symbolic tail, and rebuild only the residual operation. Append reuses its right operand directly when the left prefix ends in nil. Drop visits at most the requested number of known constructors and returns the tail as soon as the count reaches zero.

`Tests/FixedIssues/Issue233.lean` contains kernel-checked witnesses, eleven optimizer regressions for complete/partial prefixes and zero/nil cases, an optimizer-only Blaster composition, and a negative near-miss. Issue #233 was opened with the minimal examples before implementation. Existing #101 and #103 handle different rewrite rules and do not cover these cases.

Validation: `lake build Tests.FixedIssues.Issue233 Tests.Smt.SmtList` and `lake test` passed. The complete stack includes the scope-safe SMT-sharing change; tests use the same Z3 4.15.2 executable and 30-second process cap as the baseline.

Fixes #233.

The [review report](https://github.com/input-output-hk/Lean-blaster/blob/perf/beta-symbolic-list-tails/docs/reviews/beta-2026-09-09.md) records all findings, existing PR overlap, the stack, benchmark evidence and remaining draft work.
