### PR TITLE
Prevent opaque functions from fabricating empty-type inhabitants

### DIFF
--- a/Blaster/Smt/Translate/Application.lean
+++ b/Blaster/Smt/Translate/Application.lean
@@ -752,18 +752,22 @@ def generateUndeclaredFun
     let xsyms := Array.ofFn (λ f : Fin fvars.size => mkReservedSymbol s!"@x{f.val}")
     let mut pargs := (#[] : Array SortExpr)
     let mut co_quantifiers := (#[] : SortedVars)
+    let mut domainQualifiers : Array SmtTerm := #[]
     for h : i in [:fvars.size] do
       let decl ← fvars[i].fvarId!.getEnvDecl
       let st ← translateFunLambdaParamType decl.type termTranslator
       pargs := pargs.push st
       co_quantifiers := co_quantifiers.push (xsyms[i]!, st)
+      domainQualifiers := domainQualifiers.push
+        (← createPredQualifierApp xsyms[i]! (← removeTypeAbbrev decl.type))
     let ret ← translateFunLambdaParamType retType termTranslator
     declareFun s pargs ret
     -- assert codomain constraint
     if fvars.size > 0 then
       let xIds := Array.map (λ v => smtSimpleVarId v) xsyms
       let f_applyTerm := mkSimpleSmtAppN s xIds
-      let forallBody ← createPredQualifierAppAux f_applyTerm retType
+      let codomain ← createPredQualifierAppAux f_applyTerm retType
+      let forallBody := domainQualifiers.foldr impliesSmt codomain
       let qidName := mkQid $ appendSymbol s "cstr"
       let pattern := some #[mkPattern #[f_applyTerm], qidName]
       assertTerm (mkForallTerm none co_quantifiers forallBody pattern)

--- a/Blaster/Smt/Translate/Application.lean
+++ b/Blaster/Smt/Translate/Application.lean
@@ -729,17 +729,11 @@ partial def inferUndeclFunType (ft : Expr) (params : ImplicitParameters) : Trans
       | _ => return e
   visit 0 ft
 
-/-- Given `f` corresponding to either an undeclared class function, an axiom function or an opaque function
-    `params` its corresponding implicit/explicit parameters and `s` its corresponding smt symbol,
-     perform the following:
-       - Let `∀ α₀ → ∀ α₁ ... → αₙ` := inferUndecFunType (← getFunEnvInfo f).type params
-       - declare smt function `declare-fun s ((st₀) .. (stₙ₋₁)) stₙ)`
-       - assert the following proposition to constraint the codomain value:
-          - `(assert (forall ((@x₀ st₀) ... (@xₙ₋₁ stₙ₋₁))
-              (! (@isTypeₙ (s @x₁ ... @xₙ₋₁))
-                 :pattern ((s @x₁ ... @xₙ₋₁))) :qid s_cstr)`
-
-     where ∀ i ∈ [0..n], αᵢ translates to Smt type stᵢ
+/-- Declare an opaque, axiom, or undeclared class function and its result contract.
+The result qualifier is implied by all argument qualifiers. Generic type
+parameters appearing in any qualifier are universally bound: the erased SMT
+function instance can be reused across Lean type instances, and quantifier-local
+types must not escape into a top-level assertion.
 -/
 def generateUndeclaredFun
   (f : Expr) (s : SmtSymbol) (params : ImplicitParameters)
@@ -753,8 +747,10 @@ def generateUndeclaredFun
     let mut pargs := (#[] : Array SortExpr)
     let mut co_quantifiers := (#[] : SortedVars)
     let mut domainQualifiers : Array SmtTerm := #[]
+    let mut qualifierTypes := #[retType]
     for h : i in [:fvars.size] do
       let decl ← fvars[i].fvarId!.getEnvDecl
+      qualifierTypes := qualifierTypes.push decl.type
       let st ← translateFunLambdaParamType decl.type termTranslator
       pargs := pargs.push st
       co_quantifiers := co_quantifiers.push (xsyms[i]!, st)
@@ -769,8 +765,13 @@ def generateUndeclaredFun
       let codomain ← createPredQualifierAppAux f_applyTerm retType
       let forallBody := domainQualifiers.foldr impliesSmt codomain
       let qidName := mkQid $ appendSymbol s "cstr"
-      let pattern := some #[mkPattern #[f_applyTerm], qidName]
-      assertTerm (mkForallTerm none co_quantifiers forallBody pattern)
+      -- The erased function instance may be reused at another generic type.
+      -- Bind every generic in the contract, rather than capturing the first
+      -- translated type or leaving a quantifier-local type free at top level.
+      let genericQuantifiers ← genericArgsToSortedVars (← retrieveGenericArgs qualifierTypes)
+      let pattern := if genericQuantifiers.isEmpty
+        then some #[mkPattern #[f_applyTerm], qidName] else some #[qidName]
+      assertTerm (mkForallTerm none (genericQuantifiers ++ co_quantifiers) forallBody pattern)
     else
       assertTerm (← createPredQualifierAppAux (smtSimpleVarId s) retType)
 

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -37,3 +37,5 @@ import Tests.FixedIssues.Issue225
 import Tests.FixedIssues.Issue226
 import Tests.FixedIssues.Issue227
 import Tests.FixedIssues.Issue228
+
+import Tests.FixedIssues.Issue196

--- a/Tests/FixedIssues/Issue196.lean
+++ b/Tests/FixedIssues/Issue196.lean
@@ -16,4 +16,11 @@ opaque hiddenSecond {α β : Type} (_x : α) (y : β) : β := y
 #blaster (gen-cex: 0) (solve-result: 1) (timeout: 5)
   [∀ β : Type, (∀ y : β, hiddenSecond () y = y) → ∃ _ : β, True]
 
+-- A cached erased function can be used at several unrelated generic domains.
+opaque hiddenNat {α : Type} (_x : α) : Nat := 0
+#blaster [∀ (α β : Type) (x : α) (y : β),
+  Int.ofNat (hiddenNat x) + Int.ofNat (hiddenNat y) ≥ 0]
+#blaster [∀ β : Type, (∀ (α : Type) (x : α), hiddenNat x = 0) →
+  ∀ y : β, hiddenNat y = 0]
+
 end Tests.Issue196

--- a/Tests/FixedIssues/Issue196.lean
+++ b/Tests/FixedIssues/Issue196.lean
@@ -1,0 +1,19 @@
+import Blaster
+
+namespace Tests.Issue196
+
+-- Opaque functions constrain results only on members of their Lean domains.
+opaque hiddenId {α : Type} (x : α) : α := x
+example : ¬ (∀ α : Type, (∀ x : α, hiddenId x = x) → ∃ _ : α, True) := by
+  intro h
+  obtain ⟨x, _⟩ := h Empty (fun x => Empty.elim x)
+  exact Empty.elim x
+#blaster (gen-cex: 0) (solve-result: 1) (timeout: 5)
+  [∀ α : Type, (∀ x : α, hiddenId x = x) → ∃ _ : α, True]
+
+-- Also guard later arguments when an earlier domain is inhabited.
+opaque hiddenSecond {α β : Type} (_x : α) (y : β) : β := y
+#blaster (gen-cex: 0) (solve-result: 1) (timeout: 5)
+  [∀ β : Type, (∀ y : β, hiddenSecond () y = y) → ∃ _ : β, True]
+
+end Tests.Issue196


### PR DESCRIPTION
An opaque identity function `α → α` currently forces `α` to be inhabited in the SMT encoding. Choosing `Empty` gives a kernel-checked counterexample, but beta reports `Valid`.

Guard the result-membership assertion with the membership of every argument, and universally bind all generic types occurring in that contract so reuse does not capture the first type instance. `Tests/FixedIssues/Issue196.lean` includes the minimal counterexample, its ordinary Lean proof, and a second regression checking a later empty argument after an inhabited first domain. Both must report `Falsified`. Two positive regressions check reuse across unrelated generic types and quantifier-local type parameters.

The issue existed as an audit; the concrete reproducer was added before this fix. This addresses the opaque-function part of #196. Its separate coercion-site audit stays open. Existing #198/#199 concern lambda/function membership and do not fix this site.

Validation: the numbered regressions, existing polymorphism/qualifier modules, and `lake test` pass with Z3 4.15.2 under the same 30-second process cap as the baseline.
