### PR TITLE
Measure Cardano preparation separately from proof checking

### DIFF
--- a/Benchmarks/cardano/README.md
+++ b/Benchmarks/cardano/README.md
@@ -1,0 +1,101 @@
+# Cardano preparation benchmarks
+
+These benchmarks isolate the expensive `#prep_uplc` phase on real
+CardanoLedgerApiBlaster scripts. Proof checks are a separate phase. The WSC
+case uses the production CIP-153 `programmableLogicGlobal.flat`, with all
+inputs symbolic at preparation time.
+
+## Recreate the workspaces
+
+`pins.json` records the exact source revisions. The Cardano `7245eb8` and
+PlutusCore WSC `5f2baa2a` revisions are local investigation commits: they were
+not available in either upstream or Anastasia-Labs GitHub histories when
+checked on 2026-09-09. Supply local clones containing these commits. This
+script copies committed source only and applies the small, supplied dependency
+and preparation-telemetry patches. It does not copy dirty source changes.
+
+```sh
+python3 Benchmarks/cardano/prepare_local.py \
+  --root /tmp/cardano-baseline \
+  --blaster /path/to/Lean-blaster \
+  --cardano /path/to/CardanoLedgerApiBlaster \
+  --wsc /path/to/CardanoLedgerApiBlaster-wsc \
+  --plutuscore /path/to/PlutusCoreBlaster \
+  --plutuscore-wsc /path/to/PlutusCoreBlaster-wsc
+```
+
+For a candidate, use a second new output directory and
+`--blaster-rev YOUR_CANDIDATE_COMMIT`. Dependencies build before the script
+returns. Use the same solver executable and environment for both workspaces.
+The helper preserves the libraries' native compilation settings.
+
+## Measure preparation
+
+```sh
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-baseline \
+  --label baseline --repeat 3 --timeout 240 --max-rss-gib 16 \
+  --cases sellnft:1800 minting:1200 paramfeed:10000 governance:9000 global:1600
+```
+
+Run the two arms serially, preferably alternating them. No other build or
+benchmark should be running during a timing comparison. Use `lake build`,
+not a direct `lake env lean` invocation: native elaborator code materially
+changes the performance being measured.
+
+The runner removes only its generated module's compiled outputs before each
+repetition. It records wall time, aggregate descendant RSS sampled every
+0.5 seconds, the output module's size, optimizer milliseconds, final hash-cons
+entry count, allocated context IDs, beta cache size, source hashes, revisions,
+and tracked-patch hashes. RSS is a sampled process-tree estimate, not an OS
+high-water mark. Dependency setup is excluded; module elaboration and teardown
+remain included in wall time. `optimize_ms` ends when `Optimize.main` returns.
+
+`results/LABEL/results.json` is checkpointed during execution. Full build logs
+are kept beside it. The time and memory limits kill only the owned process
+group. A timeout is a censored observation, not a successful preparation.
+
+`--sample` takes one five-second macOS CPU sample after ten seconds. Keep
+these profiling runs separate from unprofiled timing comparisons. The runner
+uses standard-library Python and `ps`; process inspection must be allowed by
+the environment. It does not change allocator settings.
+
+## Check properties against the measured residual
+
+Immediately after preparing one case, run:
+
+```sh
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-baseline \
+  --label global-proof --cases global:1600 --proofs-only \
+  --timeout 240 --max-rss-gib 16
+```
+
+The existing preparation source must exactly match the requested case and
+budget. No preparation is regenerated in this phase. The global check rejects
+the production validator's `SeizeAct` arm with symbolic fields, transaction
+info, purpose and parameter. It does not establish non-vacuity or all global
+validator properties. SellNFT checks the two positive properties and three
+expected counterexamples, including acceptance/non-vacuity. MintingPolicy
+checks its two positive properties and negative control; ParamFeed checks its
+parameter property. Governance checks its first four properties, through
+`invalid_minFeeA_changed`. Each Blaster call has a 30-second solver timeout;
+a separately bounded solver executable can enforce a process-level cap.
+
+Blaster's `Valid` result is its existing trusted solver verdict, not a new
+kernel-checked equivalence between `PrepUPLC.prop` and the CEK interpreter.
+Fuel remains unchanged: CEK exhaustion maps to `State.Error`, so increasing
+fuel changes the checked behavior. A cheap rejection property alone does not
+show that an accepting execution is covered by the bound.
+
+## Experimental flags and evidence
+
+The [review](../../docs/reviews/cardano-preparation-2026-09-09.md) records the
+baseline and explains the rejected prototypes. Archived patches and focused
+tests are under `experiments/`. They are not part of Blaster's imported code.
+The runner's `--retain-constructor-choices`, `--retain-choice-types` and
+`--reduce-before-arguments` flags require the corresponding experimental patch;
+they are not options present in the pinned baseline. Rebuild dependencies after
+applying a patch, before starting any timed run.
+
+Checked-in result JSON uses relative log basenames. Complete logs remain local;
+re-running the harness produces fresh logs. Do not include setup errors,
+interruptions, timeouts or profiling runs in successful-run speedup averages.

--- a/Benchmarks/cardano/experiments/ConstructorChoices.lean
+++ b/Benchmarks/cardano/experiments/ConstructorChoices.lean
@@ -1,0 +1,20 @@
+import Tests.Utils
+
+set_option blaster.hoistConstructorChoices false
+
+namespace Tests.ConstructorChoices
+
+#testOptimize ["KeepChoiceInConstructor"] (norm-result: 1)
+  (fun b : Bool => some (if b then (3 : Nat) else 4)) ===>
+  (fun b : Bool => some (Blaster.dite' (true = b) (fun _ => 3) (fun _ => 4)))
+
+#testOptimize ["ConsumeConstructorChoice"]
+  (∀ b : Bool, (some (if b then (3 : Nat) else 4)).getD 5 = (if b then 3 else 4)) ===> True
+
+#blaster (gen-cex: 0)
+  [∀ b c : Bool, ((if b then (3 : Nat) else 4), (if c then (5 : Nat) else 6)).1 = (if b then 3 else 4)]
+
+#blaster (gen-cex: 0) (solve-result: 1)
+  [∀ b c : Bool, ((if b then (3 : Nat) else 4), (if c then (5 : Nat) else 6)).1 = 3]
+
+end Tests.ConstructorChoices

--- a/Benchmarks/cardano/experiments/DemandReduction.lean
+++ b/Benchmarks/cardano/experiments/DemandReduction.lean
@@ -1,0 +1,20 @@
+import Tests.Utils
+set_option blaster.reduceBeforeArguments true
+namespace Tests.DemandReduction
+
+def countdown : Nat → Nat
+  | 0 => 0
+  | n + 1 => countdown n
+
+def ignore (_ : Nat) : Nat := 7
+
+#testOptimize ["IgnoreUnusedComputation"] (norm-result: 1) (ignore (countdown 100000)) ===> (7 : Nat)
+#testOptimize ["ProjectBeforeFields"]
+  (fun x : Nat => ((x, countdown 100000) : Nat × Nat).1) ===> (fun x : Nat => x)
+#testOptimize ["RecursiveCallStillReduces"] (norm-result: 1) (countdown 100) ===> (0 : Nat)
+#testOptimize ["KeepChildFacts"]
+  (∀ a b c : Prop, (a → b) ∧ (a → c ∧ (a → b))) ===>
+  (∀ a b c : Prop, (a → b) ∧ (a → b ∧ c))
+#blaster (gen-cex: 0) [∀ n : Nat, ignore n = 7]
+#blaster (gen-cex: 0) (solve-result: 1) [∀ n : Nat, ignore n = n]
+end Tests.DemandReduction

--- a/Benchmarks/cardano/experiments/README.md
+++ b/Benchmarks/cardano/experiments/README.md
@@ -1,0 +1,31 @@
+# Rejected preparation experiments
+
+These patches are archived evidence, not enabled code or recommended defaults.
+The review explains each failed gate. Apply one patch at a time to Blaster
+`36c3a15a9fdc9f3237ad376f8d67665e3742d3f8`, then rebuild both Cardano dependency
+sets before measuring. Do not combine these patches.
+
+- `ancestor-candidate.patch`: the first port of PR #160 ancestor lookup. It
+  returns ancestor results directly and fails child-normalization tests. Copy
+  `ancestor-scope-tests.lean` to `Tests/Optimize/CacheReuse/AncestorScopes.lean`
+  before running the full test suite.
+- `pure-candidate.patch`: bounded raw abstraction/substitution memoization.
+  Copy `pure-transform-tests.lean` to
+  `Tests/Optimize/CacheReuse/PureTransforms.lean`. The recorded additional
+  cache counters came from temporary preparation diagnostics; the core patch
+  reproduces the algorithm, while the regular telemetry patch reports the
+  comparable optimizer time and retained node/context counts.
+- `constructor-choices.patch`: opt-in global constructor-choice retention. Use
+  the runner's `--retain-constructor-choices`. `ConstructorChoices.lean` is the
+  focused semantic test; it can be copied under `Tests/Optimize/CacheReuse/`.
+- `demand-candidate.patch`: broad early function/projection reduction. Use
+  `--reduce-before-arguments`. `DemandReduction.lean` contains the focused
+  tests; they pass while real Cardano workloads regress.
+- `selective-candidate.patch`: retain choices for named types/constructors.
+  The recorded scout uses `--retain-choice-types List Prod PlutusCore.Data.Data`.
+  It still regresses global preparation and does not improve the ordinary
+  examples. Its algorithm does not recursively label container element types.
+
+The test names imported by the first two patches are not part of the benchmark
+build targets. For benchmark-only reproduction, their test-import hunks can be
+excluded with `git apply --exclude=Tests/Optimize.lean PATCH`.

--- a/Benchmarks/cardano/experiments/README.md
+++ b/Benchmarks/cardano/experiments/README.md
@@ -29,3 +29,15 @@ sets before measuring. Do not combine these patches.
 The test names imported by the first two patches are not part of the benchmark
 build targets. For benchmark-only reproduction, their test-import hunks can be
 excluded with `git apply --exclude=Tests/Optimize.lean PATCH`.
+
+`replay2-candidate.patch` is the conservative ancestor-replay follow-up. Copy
+`replay2-scope-tests.lean` to
+`Tests/Optimize/CacheReuse/AncestorRenormalization.lean`. It passes the previous
+normalization failures but gives no Cardano speedup. The full-suite arithmetic
+timeout did not reproduce when the module ran alone (both arms pass).
+
+`values-candidate.patch` adds container-aware labels to the selective policy.
+Its scout labels PlutusCore.UPLC.Term.Const, PlutusCore.UPLC.Term.Term,
+PlutusCore.UPLC.CekValue.CekValue, PlutusCore.UPLC.CekValue.Environment and
+PlutusCore.Data.Data. It regresses global preparation. The final scoped-label
+PR removes the earlier global Boolean switch; labels are its only opt-in.

--- a/Benchmarks/cardano/experiments/ancestor-candidate.patch
+++ b/Benchmarks/cardano/experiments/ancestor-candidate.patch
@@ -1,0 +1,187 @@
+diff --git a/Blaster/Optimize/Env/Types.lean b/Blaster/Optimize/Env/Types.lean
+index 6bd7b1ef..0f709946 100644
+--- a/Blaster/Optimize/Env/Types.lean
++++ b/Blaster/Optimize/Env/Types.lean
+@@ -101,6 +101,12 @@ structure OptimizeOptions where
+ 
+   resetOptions : ResetOptions
+ 
++  /-- Parent links for scoped rewrite reuse, adapted from PR #160. A cached
++      equivalence in an active ancestor remains valid under the additional
++      hypotheses of its descendants. Links also survive choice-context reuse. -/
++  parents : HashMap CtxId CtxId := HashMap.emptyWithCapacity 1024
++
++
+ instance : Inhabited OptimizeOptions where
+   default := { normalizeFunCall := true, inFunApp := false, mcDepth := 0, solverOptions := default, resetOptions := default }
+ 
+@@ -861,7 +867,7 @@ def updateGlobalRewriteCache (a : Expr) (b : Expr) (insertIfNew := false) : Tran
+ /-- Update rewrite cache at curCtx with `a := b`. -/
+ @[always_inline, inline]
+ def updateLocalRewriteCache (a : Expr) (b : Expr) (insertIfNew := false) : TranslateEnvT Unit := do
+-  let ⟨_, rewriteCache, _, _, _, _, _, _, _, _, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, rewriteCache, _, _, _, _, _, _, _, _, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   match rewriteCache.get? curCtx with
+   | none =>
+        let refEntry ← IO.mkRef $ (HashMap.emptyWithCapacity 256 : HashMap PtrExpr Expr).insert a b
+@@ -896,7 +902,7 @@ def updateEqualityMap (lhs : Expr) (rhs : Expr) (ctxId : CtxId) : TranslateEnvT
+     newest entry visible in the current context (tag ∈ active). -/
+ @[always_inline, inline]
+ def eqMapFind? (lhs : Expr) : TranslateEnvT (Option Expr) := do
+-  let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
+   if equalityMap.size == 0
+   then return none
+   else ContextMap.findRaw equalityMap active lhs
+@@ -906,7 +912,7 @@ def eqMapFind? (lhs : Expr) : TranslateEnvT (Option Expr) := do
+     proof of the newest entry for `e` whose tag is active in the current context. -/
+ @[always_inline, inline]
+ def hypMapFind? (e : Expr) : TranslateEnvT (Option Expr) := do
+-  let ⟨_, _, _, _, _, _, _, ⟨hypothesisMap, _⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, ⟨hypothesisMap, _⟩, _, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
+   if hypothesisMap.size == 0
+   then return none
+   else ContextMap.findRaw hypothesisMap active e
+@@ -924,7 +930,8 @@ def newCtx : TranslateEnvT CtxScope := do
+    let current := env.optEnv.options.nextCtxId
+    let parent := env.optEnv.options.curCtx
+    (⟨parent, current⟩, {env with optEnv.options.nextCtxId := current + 1, optEnv.options.curCtx := current
+-                                 optEnv.options.active := env.optEnv.options.active.insert current })
++                                 optEnv.options.active := env.optEnv.options.active.insert current
++                                 optEnv.options.parents := env.optEnv.options.parents.insert current parent })
+ 
+ @[always_inline, inline]
+ def setAndCommitCtx (s : CtxScope) : TranslateEnvT Unit :=
+@@ -936,9 +943,9 @@ def setAndCommitCtx (s : CtxScope) : TranslateEnvT Unit :=
+ -/
+ @[always_inline, inline]
+ def endCtx (s : CtxScope) : TranslateEnvT Unit :=
+-  modifyOptEnv fun ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7⟩, o12, o13, o14⟩ =>
++  modifyOptEnv fun ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7, parents⟩, o12, o13, o14⟩ =>
+                    ⟨o1, rewrite.erase s.current, o3, o4, o5, o6, o7, o8, o9, o10,
+-                   ⟨s1, s2, s3, s4, s.parent, s6, active.erase s.current, s7⟩, o12, o13, o14⟩
++                   ⟨s1, s2, s3, s4, s.parent, s6, active.erase s.current, s7, parents⟩, o12, o13, o14⟩
+ 
+ 
+ 
+@@ -954,7 +961,7 @@ def ContextReuseMap.findRaw (m : ContextReuseMap) (e : Expr) (idx : USize) (curC
+ 
+ @[always_inline, inline]
+ def reuseContext? (e : Expr) (idx : USize) : TranslateEnvT (Option CtxReuseScope) := do
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   memCache.contextReuseCache.findRaw e idx curCtx
+ 
+ @[always_inline, inline]
+@@ -1199,7 +1206,7 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
+ 
+ 
+ @[inline] def propagateReuseContext (current : Expr) (next : Expr) (idx : USize) : TranslateEnvT Unit := do
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   match ← memCache.contextReuseCache.findRaw current idx curCtx with
+   | some reuse => updateContextReuseCache next idx reuse
+   | none => return ()
+@@ -1213,7 +1220,7 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
+                     ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12, o13, o14⟩
+ 
+ @[inline] def freeRewriteCacheReuse (e : Expr) (idx : USize) : TranslateEnvT Unit := do
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   match ← memCache.contextReuseCache.findRaw e idx curCtx with
+   | some reuse =>
+       modifyOptEnv
+@@ -1232,11 +1239,25 @@ def findGlobalCache (a : Expr) (env : TranslateEnv) : IO Expr :=
+   | none => return instCacheMiss
+   | some refEntry => return (← refEntry.get).getD a instCacheMiss
+ 
++/-- Look up the nearest active ancestor's cached rewrite. Entries from closed
++    siblings are invisible, and erased cache maps are skipped. This ports the
++    ancestor lookup from #160 onto the reviewed beta stack without its GC or
++    allocator experiments. Returning an ancestor normal form can leave further
++    descendant simplifications available; it must not assume sibling facts. -/
++partial def findAncestorCache (a : Expr) (env : TranslateEnv) : IO Expr := do
++  let o := env.optEnv
++  let rec go (ctx : CtxId) : IO Expr := do
++    if ctx == 0 || o.options.active.contains ctx then
++      if let some refEntry := o.rewriteCache.get? ctx then
++        let v := (← refEntry.get).getD a instCacheMiss
++        if !exprEq v instCacheMiss then return v
++    if ctx == 0 then return instCacheMiss
++    go (o.options.parents.getD ctx 0)
++  go o.options.curCtx
++
+ @[always_inline, inline]
+ def findLocalCache (a : Expr) (env : TranslateEnv) : IO Expr :=
+-  match env.optEnv.rewriteCache.get? env.optEnv.options.curCtx with
+-  | none => return instCacheMiss
+-  | some refEntry => return (← refEntry.get).getD a instCacheMiss
++  findAncestorCache a env
+ 
+ end Blaster.Optimize
+ 
+diff --git a/Blaster/Optimize/OptimizeStack.lean b/Blaster/Optimize/OptimizeStack.lean
+index 84df5eac..0e0aac42 100644
+--- a/Blaster/Optimize/OptimizeStack.lean
++++ b/Blaster/Optimize/OptimizeStack.lean
+@@ -65,8 +65,8 @@ def resetChoiceContext (h : HypsStackContext) (fvars : Array Expr) (lam : Expr)
+   | some scope =>
+        updateContextReuseCache lam idx ⟨scope, fvars⟩
+        modifyOptEnv
+-         fun ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7⟩, o12, o13, o14⟩ =>
+-             ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, scope.parent, s6, active.erase scope.current, s7⟩, o12, o13, o14⟩
++         fun ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7, parents⟩, o12, o13, o14⟩ =>
++             ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, scope.parent, s6, active.erase scope.current, s7, parents⟩, o12, o13, o14⟩
+   | none => return ()
+ 
+ def restoreMVarDecls (optDecls : Option MVarIdDecls) : TranslateEnvT Unit :=
+diff --git a/Blaster/Optimize/Rewriting/OptimizeMatch.lean b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+index c654e50f..abab5e2c 100644
+--- a/Blaster/Optimize/Rewriting/OptimizeMatch.lean
++++ b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+@@ -15,7 +15,7 @@ partial def eraseMatchRhsRewriteCache (mInfo : MatchInfo) : TranslateEnvT Unit :
+     else
+       freeRewriteCacheReuse mInfo.nameExpr (idx - offset)
+       visit (idx + 1) stop offset
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   if (← memCache.contextReuseCache.findRaw mInfo.nameExpr 0 curCtx).isSome then
+     let start := mInfo.getFirstAltPos.toUSize
+     visit start mInfo.arity.toUSize start
+@@ -306,7 +306,7 @@ def reduceMatch? (args : Array Expr) (mInfo : MatchInfo) (resolveArgs := false)
+      go mInfo.getFirstDiscrPos mInfo.getFirstAltPos
+ 
+     resolveArgsWithEqualityStack (args : Array Expr) : TranslateEnvT (Array Expr) := do
+-     let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++     let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
+      let rec visit (idx : Nat) (stop : Nat) (args : Array Expr) : TranslateEnvT (Array Expr) := do
+        if idx ≥ stop then return args
+        else
+@@ -718,7 +718,7 @@ partial def optimizeMatchAlt
+        return .InitOptimizeExpr body :: .MatchAltWaitForExpr reuse.fvars (some reuse.scope) currIdx matchInst :: stack
+   | none =>
+        let alts ← getMatchAlts args mInfo
+-       let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _⟩, _, _, _⟩⟩ ← get
++       let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _, _⟩, _, _, _⟩⟩ ← get
+        let updatedMCtx ← addNotEqPatternToContext args mInfo alts 0 currIdx nextCtxId false
+        forallTelescope alts[currIdx]! fun xs b => do
+          let lhs := b.getAppArgs
+@@ -827,7 +827,7 @@ where
+ 
+   @[always_inline, inline]
+   lastPatternReduction? (mInfo : MatchInfo) (args : Array Expr) : TranslateEnvT (Option MatchElimResult) := do
+-     let ⟨_, _, _, _, _, _, _, _, matchInContext, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++     let ⟨_, _, _, _, _, _, _, _, matchInContext, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
+      let h := (← get).optEnv.matchInContext
+      let alts ← getMatchAlts args mInfo
+      for i in [:alts.size - 1] do
+diff --git a/Tests/Optimize.lean b/Tests/Optimize.lean
+index 200e9bdc..8a10304b 100644
+--- a/Tests/Optimize.lean
++++ b/Tests/Optimize.lean
+@@ -15,3 +15,5 @@ import Tests.Optimize.OptimizeNat
+ import Tests.Optimize.OptimizeProp
+ import Tests.Optimize.OptimizeRecFun
+ import Tests.Optimize.OptimizeUnfold
++
++import Tests.Optimize.CacheReuse.AncestorScopes

--- a/Benchmarks/cardano/experiments/ancestor-scope-tests.lean
+++ b/Benchmarks/cardano/experiments/ancestor-scope-tests.lean
@@ -1,0 +1,54 @@
+import Tests.Utils
+
+open Lean Meta Elab Command Blaster.Optimize
+
+namespace Tests.Optimize.CacheReuse
+
+-- Lifetime/isolation checks for the stateful cache, independent of any solver.
+run_cmd liftTermElabM do
+  let check : TranslateEnvT Unit := do
+    let key ← hashcons (mkConst `cacheProbe)
+    let one ← hashcons (mkRawNatLit 1)
+    let two ← hashcons (mkRawNatLit 2)
+    let parent ← newCtx
+    updateLocalRewriteCache key one
+    let child ← newCtx
+    unless exprEq (← findLocalCache key (← get)) one do
+      throwError "child did not reuse its parent's rewrite"
+    updateLocalRewriteCache key two
+    unless exprEq (← findLocalCache key (← get)) two do
+      throwError "nearest cache entry must win"
+    endCtx child
+    let sibling ← newCtx
+    unless exprEq (← findLocalCache key (← get)) one do
+      throwError "a closed sibling's rewrite escaped its scope"
+    endCtx sibling
+    endCtx parent
+    let other ← newCtx
+    unless exprEq (← findLocalCache key (← get)) instCacheMiss do
+      throwError "a closed parent's rewrite escaped its scope"
+    endCtx other
+    -- Choice scopes can be re-entered, while discarded maps remain misses.
+    let reused ← newCtx
+    updateLocalRewriteCache key two
+    resetChoiceContext (some reused) #[] key 0
+    setAndCommitCtx reused
+    let nested ← newCtx
+    unless exprEq (← findLocalCache key (← get)) two do
+      throwError "re-entered choice scope lost its parent relationship"
+    endCtx nested
+    endCtx reused
+  check.run' (default : TranslateEnv)
+
+-- A child's additional facts still need to simplify the result of an ancestor.
+#blaster (gen-cex: 0)
+  [∀ x y : Nat, x = y → y = 0 → x + 1 = 1]
+#testOptimize ["NestedBranchFacts"]
+  (∀ x y : Nat, (if x = y then (if y = 0 then x + 1 else y + 1) else x + 1) = x + 1) ===> True
+#testOptimize ["SiblingIsolation"]
+  (∀ x : Nat, (if x = 0 then x + 1 else x + 2) =
+    (if x = 0 then 1 else x + 2)) ===> True
+#blaster (gen-cex: 0) (solve-result: 1)
+  [∀ x : Nat, (if x = 0 then x + 1 else x + 2) = 1]
+
+end Tests.Optimize.CacheReuse

--- a/Benchmarks/cardano/experiments/constructor-choices.patch
+++ b/Benchmarks/cardano/experiments/constructor-choices.patch
@@ -1,0 +1,27 @@
+diff --git a/Blaster/Optimize/Rewriting/FunPropagation.lean b/Blaster/Optimize/Rewriting/FunPropagation.lean
+index adea608f..54a805cf 100644
+--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
++++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
+@@ -3,6 +3,12 @@ import Blaster.Optimize.Rewriting.NormalizeMatch
+ import Blaster.Optimize.Rewriting.OptimizeMatch
+ 
+ open Lean Meta Elab
++
++register_option blaster.hoistConstructorChoices : Bool := {
++  defValue := true
++  descr := "Lift conditional and match expressions out of constructor fields. Disable during symbolic preparation to keep independent field choices shared."
++}
++
+ namespace Blaster.Optimize
+ 
+ /-- Given application `f x₁ ... xₙ`, apply the following normalization rules:
+@@ -145,7 +151,8 @@ def funPropagation?
+     @[always_inline, inline]
+     propagate (f : Expr) (n : Name) (args : Array Expr) : TranslateEnvT Bool := do
+       if !(← hasMatchITEArgs args) then return false
+-      else if (← isCtorName n) then return true
++      else if (← isCtorName n) then
++        return blaster.hoistConstructorChoices.get (← getOptions)
+       else if (← allExplicitParamsAreCtor f args (funPropagation := true)) then return true
+       else
+         match n with

--- a/Benchmarks/cardano/experiments/demand-candidate.patch
+++ b/Benchmarks/cardano/experiments/demand-candidate.patch
@@ -1,0 +1,88 @@
+diff --git a/Blaster/Optimize/Basic.lean b/Blaster/Optimize/Basic.lean
+index d92b5c37..fbe489da 100644
+--- a/Blaster/Optimize/Basic.lean
++++ b/Blaster/Optimize/Basic.lean
+@@ -85,8 +85,13 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
+               else optimizeExprAux (.InitOptimizeExpr me :: i_stack)
+ 
+           | Expr.proj n idx s =>
+-              let i_stack' := .ProjWaitForExpr n idx :: i_stack
+-              optimizeExprAux (.InitOptimizeExpr s :: i_stack')
++              if blaster.reduceBeforeArguments.get (← getOptions) then
++                if let some r ← reduceEnvProj? e then
++                  optimizeExprAux (.InitOptimizeExpr r :: i_stack)
++                else
++                  optimizeExprAux (.InitOptimizeExpr s :: .ProjWaitForExpr n idx :: i_stack)
++              else
++                optimizeExprAux (.InitOptimizeExpr s :: .ProjWaitForExpr n idx :: i_stack)
+ 
+           | Expr.bvar .. => throwEnvError "optimizeExpr: unexpected bound variable {e}"
+ 
+@@ -144,6 +149,9 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
+               -- only optimizing match return type and discriminators first
+               setIsAppArg true
+               optimizeExprAux (.MatchChoiceOptimizeDiscrs f args pInfo (mInfo.getFirstDiscrPos - 1) mInfo prevInApp :: xs)
++         else if let some r ← reduceBeforeArguments? f args then
++           setIsAppArg prevInApp
++           optimizeExprAux (.InitOptimizeExpr r.betaReduced r.prevMVarIdDecls :: xs)
+          -- try to apply funPropagation to avoid optimizing ite/match multiple times
+          else if let some r ← funPropagation? f args (reorderArgs := true) (resolveArgs := true) prevInApp then
+            optimizeExprAux (r :: xs)
+diff --git a/Blaster/Optimize/Rewriting/FunPropagation.lean b/Blaster/Optimize/Rewriting/FunPropagation.lean
+index adea608f..54a805cf 100644
+--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
++++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
+@@ -3,6 +3,12 @@ import Blaster.Optimize.Rewriting.NormalizeMatch
+ import Blaster.Optimize.Rewriting.OptimizeMatch
+ 
+ open Lean Meta Elab
++
++register_option blaster.hoistConstructorChoices : Bool := {
++  defValue := true
++  descr := "Lift conditional and match expressions out of constructor fields. Disable during symbolic preparation to keep independent field choices shared."
++}
++
+ namespace Blaster.Optimize
+ 
+ /-- Given application `f x₁ ... xₙ`, apply the following normalization rules:
+@@ -145,7 +151,8 @@ def funPropagation?
+     @[always_inline, inline]
+     propagate (f : Expr) (n : Name) (args : Array Expr) : TranslateEnvT Bool := do
+       if !(← hasMatchITEArgs args) then return false
+-      else if (← isCtorName n) then return true
++      else if (← isCtorName n) then
++        return blaster.hoistConstructorChoices.get (← getOptions)
+       else if (← allExplicitParamsAreCtor f args (funPropagation := true)) then return true
+       else
+         match n with
+diff --git a/Blaster/Optimize/Rewriting/OptimizeApp.lean b/Blaster/Optimize/Rewriting/OptimizeApp.lean
+index 1eae5b61..2880e0e4 100644
+--- a/Blaster/Optimize/Rewriting/OptimizeApp.lean
++++ b/Blaster/Optimize/Rewriting/OptimizeApp.lean
+@@ -14,8 +14,26 @@ import Blaster.Optimize.OptimizeStack
+ 
+ open Lean Meta
+ 
++register_option blaster.reduceBeforeArguments : Bool := {
++  defValue := false
++  descr := "Reduce transparent function applications and known projections before normalizing their arguments."
++}
++
+ namespace Blaster.Optimize
+ 
++/-- Experimental demand-driven reduction. Preserve the existing opacity and
++    recursive-call guards; the returned body still enters the normal optimizer. -/
++def reduceBeforeArguments? (f : Expr) (args : Array Expr) : TranslateEnvT (Option BetaLambdaResult) := do
++  if !(blaster.reduceBeforeArguments.get (← getOptions)) then return none
++  if !(← isOptimizeRecCall) then return none
++  if let some r ← getUnfoldFunDef? f args then return r
++  if (← isOpaqueFunExpr f args) then return none
++  let Expr.const n _ := f | return none
++  if !(← isRecursiveFun n) then return none
++  if !(← allExplicitParamsAreCtor f args) then return none
++  let some body ← getFunBody f | return none
++  betaLambdaEnv body args
++
+ /-- Given application `f x₁ ... xₙ`, perform the following:
+      - When `isOpaqueRecFun f #[x₁ ... xₙ] ∧ allExplicitParamsAreCtor f #[x₁ ... xₙ]
+           - When some auxFun ← unfoldOpaqueFunDef f #[x₁ ... xₙ]

--- a/Benchmarks/cardano/experiments/pure-candidate.patch
+++ b/Benchmarks/cardano/experiments/pure-candidate.patch
@@ -1,0 +1,250 @@
+diff --git a/Blaster/Optimize/Env/Abstract.lean b/Blaster/Optimize/Env/Abstract.lean
+index 9d4c60d8..e716d2b6 100644
+--- a/Blaster/Optimize/Env/Abstract.lean
++++ b/Blaster/Optimize/Env/Abstract.lean
+@@ -100,7 +100,8 @@ Aassume the input is maximally shared and ensure that the result is also maximal
+ def abstractFVarsRange (e : Expr) (endIdx : Nat) (xs : Array Expr) : TranslateEnvT Expr :=
+   if !e.hasFVar then return e
+   else if endIdx < xs.size then
+-    unsafe abstractFVarsAux e endIdx.toUSize xs
++    memoSharedTransform ⟨e, xs, 0, endIdx + 1, true⟩ do
++      unsafe abstractFVarsAux e endIdx.toUSize xs
+   else return e
+ 
+ /--
+diff --git a/Blaster/Optimize/Env/Instantiate.lean b/Blaster/Optimize/Env/Instantiate.lean
+index 16df3fc2..309afe6d 100644
+--- a/Blaster/Optimize/Env/Instantiate.lean
++++ b/Blaster/Optimize/Env/Instantiate.lean
+@@ -118,7 +118,8 @@ def instantiateSharedRevRange (e : Expr) (beginIdx endIdx : Nat) (subst : Array
+   if beginIdx == endIdx then return e else
+   let s := beginIdx.toUSize
+   let n := endIdx.toUSize - s
+-  unsafe instantiateSharedRevRangeAux e 0 s n subst
++  memoSharedTransform ⟨e, subst, beginIdx, endIdx, false⟩ do
++    unsafe instantiateSharedRevRangeAux e 0 s n subst
+ 
+ 
+ @[always_inline, inline]
+diff --git a/Blaster/Optimize/Env/Types.lean b/Blaster/Optimize/Env/Types.lean
+index 6bd7b1ef..51959cd8 100644
+--- a/Blaster/Optimize/Env/Types.lean
++++ b/Blaster/Optimize/Env/Types.lean
+@@ -282,6 +282,41 @@ deriving Inhabited, Repr
+ abbrev ContextReuseEntry := HashMap CtxId CtxReuseScope
+ abbrev ContextReuseMap := HashMap InstKey (IO.Ref ContextReuseEntry)
+ 
++/-- An environment-independent shared-expression transformation. Retaining the
++    operands keeps pointer keys alive. The operation and complete substitution
++    slice are part of the key; hypotheses and metavariable assignments are never
++    consulted by these raw transformations. -/
++structure SharedTransformKey where
++  expr : Expr
++  args : Array Expr
++  beginIdx : Nat
++  endIdx : Nat
++  abstract : Bool
++  deriving Inhabited
++
++instance : BEq SharedTransformKey where
++  beq a b := Id.run do
++    if a.abstract != b.abstract || !exprEq a.expr b.expr ||
++       a.beginIdx != b.beginIdx || a.endIdx != b.endIdx || a.args.size != b.args.size then
++      return false
++    for i in [:a.args.size] do
++      if !exprEq a.args[i]! b.args[i]! then return false
++    return true
++
++instance : Hashable SharedTransformKey where
++  hash k := Id.run do
++    let mut h := mixHash (hashPtrExpr k.expr) (mixHash (hash k.beginIdx) (hash k.endIdx))
++    h := mixHash h (hash k.abstract)
++    for e in k.args do h := mixHash h (hashPtrExpr e)
++    return h
++
++structure SharedTransformMemo where
++  entries : HashMap SharedTransformKey Expr := HashMap.emptyWithCapacity 1024
++  hits : Nat := 0
++  misses : Nat := 0
++  resets : Nat := 0
++  deriving Inhabited
++
+ /-- Type defining the memoization cache for internally demanding functions. -/
+ structure MemoizeEnv where
+   /-- Cache memoizing the isRecursiveFun result -/
+@@ -351,6 +386,9 @@ structure MemoizeEnv where
+   /-- Cache memoizing the isStructure result -/
+   isStructureCache : HashMap PtrName Bool
+ 
++  /-- Bounded memoization of raw abstraction and substitution, across scopes. -/
++  sharedTransforms : SharedTransformMemo := default
++
+ 
+ private def mkCommonExpr : CommonExpr :=
+   let le := mkConst ``LE.le [levelZero]
+@@ -1107,83 +1145,105 @@ def withLocalContext (f : TranslateEnvT α) : TranslateEnvT α := do
+   modify fun ⟨s, ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12, o13, o14⟩⟩ =>
+              ⟨s, ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, f o10, o11, o12, o13, o14⟩⟩
+ 
++/-- Memoize a context-independent transformation. Large argument vectors bypass
++    the table; bounded generations prevent retaining every intermediate root. -/
++def memoSharedTransform (key : SharedTransformKey) (compute : TranslateEnvT Expr) : TranslateEnvT Expr := do
++  if key.args.size > 16 then return ← compute
++  let cached := (← get).optEnv.memCache.sharedTransforms.entries.getD key instCacheMiss
++  if !exprEq cached instCacheMiss then
++    modifyMemCache fun m => { m with sharedTransforms.hits := m.sharedTransforms.hits + 1 }
++    return cached
++  let result ← compute
++  modifyMemCache fun m =>
++    let t := m.sharedTransforms
++    let reset := t.entries.size >= 65536
++    let entries := if reset then HashMap.emptyWithCapacity 1024 else t.entries
++    let updated : SharedTransformMemo := {
++      entries := entries.insert key result
++      hits := t.hits
++      misses := t.misses + 1
++      resets := t.resets + (if reset then 1 else 0)
++    }
++    { m with sharedTransforms := updated }
++  return result
++
+ @[inline] def updateConstInfoCache (n : Name) (info : ConstantInfo) : TranslateEnvT Unit :=
+-  modifyMemCache fun ⟨m1, m2, m3, m4, getConstInfoCache, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, getConstInfoCache.insert n info, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, getConstInfoCache, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, getConstInfoCache.insert n info, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateBetaLambdaCache (key : InstKey) (decl : BetaLambda) : TranslateEnvT Unit := do
+-  unsafe modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, betaLambdaCache, m16, m17, m18, m19, m20, m21⟩ =>
++  unsafe modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, betaLambdaCache, m16, m17, m18, m19, m20, m21, transforms⟩ =>
+                             ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14,
+-                             betaLambdaCache.insert key decl, m16, m17, m18, m19, m20, m21⟩
++                             betaLambdaCache.insert key decl, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateForallMetaCache (t : Expr) (inst : ForallMeta) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, forallMetaCache, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, forallMetaCache.insert t inst, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, forallMetaCache, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, forallMetaCache.insert t inst, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateInstanceCache (f : Name) (b : Bool) : TranslateEnvT Unit :=
+-  modifyMemCache fun ⟨m1, isInstanceCache, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, isInstanceCache.insert f b, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, isInstanceCache, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, isInstanceCache.insert f b, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateIsRecFunCache (f : Name) (b : Bool) : TranslateEnvT Unit :=
+-  modifyMemCache fun ⟨isRecFunCache, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨isRecFunCache.insert f b, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨isRecFunCache, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨isRecFunCache.insert f b, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateIsClassCache (n : Name) (b : Bool) : TranslateEnvT Unit :=
+-  modifyMemCache fun ⟨m1, m2, isClassCache, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, isClassCache.insert n b, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, isClassCache, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, isClassCache.insert n b, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateMatcherCache (n : Name) (m : Option MatcherRecInfo) : TranslateEnvT Unit :=
+-  modifyMemCache fun ⟨m1, m2, m3, getMatcherCache, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, getMatcherCache.insert n m, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, getMatcherCache, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, getMatcherCache.insert n m, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateIsMatcherCache (n : Name) (mInfo : MatchInfo) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, isMatcherCache, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, isMatcherCache.insert n mInfo, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, isMatcherCache, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, isMatcherCache.insert n mInfo, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateIsPartialCache (n : Name) (b : Bool) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, isPartialCache, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, isPartialCache.insert n b, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, isPartialCache, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, isPartialCache.insert n b, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateInferTypeCache (e : Expr) (t : Expr) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, inferTypeCache, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, inferTypeCache.insert e t, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, inferTypeCache, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, inferTypeCache.insert e t, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updatePropCache (e : Expr) (b : Bool) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, isPropCache, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, isPropCache.insert e b, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, isPropCache, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, isPropCache.insert e b, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateFunInfoCache (f : Expr) (info : FunEnvInfo) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, getFunEnvInfoCache, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, getFunEnvInfoCache.insert f info, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, getFunEnvInfoCache, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, getFunEnvInfoCache.insert f info, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateFunBodyCache (f : Expr) (body : Option Expr) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, getFunBodyCache, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, getFunBodyCache.insert f body, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, getFunBodyCache, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, getFunBodyCache.insert f body, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateIsNotFunCache (e : Expr) (b : Bool) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, isNotFunCache, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, isNotFunCache.insert e b, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, isNotFunCache, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, isNotFunCache.insert e b, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateMatchAltsCache (genApp : Expr) (alts : Array Expr) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, matchAltsCache, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, matchAltsCache.insert genApp alts, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, matchAltsCache, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, matchAltsCache.insert genApp alts, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateMatchToIteCache (n : Name) (b : Bool) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, isMatchToIte, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, isMatchToIte.insert n b, m13, m14, m15, m16, m17, m18, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, isMatchToIte, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, isMatchToIte.insert n b, m13, m14, m15, m16, m17, m18, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateGenericMatchCache (genType : Expr) (g : GenericMatchResult) : TranslateEnvT Unit := do
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, genericMatchCache, m19, m20, m21⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, genericMatchCache.insert genType g, m19, m20, m21⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, genericMatchCache, m19, m20, m21, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, genericMatchCache.insert genType g, m19, m20, m21, transforms⟩
+ 
+ @[inline] def updateCtorMatchPropCache (e : Expr) : TranslateEnvT Unit :=
+   modifyMemCache fun
+-    ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, isCtorMatchPropCache, m20⟩ =>
+-    ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, isCtorMatchPropCache.insert e, m20⟩
++    ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, isCtorMatchPropCache, m20, transforms⟩ =>
++    ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, isCtorMatchPropCache.insert e, m20, transforms⟩
+ 
+ @[inline] def updateIsStructureCache (n : Name) (b : Bool) : TranslateEnvT Unit :=
+-  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, isStructureCache⟩ =>
+-                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, isStructureCache.insert n b⟩
++  modifyMemCache fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, isStructureCache, transforms⟩ =>
++                     ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, isStructureCache.insert n b, transforms⟩
+ 
+ @[always_inline, inline]
+ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : TranslateEnvT Unit := do
+@@ -1192,9 +1252,9 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
+   | none =>
+       let refEntry ← IO.mkRef (HashMap.emptyWithCapacity.insert s.scope.parent s)
+       modifyMemCache
+-        fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, contextReuseCache, m20, m21⟩ =>
++        fun ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, contextReuseCache, m20, m21, transforms⟩ =>
+             ⟨m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16,
+-             m17, m18, contextReuseCache.insert key refEntry, m20, m21⟩
++             m17, m18, contextReuseCache.insert key refEntry, m20, m21, transforms⟩
+   | some refEntry => refEntry.modify (λ h => h.insert s.scope.parent s)
+ 
+ 
+diff --git a/Tests/Optimize.lean b/Tests/Optimize.lean
+index 200e9bdc..60fd899f 100644
+--- a/Tests/Optimize.lean
++++ b/Tests/Optimize.lean
+@@ -15,3 +15,5 @@ import Tests.Optimize.OptimizeNat
+ import Tests.Optimize.OptimizeProp
+ import Tests.Optimize.OptimizeRecFun
+ import Tests.Optimize.OptimizeUnfold
++
++import Tests.Optimize.CacheReuse.PureTransforms

--- a/Benchmarks/cardano/experiments/pure-transform-tests.lean
+++ b/Benchmarks/cardano/experiments/pure-transform-tests.lean
@@ -1,0 +1,55 @@
+import Tests.Utils
+
+open Lean Meta Elab Command Blaster.Optimize
+
+namespace Tests.Optimize.CacheReuse
+
+-- Compare both cold and warm results with Lean, including a shared subterm
+-- reached under different binder depths and different substitution slices.
+run_cmd liftTermElabM do
+  let check : TranslateEnvT Unit := do
+    let nat ← hashcons (mkConst ``Nat)
+    let x ← hashcons (mkFVar ⟨`transform_x⟩)
+    let y ← hashcons (mkFVar ⟨`transform_y⟩)
+    let z ← hashcons (mkFVar ⟨`transform_z⟩)
+    let args := #[x, y, z]
+    let pair ← hashcons (mkApp2 (mkConst ``Nat.add) x y)
+    let body ← hashcons (mkApp2 (mkConst ``Nat.add) pair (mkLambda `t .default nat pair))
+    for vars in #[args, #[z, x, y], #[x], #[y, z]] do
+      for stop in [:vars.size] do
+        for _ in [:2] do
+          let r ← abstractFVarsRange body stop vars
+          unless r == body.abstractRange (stop + 1) vars do
+            throwError "memoized abstraction disagrees with Lean"
+    let abstracted ← abstractFVars body args
+    let replacements ← (#[mkRawNatLit 11, mkBVar 2, mkRawNatLit 33]).mapM hashcons
+    for vars in #[args, replacements, replacements.reverse] do
+      for start in [:vars.size + 1] do
+        for stop in [start:vars.size + 1] do
+          for _ in [:2] do
+            let r ← instantiateSharedRevRange abstracted start stop vars
+            unless r == abstracted.instantiateRevRange start stop vars do
+              throwError "memoized substitution disagrees with Lean"
+    -- Syntactic operations remain identical when the active hypotheses change.
+    let parent ← newCtx
+    updateEqualityMap x y parent.current
+    let r ← abstractFVars body args
+    let child ← newCtx
+    updateEqualityMap x z child.current
+    unless (← abstractFVars body args) == r do
+      throwError "raw abstraction depended on branch hypotheses"
+    endCtx child
+    endCtx parent
+    unless (← get).optEnv.memCache.sharedTransforms.hits > 0 do
+      throwError "the differential checks did not exercise warm cache entries"
+  check.run' (default : TranslateEnv)
+
+-- Child facts must still normalize existing propositions and nested choices.
+#testOptimize ["ChildHypothesesRemainVisible"]
+  (∀ a b c : Prop, (a → b) ∧ (a → c ∧ (a → b))) ===>
+  (∀ a b c : Prop, (a → b) ∧ (a → b ∧ c))
+
+#blaster (gen-cex: 0) [∀ x y : Nat, (fun a b : Nat => a + b) y x = x + y]
+#blaster (gen-cex: 0) (solve-result: 1) [∀ x : Nat, (if x = 0 then x + 1 else x + 2) = 1]
+
+end Tests.Optimize.CacheReuse

--- a/Benchmarks/cardano/experiments/replay2-candidate.patch
+++ b/Benchmarks/cardano/experiments/replay2-candidate.patch
@@ -1,0 +1,226 @@
+diff --git a/Blaster/Optimize/Env/Types.lean b/Blaster/Optimize/Env/Types.lean
+index 6bd7b1ef..ec50c0ef 100644
+--- a/Blaster/Optimize/Env/Types.lean
++++ b/Blaster/Optimize/Env/Types.lean
+@@ -101,6 +101,15 @@ structure OptimizeOptions where
+ 
+   resetOptions : ResetOptions
+ 
++  /-- Parent links for scoped rewrite reuse, adapted from PR #160. A cached
++      equivalence in an active ancestor remains valid under the additional
++      hypotheses of its descendants. Links also survive choice-context reuse. -/
++  parents : HashMap CtxId CtxId := HashMap.emptyWithCapacity 1024
++
++  /-- Ancestor results must be normalized without recursively reusing ancestors. -/
++  replayingAncestor : Bool := false
++
++
+ instance : Inhabited OptimizeOptions where
+   default := { normalizeFunCall := true, inFunApp := false, mcDepth := 0, solverOptions := default, resetOptions := default }
+ 
+@@ -861,7 +870,7 @@ def updateGlobalRewriteCache (a : Expr) (b : Expr) (insertIfNew := false) : Tran
+ /-- Update rewrite cache at curCtx with `a := b`. -/
+ @[always_inline, inline]
+ def updateLocalRewriteCache (a : Expr) (b : Expr) (insertIfNew := false) : TranslateEnvT Unit := do
+-  let ⟨_, rewriteCache, _, _, _, _, _, _, _, _, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, rewriteCache, _, _, _, _, _, _, _, _, ⟨_, _, _, _, curCtx, _, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   match rewriteCache.get? curCtx with
+   | none =>
+        let refEntry ← IO.mkRef $ (HashMap.emptyWithCapacity 256 : HashMap PtrExpr Expr).insert a b
+@@ -896,7 +905,7 @@ def updateEqualityMap (lhs : Expr) (rhs : Expr) (ctxId : CtxId) : TranslateEnvT
+     newest entry visible in the current context (tag ∈ active). -/
+ @[always_inline, inline]
+ def eqMapFind? (lhs : Expr) : TranslateEnvT (Option Expr) := do
+-  let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   if equalityMap.size == 0
+   then return none
+   else ContextMap.findRaw equalityMap active lhs
+@@ -906,7 +915,7 @@ def eqMapFind? (lhs : Expr) : TranslateEnvT (Option Expr) := do
+     proof of the newest entry for `e` whose tag is active in the current context. -/
+ @[always_inline, inline]
+ def hypMapFind? (e : Expr) : TranslateEnvT (Option Expr) := do
+-  let ⟨_, _, _, _, _, _, _, ⟨hypothesisMap, _⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, ⟨hypothesisMap, _⟩, _, _, ⟨_, _, _, _, _, _, active, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   if hypothesisMap.size == 0
+   then return none
+   else ContextMap.findRaw hypothesisMap active e
+@@ -924,7 +933,8 @@ def newCtx : TranslateEnvT CtxScope := do
+    let current := env.optEnv.options.nextCtxId
+    let parent := env.optEnv.options.curCtx
+    (⟨parent, current⟩, {env with optEnv.options.nextCtxId := current + 1, optEnv.options.curCtx := current
+-                                 optEnv.options.active := env.optEnv.options.active.insert current })
++                                 optEnv.options.active := env.optEnv.options.active.insert current
++                                 optEnv.options.parents := env.optEnv.options.parents.insert current parent })
+ 
+ @[always_inline, inline]
+ def setAndCommitCtx (s : CtxScope) : TranslateEnvT Unit :=
+@@ -936,9 +946,9 @@ def setAndCommitCtx (s : CtxScope) : TranslateEnvT Unit :=
+ -/
+ @[always_inline, inline]
+ def endCtx (s : CtxScope) : TranslateEnvT Unit :=
+-  modifyOptEnv fun ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7⟩, o12, o13, o14⟩ =>
++  modifyOptEnv fun ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7, parents, replaying⟩, o12, o13, o14⟩ =>
+                    ⟨o1, rewrite.erase s.current, o3, o4, o5, o6, o7, o8, o9, o10,
+-                   ⟨s1, s2, s3, s4, s.parent, s6, active.erase s.current, s7⟩, o12, o13, o14⟩
++                   ⟨s1, s2, s3, s4, s.parent, s6, active.erase s.current, s7, parents, replaying⟩, o12, o13, o14⟩
+ 
+ 
+ 
+@@ -954,7 +964,7 @@ def ContextReuseMap.findRaw (m : ContextReuseMap) (e : Expr) (idx : USize) (curC
+ 
+ @[always_inline, inline]
+ def reuseContext? (e : Expr) (idx : USize) : TranslateEnvT (Option CtxReuseScope) := do
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   memCache.contextReuseCache.findRaw e idx curCtx
+ 
+ @[always_inline, inline]
+@@ -1199,7 +1209,7 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
+ 
+ 
+ @[inline] def propagateReuseContext (current : Expr) (next : Expr) (idx : USize) : TranslateEnvT Unit := do
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   match ← memCache.contextReuseCache.findRaw current idx curCtx with
+   | some reuse => updateContextReuseCache next idx reuse
+   | none => return ()
+@@ -1213,7 +1223,7 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
+                     ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12, o13, o14⟩
+ 
+ @[inline] def freeRewriteCacheReuse (e : Expr) (idx : USize) : TranslateEnvT Unit := do
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   match ← memCache.contextReuseCache.findRaw e idx curCtx with
+   | some reuse =>
+       modifyOptEnv
+@@ -1232,6 +1242,23 @@ def findGlobalCache (a : Expr) (env : TranslateEnv) : IO Expr :=
+   | none => return instCacheMiss
+   | some refEntry => return (← refEntry.get).getD a instCacheMiss
+ 
++/-- Look up the nearest active ancestor's cached rewrite. Entries from closed
++    siblings are invisible, and erased cache maps are skipped. This ports the
++    ancestor lookup from #160 onto the reviewed beta stack without its GC or
++    allocator experiments. Returning an ancestor normal form can leave further
++    descendant simplifications available; it must not assume sibling facts. -/
++partial def findAncestorCache (a : Expr) (env : TranslateEnv) : IO Expr := do
++  let o := env.optEnv
++  let rec go (ctx : CtxId) : IO Expr := do
++    if ctx == 0 || o.options.active.contains ctx then
++      if let some refEntry := o.rewriteCache.get? ctx then
++        let v := (← refEntry.get).getD a instCacheMiss
++        if !exprEq v instCacheMiss then return v
++    if ctx == 0 then return instCacheMiss
++    go (o.options.parents.getD ctx 0)
++  if o.options.curCtx == 0 then return instCacheMiss
++  go (o.options.parents.getD o.options.curCtx 0)
++
+ @[always_inline, inline]
+ def findLocalCache (a : Expr) (env : TranslateEnv) : IO Expr :=
+   match env.optEnv.rewriteCache.get? env.optEnv.options.curCtx with
+diff --git a/Blaster/Optimize/OptimizeStack.lean b/Blaster/Optimize/OptimizeStack.lean
+index 84df5eac..f40b4602 100644
+--- a/Blaster/Optimize/OptimizeStack.lean
++++ b/Blaster/Optimize/OptimizeStack.lean
+@@ -14,6 +14,7 @@ instance : Repr (Option MVarIdDecls) where
+ 
+ inductive OptimizeStack where
+  | InitOptimizeExpr (e : Expr) (mvarDecls : Option MVarIdDecls := none)
++ | EndAncestorRewrite
+  | InitOptimizeReturn (e : Expr) (isGlobal : Bool) (mvarDecls : Option MVarIdDecls)
+  | RecFunDefWaitForStorage (args : Array Expr) (instApp : Expr)
+                            (subsInts : Expr) (params : ImplicitParameters) (startCtxId : CtxId)
+@@ -65,8 +66,8 @@ def resetChoiceContext (h : HypsStackContext) (fvars : Array Expr) (lam : Expr)
+   | some scope =>
+        updateContextReuseCache lam idx ⟨scope, fvars⟩
+        modifyOptEnv
+-         fun ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7⟩, o12, o13, o14⟩ =>
+-             ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, scope.parent, s6, active.erase scope.current, s7⟩, o12, o13, o14⟩
++         fun ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7, parents, replaying⟩, o12, o13, o14⟩ =>
++             ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, scope.parent, s6, active.erase scope.current, s7, parents, replaying⟩, o12, o13, o14⟩
+   | none => return ()
+ 
+ def restoreMVarDecls (optDecls : Option MVarIdDecls) : TranslateEnvT Unit :=
+@@ -97,6 +98,10 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache :=
+   match stack with
+   | [] => return Sum.inr optExpr
+ 
++  | .EndAncestorRewrite :: xs =>
++       modifyOptEnv fun env => {env with options.replayingAncestor := false}
++       stackContinuity xs optExpr skipCache
++
+   | .InitOptimizeReturn e isGlobal mvarDecls :: xs =>
+        let optExpr ← isInEqualityMap optExpr isGlobal
+        if !skipCache then
+@@ -383,8 +388,19 @@ def isInOptimizeEnvCache (a : Expr) (stack : List OptimizeStack) (mvarDecls : Op
+   let useCache := !a.hasMVar
+   if useCache then
+     let cached := ← isInOptimizeCache? a isGlobal env
+-    if !exprEq cached instCacheMiss then Sum.inr <$> stackContinuity stack cached
+-    else return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
++    if !exprEq cached instCacheMiss then return .inr (← stackContinuity stack cached)
++    if !isGlobal && !env.optEnv.options.replayingAncestor then
++      let inherited ← findAncestorCache a env
++      if !exprEq inherited instCacheMiss && !exprEq inherited a then
++        -- An ancestor equivalence remains valid, but its normal form need not
++        -- be normal under this child's additional hypotheses. Re-enter the
++        -- optimizer and cache the resulting child normal form for the source.
++        -- Disable ancestor lookup throughout the replacement subtree: a
++        -- cached replacement can contain an earlier source as a subterm.
++        modifyOptEnv fun env => {env with options.replayingAncestor := true}
++        return .inr (.inl (.InitOptimizeExpr inherited :: .EndAncestorRewrite ::
++          .InitOptimizeReturn a isGlobal mvarDecls :: stack))
++    return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
+   else return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
+ 
+   where
+diff --git a/Blaster/Optimize/Rewriting/OptimizeMatch.lean b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+index c654e50f..fd20fb84 100644
+--- a/Blaster/Optimize/Rewriting/OptimizeMatch.lean
++++ b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+@@ -15,7 +15,7 @@ partial def eraseMatchRhsRewriteCache (mInfo : MatchInfo) : TranslateEnvT Unit :
+     else
+       freeRewriteCacheReuse mInfo.nameExpr (idx - offset)
+       visit (idx + 1) stop offset
+-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
++  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+   if (← memCache.contextReuseCache.findRaw mInfo.nameExpr 0 curCtx).isSome then
+     let start := mInfo.getFirstAltPos.toUSize
+     visit start mInfo.arity.toUSize start
+@@ -306,7 +306,7 @@ def reduceMatch? (args : Array Expr) (mInfo : MatchInfo) (resolveArgs := false)
+      go mInfo.getFirstDiscrPos mInfo.getFirstAltPos
+ 
+     resolveArgsWithEqualityStack (args : Array Expr) : TranslateEnvT (Array Expr) := do
+-     let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++     let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+      let rec visit (idx : Nat) (stop : Nat) (args : Array Expr) : TranslateEnvT (Array Expr) := do
+        if idx ≥ stop then return args
+        else
+@@ -718,7 +718,7 @@ partial def optimizeMatchAlt
+        return .InitOptimizeExpr body :: .MatchAltWaitForExpr reuse.fvars (some reuse.scope) currIdx matchInst :: stack
+   | none =>
+        let alts ← getMatchAlts args mInfo
+-       let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _⟩, _, _, _⟩⟩ ← get
++       let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _, _, _⟩, _, _, _⟩⟩ ← get
+        let updatedMCtx ← addNotEqPatternToContext args mInfo alts 0 currIdx nextCtxId false
+        forallTelescope alts[currIdx]! fun xs b => do
+          let lhs := b.getAppArgs
+@@ -827,7 +827,7 @@ where
+ 
+   @[always_inline, inline]
+   lastPatternReduction? (mInfo : MatchInfo) (args : Array Expr) : TranslateEnvT (Option MatchElimResult) := do
+-     let ⟨_, _, _, _, _, _, _, _, matchInContext, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
++     let ⟨_, _, _, _, _, _, _, _, matchInContext, _, ⟨_, _, _, _, _, _, active, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+      let h := (← get).optEnv.matchInContext
+      let alts ← getMatchAlts args mInfo
+      for i in [:alts.size - 1] do
+diff --git a/Tests/Optimize.lean b/Tests/Optimize.lean
+index 200e9bdc..39e02dde 100644
+--- a/Tests/Optimize.lean
++++ b/Tests/Optimize.lean
+@@ -15,3 +15,5 @@ import Tests.Optimize.OptimizeNat
+ import Tests.Optimize.OptimizeProp
+ import Tests.Optimize.OptimizeRecFun
+ import Tests.Optimize.OptimizeUnfold
++
++import Tests.Optimize.CacheReuse.AncestorRenormalization

--- a/Benchmarks/cardano/experiments/replay2-scope-tests.lean
+++ b/Benchmarks/cardano/experiments/replay2-scope-tests.lean
@@ -1,0 +1,58 @@
+import Tests.Utils
+
+open Lean Meta Elab Command Blaster.Optimize
+
+namespace Tests.Optimize.AncestorRenormalization
+
+-- Lifetime/isolation checks for the stateful cache, independent of any solver.
+run_cmd liftTermElabM do
+  let check : TranslateEnvT Unit := do
+    let key ← hashcons (mkConst `cacheProbe)
+    let one ← hashcons (mkRawNatLit 1)
+    let two ← hashcons (mkRawNatLit 2)
+    let parent ← newCtx
+    updateLocalRewriteCache key one
+    let child ← newCtx
+    unless exprEq (← findAncestorCache key (← get)) one do
+      throwError "child did not reuse its parent's rewrite"
+    updateLocalRewriteCache key two
+    unless exprEq (← findLocalCache key (← get)) two do
+      throwError "nearest cache entry must win"
+    endCtx child
+    let sibling ← newCtx
+    unless exprEq (← findAncestorCache key (← get)) one do
+      throwError "a closed sibling's rewrite escaped its scope"
+    endCtx sibling
+    endCtx parent
+    let other ← newCtx
+    unless exprEq (← findAncestorCache key (← get)) instCacheMiss do
+      throwError "a closed parent's rewrite escaped its scope"
+    endCtx other
+    -- Choice scopes can be re-entered, while discarded maps remain misses.
+    let reused ← newCtx
+    updateLocalRewriteCache key two
+    resetChoiceContext (some reused) #[] key 0
+    setAndCommitCtx reused
+    let nested ← newCtx
+    unless exprEq (← findAncestorCache key (← get)) two do
+      throwError "re-entered choice scope lost its parent relationship"
+    endCtx nested
+    endCtx reused
+  check.run' (default : TranslateEnv)
+
+#testOptimize ["RenormalizeWithChildFacts"]
+  (∀ a b c : Prop, (a → b) ∧ (a → c ∧ (a → b))) ===>
+  (∀ a b c : Prop, (a → b) ∧ (a → b ∧ c))
+
+-- A child's additional facts still need to simplify the result of an ancestor.
+#blaster (gen-cex: 0)
+  [∀ x y : Nat, x = y → y = 0 → x + 1 = 1]
+#testOptimize ["NestedBranchFacts"]
+  (∀ x y : Nat, (if x = y then (if y = 0 then x + 1 else y + 1) else x + 1) = x + 1) ===> True
+#testOptimize ["SiblingIsolation"]
+  (∀ x : Nat, (if x = 0 then x + 1 else x + 2) =
+    (if x = 0 then 1 else x + 2)) ===> True
+#blaster (gen-cex: 0) (solve-result: 1)
+  [∀ x : Nat, (if x = 0 then x + 1 else x + 2) = 1]
+
+end Tests.Optimize.AncestorRenormalization

--- a/Benchmarks/cardano/experiments/selective-candidate.patch
+++ b/Benchmarks/cardano/experiments/selective-candidate.patch
@@ -1,0 +1,36 @@
+diff --git a/Blaster/Optimize/Rewriting/FunPropagation.lean b/Blaster/Optimize/Rewriting/FunPropagation.lean
+index adea608f..f5417f37 100644
+--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
++++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
+@@ -3,8 +3,17 @@ import Blaster.Optimize.Rewriting.NormalizeMatch
+ import Blaster.Optimize.Rewriting.OptimizeMatch
+ 
+ open Lean Meta Elab
++
++register_option blaster.hoistConstructorChoices : Bool := {
++  defValue := true
++  descr := "Lift conditional and match expressions out of constructor fields. Disable during symbolic preparation to keep independent field choices shared."
++}
++
+ namespace Blaster.Optimize
+ 
++initialize keepChoicesExt : LabelExtension ← registerLabelAttr `blaster_keep_choices "Keep symbolic choices inside constructors of the labelled inductive type or constructor."
++syntax (name := _root_.Parser.Attr.blaster_keep_choices) "blaster_keep_choices" : attr
++
+ /-- Given application `f x₁ ... xₙ`, apply the following normalization rules:
+      - When `f := Blaster.dite' c (fun h : c => t₁) (fun h : ¬ c => t₂)`
+        Return
+@@ -145,7 +154,12 @@ def funPropagation?
+     @[always_inline, inline]
+     propagate (f : Expr) (n : Name) (args : Array Expr) : TranslateEnvT Bool := do
+       if !(← hasMatchITEArgs args) then return false
+-      else if (← isCtorName n) then return true
++      else if (← isCtorName n) then
++        if !(blaster.hoistConstructorChoices.get (← getOptions)) then return false
++        let kept := keepChoicesExt.getState (← getEnv)
++        if kept.isEmpty then return true
++        let .ctorInfo info ← getConstEnvInfo n | return true
++        return !(kept.contains n || kept.contains info.induct)
+       else if (← allExplicitParamsAreCtor f args (funPropagation := true)) then return true
+       else
+         match n with

--- a/Benchmarks/cardano/experiments/values-candidate.patch
+++ b/Benchmarks/cardano/experiments/values-candidate.patch
@@ -1,0 +1,44 @@
+diff --git a/Blaster/Optimize/Rewriting/FunPropagation.lean b/Blaster/Optimize/Rewriting/FunPropagation.lean
+index adea608f..e4bed6f7 100644
+--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
++++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
+@@ -3,8 +3,24 @@ import Blaster.Optimize.Rewriting.NormalizeMatch
+ import Blaster.Optimize.Rewriting.OptimizeMatch
+ 
+ open Lean Meta Elab
++
++register_option blaster.hoistConstructorChoices : Bool := {
++  defValue := true
++  descr := "Lift conditional and match expressions out of constructor fields. Disable during symbolic preparation to keep independent field choices shared."
++}
++
+ namespace Blaster.Optimize
+ 
++initialize keepChoicesExt : LabelExtension ← registerLabelAttr `blaster_keep_choices "Keep symbolic choices inside constructors of the labelled inductive type or constructor."
++syntax (name := _root_.Parser.Attr.blaster_keep_choices) "blaster_keep_choices" : attr
++
++/-- A selected datatype also keeps choices in containers parameterized by it,
++    such as `List Value`, without affecting `List Frame`. -/
++private partial def hasKeptChoiceType (kept : Array Name) (e : Expr) : Bool :=
++  match e.getAppFn with
++  | .const n _ => kept.contains n || e.getAppArgs.any (hasKeptChoiceType kept)
++  | _ => false
++
+ /-- Given application `f x₁ ... xₙ`, apply the following normalization rules:
+      - When `f := Blaster.dite' c (fun h : c => t₁) (fun h : ¬ c => t₂)`
+        Return
+@@ -145,7 +161,13 @@ def funPropagation?
+     @[always_inline, inline]
+     propagate (f : Expr) (n : Name) (args : Array Expr) : TranslateEnvT Bool := do
+       if !(← hasMatchITEArgs args) then return false
+-      else if (← isCtorName n) then return true
++      else if (← isCtorName n) then
++        if !(blaster.hoistConstructorChoices.get (← getOptions)) then return false
++        let kept := keepChoicesExt.getState (← getEnv)
++        if kept.isEmpty then return true
++        let .ctorInfo info ← getConstEnvInfo n | return true
++        return !(kept.contains n || kept.contains info.induct ||
++          (args.take info.numParams).any (hasKeptChoiceType kept))
+       else if (← allExplicitParamsAreCtor f args (funPropagation := true)) then return true
+       else
+         match n with

--- a/Benchmarks/cardano/patches/cardano.patch
+++ b/Benchmarks/cardano/patches/cardano.patch
@@ -1,0 +1,65 @@
+diff --git a/lake-manifest.json b/lake-manifest.json
+index e4ceb04..fdfef11 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,19 +1,26 @@
+-{"version": "1.1.0",
+- "packagesDir": ".lake/packages",
+- "packages":
+- [{"type": "path",
+-   "scope": "",
+-   "name": "Blaster",
+-   "manifestFile": "lake-manifest.json",
+-   "inherited": false,
+-   "dir": "/Users/romainsoulat/Lean-blaster",
+-   "configFile": "lakefile.lean"},
+-  {"type": "path",
+-   "scope": "",
+-   "name": "PlutusCore",
+-   "manifestFile": "lake-manifest.json",
+-   "inherited": false,
+-   "dir": "/Users/romainsoulat/PlutusCoreBlaster",
+-   "configFile": "lakefile.lean"}],
+- "name": "CardanoLedgerApi",
+- "lakeDir": ".lake"}
++{
++  "version": "1.1.0",
++  "packagesDir": ".lake/packages",
++  "packages": [
++    {
++      "type": "path",
++      "scope": "",
++      "name": "Blaster",
++      "manifestFile": "lake-manifest.json",
++      "inherited": false,
++      "dir": "../blaster",
++      "configFile": "lakefile.lean"
++    },
++    {
++      "type": "path",
++      "scope": "",
++      "name": "PlutusCore",
++      "manifestFile": "lake-manifest.json",
++      "inherited": false,
++      "dir": "../plutuscore",
++      "configFile": "lakefile.lean"
++    }
++  ],
++  "name": "CardanoLedgerApi",
++  "lakeDir": ".lake"
++}
+diff --git a/lakefile.lean b/lakefile.lean
+index 05bfcc1..7b7f2de 100644
+--- a/lakefile.lean
++++ b/lakefile.lean
+@@ -7,8 +7,8 @@ package «CardanoLedgerApi» where
+   moreLeanArgs := #["--threads=4"]
+   -- Investigation branch (#138 telemetry): local paths for fast iteration.
+   -- Originals: PlutusCore @ git main; Blaster @ git beta-lambda-cache-optimization
+-  require PlutusCore from "/Users/romainsoulat/PlutusCoreBlaster"
+-  require Blaster from "/Users/romainsoulat/Lean-blaster"
++  require Blaster from "../blaster"
++  require PlutusCore from "../plutuscore"
+ 
+ @[default_target]
+ lean_lib «CardanoLedgerApi» where

--- a/Benchmarks/cardano/patches/plutuscore-wsc.patch
+++ b/Benchmarks/cardano/patches/plutuscore-wsc.patch
@@ -1,0 +1,75 @@
+diff --git a/PlutusCore/UPLC/PreProcess.lean b/PlutusCore/UPLC/PreProcess.lean
+index d5ce4dd2..0df14953 100644
+--- a/PlutusCore/UPLC/PreProcess.lean
++++ b/PlutusCore/UPLC/PreProcess.lean
+@@ -2,7 +2,6 @@ import Lean
+ import PlutusCore.UPLC.CekMachine
+ import PlutusCore.UPLC.PlutusScript
+ import Blaster.Optimize.Basic
+-import Blaster.Optimize.Stats
+ import Blaster.Command.Syntax
+ open Lean Elab Command Term Meta Blaster.Optimize Blaster.Syntax
+ 
+@@ -46,7 +45,12 @@ def preprocessImp : CommandElab := fun stx => do
+         let plutusScript ← validUplcProg stx[3]
+         let app ← mkUplcApply stx plutusScript
+         let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
+-        let (e, _) ← (withOptimizeStats <| Optimize.main app)|>.run env
++        let prepStarted ← IO.monoMsNow
++        let (e, prepEnv) ← (Optimize.main app)|>.run env
++        if (← IO.getEnv "BLASTER_PREP_METRICS") == some "1" then
++          let ms := (← IO.monoMsNow) - prepStarted
++          let o := prepEnv.optEnv
++          IO.println s!"PREP_METRICS optimize_ms={ms} hashcons={o.hashConsCache.size} contexts={o.options.nextCtxId} beta_cache={o.memCache.betaLambdaCache.size}"
+         let t ← inferType e
+         let baseName ← validNewDef stx[2]
+         let propName := Name.append baseName `prop
+diff --git a/lake-manifest.json b/lake-manifest.json
+index 216f05fd..c01e98c3 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,12 +1,17 @@
+-{"version": "1.1.0",
+- "packagesDir": ".lake/packages",
+- "packages":
+- [{"type": "path",
+-   "scope": "",
+-   "name": "Blaster",
+-   "manifestFile": "lake-manifest.json",
+-   "inherited": false,
+-   "dir": "/Users/romainsoulat/Lean-blaster-wsc",
+-   "configFile": "lakefile.lean"}],
+- "name": "PlutusCore",
+- "lakeDir": ".lake"}
++{
++  "version": "1.1.0",
++  "packagesDir": ".lake/packages",
++  "packages": [
++    {
++      "type": "path",
++      "scope": "",
++      "name": "Blaster",
++      "manifestFile": "lake-manifest.json",
++      "inherited": false,
++      "dir": "../blaster",
++      "configFile": "lakefile.lean"
++    }
++  ],
++  "name": "PlutusCore",
++  "lakeDir": ".lake"
++}
+diff --git a/lakefile.lean b/lakefile.lean
+index da21614e..2c452780 100644
+--- a/lakefile.lean
++++ b/lakefile.lean
+@@ -5,8 +5,8 @@ package «PlutusCore» where
+   -- add package configuration options here
+   -- WSC reproduction branch (#138 telemetry): local worktree of the Anastasia
+   -- wsc-d6-dite-branch-retype fork with telemetry grafted on top.
+-  -- Original pin: require Blaster from git "https://github.com/input-output-hk/Lean-blaster" @ "main"
+-  require Blaster from "/Users/romainsoulat/Lean-blaster-wsc"
++  -- Original pin: require Blaster from "../blaster"
++  require Blaster from "../blaster"
+ 
+ @[default_target]
+ lean_lib «PlutusCore» where

--- a/Benchmarks/cardano/patches/plutuscore.patch
+++ b/Benchmarks/cardano/patches/plutuscore.patch
@@ -1,0 +1,68 @@
+diff --git a/PlutusCore/UPLC/PreProcess.lean b/PlutusCore/UPLC/PreProcess.lean
+index ddbaa30d..40cd2697 100644
+--- a/PlutusCore/UPLC/PreProcess.lean
++++ b/PlutusCore/UPLC/PreProcess.lean
+@@ -37,7 +37,12 @@ def preprocessImp : CommandElab := fun stx => do
+       withoutModifyingEnv $ runTermElabM fun _ => do
+         let plutusScript ← validUplcProg stx[2]
+         let app ← mkUplcApply stx plutusScript
+-        let (e, _) ← Optimize.main app|>.run default
++        let prepStarted ← IO.monoMsNow
++        let (e, prepEnv) ← Optimize.main app|>.run default
++        if (← IO.getEnv "BLASTER_PREP_METRICS") == some "1" then
++          let ms := (← IO.monoMsNow) - prepStarted
++          let o := prepEnv.optEnv
++          IO.println s!"PREP_METRICS optimize_ms={ms} hashcons={o.hashConsCache.size} contexts={o.options.nextCtxId} beta_cache={o.memCache.betaLambdaCache.size}"
+         let t ← inferType e
+         let baseName ← validNewDef stx[1]
+         let propName := Name.append baseName `prop
+diff --git a/lake-manifest.json b/lake-manifest.json
+index 57d627cc..c01e98c3 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,15 +1,17 @@
+-{"version": "1.1.0",
+- "packagesDir": ".lake/packages",
+- "packages":
+- [{"url": "https://github.com/input-output-hk/Lean-blaster",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "c576289cb55412b359411d6c89568f95af50730c",
+-   "name": "Blaster",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"}],
+- "name": "PlutusCore",
+- "lakeDir": ".lake"}
++{
++  "version": "1.1.0",
++  "packagesDir": ".lake/packages",
++  "packages": [
++    {
++      "type": "path",
++      "scope": "",
++      "name": "Blaster",
++      "manifestFile": "lake-manifest.json",
++      "inherited": false,
++      "dir": "../blaster",
++      "configFile": "lakefile.lean"
++    }
++  ],
++  "name": "PlutusCore",
++  "lakeDir": ".lake"
++}
+diff --git a/lakefile.lean b/lakefile.lean
+index b913bb78..3850a2ce 100644
+--- a/lakefile.lean
++++ b/lakefile.lean
+@@ -3,7 +3,7 @@ open Lake DSL
+ 
+ package «PlutusCore» where
+   -- add package configuration options here
+-  require Blaster from git "https://github.com/input-output-hk/Lean-blaster" @ "main"
++  require Blaster from "../blaster"
+ 
+ @[default_target]
+ lean_lib «PlutusCore» where

--- a/Benchmarks/cardano/patches/wsc.patch
+++ b/Benchmarks/cardano/patches/wsc.patch
@@ -1,0 +1,195 @@
+diff --git a/lake-manifest.json b/lake-manifest.json
+index bfbd62b..2d6dd71 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -3,27 +3,21 @@
+   "packagesDir": ".lake/packages",
+   "packages": [
+     {
+-      "url": "https://github.com/Anastasia-Labs/Lean-blaster",
+-      "type": "git",
+-      "subDir": null,
++      "type": "path",
+       "scope": "",
+-      "rev": "4d320dd5f70ac953945b5126f5cfd45128da8131",
+       "name": "Blaster",
+       "manifestFile": "lake-manifest.json",
+-      "inputRev": "wsc-d6-dite-branch-retype",
+       "inherited": false,
++      "dir": "../blaster",
+       "configFile": "lakefile.lean"
+     },
+     {
+-      "url": "https://github.com/Anastasia-Labs/PlutusCoreBlaster",
+-      "type": "git",
+-      "subDir": null,
++      "type": "path",
+       "scope": "",
+-      "rev": "3fdd3fb5cb259f039b60cc584cd954de18c819dc",
+       "name": "PlutusCore",
+       "manifestFile": "lake-manifest.json",
+-      "inputRev": "cip153-value-builtins",
+       "inherited": false,
++      "dir": "../plutuscore-wsc",
+       "configFile": "lakefile.lean"
+     }
+   ],
+diff --git a/lakefile.lean b/lakefile.lean
+index 344a0a6..7a22861 100644
+--- a/lakefile.lean
++++ b/lakefile.lean
+@@ -1,149 +1,9 @@
+ import Lake
+ open Lake DSL
+-
+ package «CardanoLedgerApi» where
+-  -- add package configuration options here
+-  moreGlobalServerArgs := #["--threads=4"]
+   moreLeanArgs := #["--threads=4"]
+-  -- Blaster is required FIRST on purpose (task R2): `PlutusCore`'s own lakefile
+-  -- requires `Blaster` from `input-output-hk/Lean-blaster` @ `"main"`, and lake
+-  -- resolves a package name once, at first encounter. Requiring our pinned
+-  -- Blaster before PlutusCore is what keeps that transitive `@ "main"` from
+-  -- winning. The rationale for this exact revision is the block below.
+-  require Blaster from git
+-    "https://github.com/Anastasia-Labs/Lean-blaster"
+-    @ "4d320dd5f70ac953945b5126f5cfd45128da8131"
+-  -- ══ SUBSTRATE PINS (WSC U5/X4; C3, audit D5; MACHINE-ENFORCED at task R2) ══
+-  --
+-  -- ┌── BOTH REQUIRES WERE ABSOLUTE LOCAL PATHS UNTIL 2026-07-28 ─────────────┐
+-  -- │ That was audit defect D5: lake does NOT verify the `rev` key on a       │
+-  -- │ `"type": "path"` manifest entry, so the recorded revisions were         │
+-  -- │ documentation rather than a lock and this repository could be built on  │
+-  -- │ one machine only. Both branches are now PUBLISHED and the requires      │
+-  -- │ below carry FULL 40-hex SHAs, which lake checks out by object id.       │
+-  -- │ DO NOT replace a SHA with a branch name — branch names move, object     │
+-  -- │ ids do not. Full third-party recipe: `WSC/REPRODUCE.md`.                │
+-  -- └─────────────────────────────────────────────────────────────────────────┘
+-  --
+-  -- PlutusCoreBlaster, pinned BY REVISION:
+-  --
+-  --   fork         https://github.com/Anastasia-Labs/PlutusCoreBlaster
+-  --   branch       cip153-value-builtins
+-  --   commit       3fdd3fb  (task N5; was 9f9ca8c)
+-  --   upstream base a04042c4b7b19c66e7e6fa5bbcc3b1c985894ed0
+-  --                = `refs/heads/main` of the PUBLIC repo
+-  --                  https://github.com/input-output-hk/PlutusCoreBlaster
+-  --   branch's own commits (2, +2832/−6 over the base):
+-  --     830819b  Add CIP-153 Value builtins
+-  --              (insertCoin/lookupCoin/unionValue/valueContains/valueData/unValueData)
+-  --     9f9ca8c  Value: blaster-friendly denotation restatement + algebra lemmas
+-  --     3fdd3fb  Add CIP-153 ScaleValue; fix unValueData/valueData costs to
+-  --              plutus 1.63  (task N5 — WITHOUT THIS THE POST-#112
+-  --              programmableSeize FLAT DOES NOT DECODE AT ALL)
+-  --   working tree CLEAN (`git status --porcelain` empty, re-verified 2026-07-25),
+-  --                so the verified substrate is a real commit and not an
+-  --                unrecorded working-tree state.
+-  --   CAVEAT      that checkout is a SHALLOW clone (`.git/shallow` grafts at the
+-  --                base; only 3 commits are present), so a whole-history
+-  --                `git bundle` made from it is UNUSABLE even though
+-  --                `git bundle verify` calls it "a complete history" — E3
+-  --                measured that failure. Use the incremental bundle below.
+-  --
+-  -- REVISION RECORD, in three places, deliberately redundant:
+-  --   * here;
+-  --   * `lake-manifest.json` — E3 measured that lake ACCEPTS and PRESERVES
+-  --     `"rev"` / `"inputRev"` keys on a `"type": "path"` entry across
+-  --     `lake build`, so the manifest now carries the revision too. (Lake does
+-  --     not itself check them for a path dep; `lake update` would drop them.)
+-  --   * `WSC/ARCHITECTURE.md` ADDENDUM E11.
+-  --
+-  -- OFFLINE ARTIFACTS (TWO, and both are needed — task N6):
+-  --   1. `WSC/substrate/pcb-cip153-value-builtins.bundle`
+-  --      (39,068 bytes, sha256 3d34a23d5e25ac09beddcdf6032ecb3d13c47d064239b09be8040842d1a82789)
+-  --      carries the two commits up to 9f9ca8c on top of the public base. E3
+-  --      verified it reconstructs HEAD 9f9ca8c and tree
+-  --      e75862b26b5055e8cc36ea8cf393054e2417ca62 byte-identically.
+-  --   2. `WSC/substrate/pcb-scalevalue-3fdd3fb.bundle`
+-  --      (14,697 bytes, sha256 0e373d0004275db3e9f80c8e4ef994e5b7955d952ca48048434ebc0a19b7d27c)
+-  --      is INCREMENTAL on top of 9f9ca8c and reconstructs HEAD 3fdd3fb, tree
+-  --      1c9d80221bd59fdd21ab132d1fcec086c7bbf3b9 — the revision ACTUALLY USED.
+-  -- See `WSC/substrate/README.md`.
+-  --
+-  -- WHAT DEPENDS ON IT: that branch carries the CIP-153 Value builtins — flat
+-  -- decoder tags 94-99 (`PlutusCore/UPLC/FlatEncoding/Basic.lean:305-310`) plus
+-  -- blaster-friendly Value denotations. Without them
+-  -- `WSC/flats/programmableLogicGlobal.flat` does not decode at all: against PCB
+-  -- `main` @ 4ef4860 the same flat fails with "Could not decode program!"
+-  -- (negative control, `WSC/Prep/Global.lean:10-13`). So EVERY P1/P5/P6 result
+-  -- "proved against production bytecode" inherits this pin.
+-  --
+-  -- RESIDUAL RISK, CLOSED at task R2: the bundle removed the "unpushed branch"
+-  -- objection but not the "single machine" one — an offline artifact is only as
+-  -- good as its custody. The branch is now published, so the require below is a
+-  -- real git pin and `WSC/substrate/` is historical rather than load-bearing.
+-  --
+-  -- Cross-references: `WSC/REPRODUCE.md` (third-party recipe, rehearsed end to
+-  -- end), `WSC/substrate/README.md` (bundle verify/apply),
+-  -- `WSC/flats/PROVENANCE.md` (bytecode chain), `WSC/ARCHITECTURE.md` E11.
+-  require PlutusCore from git
+-    "https://github.com/Anastasia-Labs/PlutusCoreBlaster"
+-    @ "3fdd3fb5cb259f039b60cc584cd954de18c819dc"
+-  -- Blaster IS pinned by rev in `lake-manifest.json`:
+-  --   59db213ca6396269d2606b7dd9ac2bc26ae7c4ce
+-  -- on the PUBLIC repo https://github.com/input-output-hk/Lean-blaster, where
+-  -- `refs/heads/beta-lambda-cache-optimization` still resolved to exactly that
+-  -- rev when E3 re-checked it (2026-07-25). Branch names move; the manifest rev
+-  -- is what is verified.
+-  -- ══ BLASTER MOVED PIN TOO (task N5, defect D6; republished at task R2) ════
+-  --
+-  -- Blaster WAS `from git … @ "beta-lambda-cache-optimization"` (rev 59db213).
+-  -- It is now THAT EXACT REV plus ONE commit, on a published fork:
+-  --
+-  --   fork    https://github.com/Anastasia-Labs/Lean-blaster
+-  --   branch  wsc-d6-dite-branch-retype
+-  --   commit  4d320dd  "Optimize/DITE: re-type branch binders from the final
+-  --                     condition (defect D6)"
+-  --   base    59db213  = the previously pinned git rev, unchanged underneath
+-  --
+-  -- WHY THIS HAD TO MOVE.  `Blaster.dite'` is well typed only when its branch
+-  -- binders are syntactically `c` and `¬c`, but the condition and the branch
+-  -- lambdas are optimized independently, so any normalisation that rewrites
+-  -- `¬c` without rewriting `c` produces a KERNEL-ILL-TYPED term and kills the
+-  -- whole `#prep_uplc`. Two such normalisations fire on the PR #112 bytecode
+-  -- (`¬(a ∧ b) ⇝ ¬a ∨ ¬b`, and `¬(true = x) ⇝ false = x`). Without the fix:
+-  --   * the programmableSeize shaped prep FAILS  → P2 unstatable  (defect D6)
+-  --   * WSC/Prep/Global1600 FAILS after ~8 min   → P1/P5/P6 unstatable (D8)
+-  -- With it, both elaborate, and the P4/minting family returns byte-identical
+-  -- verdict counts (42 ✅ Valid + 23 ✅ Expected Falsified) with and without —
+-  -- measured as a control, see WSC/IMPACT-PR112.md.
+-  --
+-  -- PUBLISHED at task R2 (it was previously an unpushed local clone, and this
+-  -- comment said so). Nothing to edit to build elsewhere: the require is a git
+-  -- pin at a full SHA.
+-  --
+-  -- OFFLINE ARTIFACT (NEW at task N6 — before it, this dependency had NONE, so
+-  -- `WSC/substrate/` did not actually reconstruct the substrate):
+-  --   `WSC/substrate/blaster-d6-dite-4d320dd.bundle`
+-  --   (3,313 bytes, sha256 19e67631d1d5ff30ac0c47377131188031d66c6fa1aebaa37de775dbcb502b8c)
+-  --   incremental on public 59db213, reconstructs HEAD 4d320dd, tree
+-  --   9550c96b0dff95096d07d29825a19d885fe7c6cd.
+-  --   Equivalently `WSC/substrate/patches/0003-Optimize-DITE-re-type-branch-binders-D6.patch`.
+-  -- Both bundles verify with `git bundle verify` against the LOCAL repos only;
+-  -- they have not been tested against a fresh clone of the public remotes.
+-  --
+-  -- The `require Blaster` line itself is at the TOP of this block, ahead of
+-  -- `require PlutusCore` — see the ordering note there. It must stay ahead of it.
+-
+-@[default_target]
+-lean_lib «CardanoLedgerApi» where
+-   -- add library configuration options here
+-
+-@[test_driver]
+-lean_lib «Tests» where
+-  -- add library configuration options here
+-
+-/-- WSC (Wyoming Stable Token / CIP-113 programmable tokens) containment
+-proofs: UPLC-level verification of the compiled production validators.
+-See WSC/ARCHITECTURE.md. -/
+-lean_lib «WSC» where
+-  -- root module WSC.lean imports the WSC.* tree
++require Blaster from "../blaster"
++require PlutusCore from "../plutuscore-wsc"
++@[default_target] lean_lib «CardanoLedgerApi»
++@[test_driver] lean_lib «Tests»
++lean_lib «WSC»

--- a/Benchmarks/cardano/pins.json
+++ b/Benchmarks/cardano/pins.json
@@ -1,0 +1,7 @@
+{
+  "blaster": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+  "cardano": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+  "wsc": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+  "plutuscore": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+  "plutuscore-wsc": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8"
+}

--- a/Benchmarks/cardano/prepare_local.py
+++ b/Benchmarks/cardano/prepare_local.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Create isolated, pinned Cardano benchmark checkouts from existing local clones.
+
+Source working-tree changes are never copied. Two workload pins are local
+investigation commits, so this intentionally accepts local repositories rather
+than pretending every pin is fetchable from upstream GitHub.
+"""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+NAMES = ['blaster', 'cardano', 'wsc', 'plutuscore', 'plutuscore-wsc']
+p = argparse.ArgumentParser(description=__doc__)
+p.add_argument('--root', type=Path, required=True, help='New output directory')
+for name in NAMES:
+    p.add_argument('--' + name, type=Path, required=True, help='Existing local source repository')
+p.add_argument('--blaster-rev', default=None, help='Override the pinned baseline with a candidate commit')
+p.add_argument('--no-build', action='store_true', help='Create checkouts only; build dependencies before timing')
+a = p.parse_args()
+pins = json.loads((HERE / 'pins.json').read_text())
+if a.blaster_rev:
+    pins['blaster'] = a.blaster_rev
+root = a.root.resolve()
+if root.exists():
+    raise SystemExit('Output directory already exists. Choose a new directory.')
+# Validate all inputs before creating anything.
+for name in NAMES:
+    source = getattr(a, name.replace('-', '_')).resolve()
+    subprocess.run(['git', '-C', str(source), 'cat-file', '-e', pins[name] + '^{commit}'], check=True)
+root.mkdir(parents=True)
+for name in NAMES:
+    source = getattr(a, name.replace('-', '_')).resolve()
+    target = root / name
+    subprocess.run(['git', 'clone', '--no-hardlinks', '--no-checkout', str(source), str(target)], check=True)
+    subprocess.run(['git', 'checkout', '--detach', pins[name]], cwd=target, check=True)
+    patch = HERE / 'patches' / (name + '.patch')
+    if patch.exists():
+        subprocess.run(['git', 'apply', str(patch)], cwd=target, check=True)
+if not a.no_build:
+    subprocess.run(['lake', 'build', 'CardanoLedgerApi.V3', 'PlutusCore.UPLC'], cwd=root/'cardano', check=True)
+    subprocess.run(['lake', 'build', 'WSC.Prep.GlobalImport'], cwd=root/'wsc', check=True)
+print(root)

--- a/Benchmarks/cardano/results/ancestor-scout.json
+++ b/Benchmarks/cardano/results/ancestor-scout.json
@@ -1,0 +1,141 @@
+{
+  "label": "ancestor-scout",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "d9e5a94333e17f861f6b3bb1d79243f33708fe73a586da3809f0747d99f4547d"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "cpu_sample": false,
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2070757376,
+      "prep": {
+        "optimize_ms": 30350,
+        "hashcons": 5235488,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "9bc0b034c60b9be3f587c3cf0a17412781a9fb2198ee7e34cec5357b24ef73de",
+      "elapsed_seconds": 32.343816000036895,
+      "exit_code": 0,
+      "olean_bytes": 815656
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1657192448,
+      "prep": {
+        "optimize_ms": 4690,
+        "hashcons": 741749,
+        "contexts": 7575,
+        "beta_cache": 237
+      },
+      "source_sha256": "ba23c32c1953bec198fe9d3d6f510a253d9b0f2956126132c688e6321dd4d0c6",
+      "elapsed_seconds": 6.172698917100206,
+      "exit_code": 0,
+      "olean_bytes": 475424
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1578008576,
+      "prep": {
+        "optimize_ms": 204,
+        "hashcons": 51642,
+        "contexts": 154,
+        "beta_cache": 189
+      },
+      "source_sha256": "05adfa8df4aaeab945c8ee1521907b5f5388b1c4e22aa9342f2a2dcebf2eb292",
+      "elapsed_seconds": 1.7124637919478118,
+      "exit_code": 0,
+      "olean_bytes": 154464
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2007711744,
+      "prep": {
+        "optimize_ms": 29462,
+        "hashcons": 5444062,
+        "contexts": 17761,
+        "beta_cache": 252
+      },
+      "source_sha256": "9939b1f4c3160625d19e03dad7a735e74e0fc8cd4498323d8c71eda169f99581",
+      "elapsed_seconds": 31.919268375029787,
+      "exit_code": 0,
+      "olean_bytes": 2216120
+    },
+    {
+      "case": "global",
+      "budget": 1400,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1400-1.log",
+      "sampled_peak_rss_bytes": 1746960384,
+      "prep": {
+        "optimize_ms": 7518,
+        "hashcons": 1927386,
+        "contexts": 21406,
+        "beta_cache": 554
+      },
+      "source_sha256": "e29be40de75de31f0d372d9771524a0f2c76a2224b40d693d964cf36958b9b61",
+      "elapsed_seconds": 9.563359082909301,
+      "exit_code": 0,
+      "olean_bytes": 167424
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 2417197056,
+      "prep": {
+        "optimize_ms": 35337,
+        "hashcons": 9832452,
+        "contexts": 95810,
+        "beta_cache": 1970
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 37.9689446662087,
+      "exit_code": 0,
+      "olean_bytes": 577424
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/baseline-ceiling.json
+++ b/Benchmarks/cardano/results/baseline-ceiling.json
@@ -1,0 +1,57 @@
+{
+  "label": "baseline-ceiling",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "timeout",
+      "log": "global-1800-1.log",
+      "sampled_peak_rss_bytes": 7406419968,
+      "prep": {},
+      "source_sha256": "d3fb9e08ab1c033bfffc5cc716814a23aba508b987cb668276a3b0b8b76fe37b",
+      "elapsed_seconds": 240.20673025003634,
+      "exit_code": -9
+    },
+    {
+      "case": "global",
+      "budget": 2000,
+      "repeat": 1,
+      "status": "cancelled",
+      "log": "global-2000-1.log",
+      "sampled_peak_rss_bytes": 0,
+      "prep": {},
+      "source_sha256": "4eaa97eb6d2fa241aa99fba55322409a8cbe09124e1dc1867772bb1cdcafaf3e",
+      "reason": "Stopped after 1800 exceeded 240 seconds; prioritize preparation optimization. No timing comparison for this partial run."
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/baseline-global-proof.json
+++ b/Benchmarks/cardano/results/baseline-global-proof.json
@@ -1,0 +1,50 @@
+{
+  "label": "baseline-global-proof",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "cpu_sample": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 1547223040,
+      "prep": {},
+      "source_sha256": "afefb5a921decf5e1b05a268c50f4518f45f823f4dd259978868a041ca9bd7d9",
+      "elapsed_seconds": 1.6716808748897165,
+      "exit_code": 0,
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:14:2: \u2705 Valid"
+      ],
+      "olean_bytes": 123544
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/baseline-global.json
+++ b/Benchmarks/cardano/results/baseline-global.json
@@ -1,0 +1,87 @@
+{
+  "label": "baseline-global",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "cpu_sample": false,
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1400,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1400-1.log",
+      "sampled_peak_rss_bytes": 1826586624,
+      "prep": {
+        "optimize_ms": 11085,
+        "hashcons": 3131631,
+        "contexts": 22056,
+        "beta_cache": 560
+      },
+      "source_sha256": "e29be40de75de31f0d372d9771524a0f2c76a2224b40d693d964cf36958b9b61",
+      "elapsed_seconds": 12.810438457876444,
+      "exit_code": 0,
+      "olean_bytes": 173856
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 3431481344,
+      "prep": {
+        "optimize_ms": 59456,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 63.079557666089386,
+      "exit_code": 0,
+      "olean_bytes": 633904
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2079604736,
+      "prep": {
+        "optimize_ms": 34587,
+        "hashcons": 7293990,
+        "contexts": 17761,
+        "beta_cache": 252
+      },
+      "source_sha256": "9939b1f4c3160625d19e03dad7a735e74e0fc8cd4498323d8c71eda169f99581",
+      "elapsed_seconds": 37.51004495797679,
+      "exit_code": 0,
+      "olean_bytes": 2216120
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/baseline-scout.json
+++ b/Benchmarks/cardano/results/baseline-scout.json
@@ -1,0 +1,111 @@
+{
+  "label": "baseline-scout",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "cpu_sample": false,
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2343944192,
+      "prep": {
+        "optimize_ms": 35622,
+        "hashcons": 8106674,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "9bc0b034c60b9be3f587c3cf0a17412781a9fb2198ee7e34cec5357b24ef73de",
+      "elapsed_seconds": 38.52531266701408,
+      "exit_code": 0,
+      "olean_bytes": 831120
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1758019584,
+      "prep": {
+        "optimize_ms": 5981,
+        "hashcons": 1682983,
+        "contexts": 7575,
+        "beta_cache": 237
+      },
+      "source_sha256": "ba23c32c1953bec198fe9d3d6f510a253d9b0f2956126132c688e6321dd4d0c6",
+      "elapsed_seconds": 7.836919958004728,
+      "exit_code": 0,
+      "olean_bytes": 475424
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1577926656,
+      "prep": {
+        "optimize_ms": 203,
+        "hashcons": 52254,
+        "contexts": 154,
+        "beta_cache": 189
+      },
+      "source_sha256": "05adfa8df4aaeab945c8ee1521907b5f5388b1c4e22aa9342f2a2dcebf2eb292",
+      "elapsed_seconds": 1.6951719999779016,
+      "exit_code": 0,
+      "olean_bytes": 154464
+    },
+    {
+      "case": "global",
+      "budget": 1400,
+      "repeat": 1,
+      "status": "error",
+      "log": "global-1400-1.log",
+      "sampled_peak_rss_bytes": 1535541248,
+      "prep": {},
+      "source_sha256": "a03716ab89e1f6eb76736b76427bbf8d75b67400a5bec6729037f8bbb7145793",
+      "elapsed_seconds": 1.7103601249400526,
+      "exit_code": 1
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "error",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 719339520,
+      "prep": {},
+      "source_sha256": "ce86806c5bf1179ba365180d2ceba768bae58c9df4589a72aa2f682bffcbd9e5",
+      "elapsed_seconds": 1.1415438749827445,
+      "exit_code": 1
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/baseline-sellnft-proof.json
+++ b/Benchmarks/cardano/results/baseline-sellnft-proof.json
@@ -1,0 +1,61 @@
+{
+  "label": "baseline-sellnft-proof",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "0d3734ed8b5d64ea41682b36f684c179fbfe99e5728369b2829817a856274327",
+  "retain_constructor_choices": false,
+  "cpu_sample": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2313306112,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.4518130000215,
+      "exit_code": 1,
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/baseline-sellnft-recheck.json
+++ b/Benchmarks/cardano/results/baseline-sellnft-recheck.json
@@ -1,0 +1,60 @@
+{
+  "label": "baseline-sellnft-recheck",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "0d3734ed8b5d64ea41682b36f684c179fbfe99e5728369b2829817a856274327",
+  "retain_constructor_choices": false,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2343944192,
+      "prep": {
+        "optimize_ms": 35053,
+        "hashcons": 8106674,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "9bc0b034c60b9be3f587c3cf0a17412781a9fb2198ee7e34cec5357b24ef73de",
+      "elapsed_seconds": 37.822682624915615,
+      "exit_code": 0,
+      "olean_bytes": 831120
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/choices-paramfeed-proof.json
+++ b/Benchmarks/cardano/results/choices-paramfeed-proof.json
@@ -1,0 +1,58 @@
+{
+  "label": "choices-paramfeed-proof",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "537e8ce1366fc29553209b737fcb2fca57369b0cd2d0b4cf7a8b4d893ae42ba4"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "0d3734ed8b5d64ea41682b36f684c179fbfe99e5728369b2829817a856274327",
+  "retain_constructor_choices": true,
+  "cpu_sample": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1578844160,
+      "prep": {},
+      "source_sha256": "32179fa549f12ef97b83fe568f0e45a4846b5ccce14d10a38c0d0be992995c87",
+      "elapsed_seconds": 1.6756786671467125,
+      "exit_code": 0,
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:21:63: \u2705 Valid"
+      ],
+      "olean_bytes": 403592
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/choices-scout.json
+++ b/Benchmarks/cardano/results/choices-scout.json
@@ -1,0 +1,132 @@
+{
+  "label": "choices-scout",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "537e8ce1366fc29553209b737fcb2fca57369b0cd2d0b4cf7a8b4d893ae42ba4"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "0d3734ed8b5d64ea41682b36f684c179fbfe99e5728369b2829817a856274327",
+  "retain_constructor_choices": true,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 2581659648,
+      "prep": {
+        "optimize_ms": 105845,
+        "hashcons": 8245343,
+        "contexts": 95418,
+        "beta_cache": 1184
+      },
+      "source_sha256": "87f5dc0e8ee07116957f9fc7569bfdaced297ef9dc87efadf4410b808d0a4740",
+      "elapsed_seconds": 108.22083837492391,
+      "exit_code": 0,
+      "olean_bytes": 633904
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1659486208,
+      "prep": {
+        "optimize_ms": 1581,
+        "hashcons": 406748,
+        "contexts": 10887,
+        "beta_cache": 764
+      },
+      "source_sha256": "8ccdd19b9ed8e8baa066e3e480e9b8a48f8fa8c4891a9f6f2863717bb85cf274",
+      "elapsed_seconds": 3.34451595810242,
+      "exit_code": 0,
+      "olean_bytes": 754032
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 1620017152,
+      "prep": {
+        "optimize_ms": 1624,
+        "hashcons": 402950,
+        "contexts": 10823,
+        "beta_cache": 743
+      },
+      "source_sha256": "0f3e6dacfcc900d0a861685c685ed5123ae232dc673f0fab9752d424f8ae2f6b",
+      "elapsed_seconds": 2.8098594578914344,
+      "exit_code": 0,
+      "olean_bytes": 1007304
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1633452032,
+      "prep": {
+        "optimize_ms": 1648,
+        "hashcons": 410645,
+        "contexts": 10887,
+        "beta_cache": 763
+      },
+      "source_sha256": "200142727fcdc8c729bddfd15617aab19fe6d28597c98a88272696bf127cccb6",
+      "elapsed_seconds": 3.348807959118858,
+      "exit_code": 0,
+      "olean_bytes": 2535128
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1628389376,
+      "prep": {
+        "optimize_ms": 1633,
+        "hashcons": 406684,
+        "contexts": 10889,
+        "beta_cache": 764
+      },
+      "source_sha256": "7875da2dceb22da7ccb87602da966f3ad14511e514a1c64be8fe94d302263e9b",
+      "elapsed_seconds": 2.8193317078985274,
+      "exit_code": 0,
+      "olean_bytes": 482016
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/choices-sellnft-proof.json
+++ b/Benchmarks/cardano/results/choices-sellnft-proof.json
@@ -1,0 +1,61 @@
+{
+  "label": "choices-sellnft-proof",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "537e8ce1366fc29553209b737fcb2fca57369b0cd2d0b4cf7a8b4d893ae42ba4"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "0d3734ed8b5d64ea41682b36f684c179fbfe99e5728369b2829817a856274327",
+  "retain_constructor_choices": true,
+  "cpu_sample": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 7196524544,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 157.26818024995737,
+      "exit_code": 1,
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/choices-sellnft-recheck.json
+++ b/Benchmarks/cardano/results/choices-sellnft-recheck.json
@@ -1,0 +1,60 @@
+{
+  "label": "choices-sellnft-recheck",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "537e8ce1366fc29553209b737fcb2fca57369b0cd2d0b4cf7a8b4d893ae42ba4"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "0d3734ed8b5d64ea41682b36f684c179fbfe99e5728369b2829817a856274327",
+  "retain_constructor_choices": true,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 1625784320,
+      "prep": {
+        "optimize_ms": 1547,
+        "hashcons": 402950,
+        "contexts": 10823,
+        "beta_cache": 743
+      },
+      "source_sha256": "0f3e6dacfcc900d0a861685c685ed5123ae232dc673f0fab9752d424f8ae2f6b",
+      "elapsed_seconds": 2.782409249804914,
+      "exit_code": 0,
+      "olean_bytes": 1007304
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/demand-scout.json
+++ b/Benchmarks/cardano/results/demand-scout.json
@@ -1,0 +1,79 @@
+{
+  "label": "demand-scout",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "daeafbc7518ed80e893d1b2868bc7688610b3ff1703b966e2707cffb7595e246"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "6439bc0c87c6e4bfaf2ff8cf6de696d37d5695b21b266bbf869f3c1f02e4af72",
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": true,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "timeout",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 7903232000,
+      "prep": {},
+      "source_sha256": "2be2a5d6c7a60a8d0352ccfd9c860c63f6195852196f374541afac9b6f48cc01",
+      "elapsed_seconds": 120.4945089998655,
+      "exit_code": -9
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "memory_limit",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 17204428800,
+      "prep": {},
+      "source_sha256": "36cc1824f8e548b248df718c38bdc9f6b3e73884eec862acac84dbdfab926f64",
+      "elapsed_seconds": 50.67584550008178,
+      "exit_code": -9
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "interrupted",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 3140452352,
+      "prep": {},
+      "source_sha256": "a8ccac8433de058b10e0a7e4c9ed21cca2e049d188f56bd0876a8d3f4d6c2df8",
+      "elapsed_seconds": 5.988912250148132,
+      "reason": "KeyboardInterrupt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/pure-scout.json
+++ b/Benchmarks/cardano/results/pure-scout.json
@@ -1,0 +1,146 @@
+{
+  "label": "pure-scout",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "6118b0d6817903113dba5a1516b858922093d18bf269ac0beed733fb50d128c9"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "7c5255e22c63cd44d3301f4c46050aa974b336e1e2f36c6f105c8be4b0505725"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "ac1b7dac82c1909fcef51b5ce0ceed1519009961cb21d7758ff77f0d09356c5a"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "b9c7c3f9f6611a02ab5d3fb864d70fa79237217a88acf32c34fb28f171f5ffe8",
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 3444490240,
+      "prep": {
+        "optimize_ms": 60097,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044,
+        "transform_hits": 1891315,
+        "transform_misses": 1022282,
+        "transform_resets": 15
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 63.66115220915526,
+      "exit_code": 0,
+      "olean_bytes": 633904
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1759150080,
+      "prep": {
+        "optimize_ms": 5791,
+        "hashcons": 1682983,
+        "contexts": 7575,
+        "beta_cache": 237,
+        "transform_hits": 188180,
+        "transform_misses": 87077,
+        "transform_resets": 1
+      },
+      "source_sha256": "ba23c32c1953bec198fe9d3d6f510a253d9b0f2956126132c688e6321dd4d0c6",
+      "elapsed_seconds": 7.25781208416447,
+      "exit_code": 0,
+      "olean_bytes": 475424
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2344206336,
+      "prep": {
+        "optimize_ms": 35916,
+        "hashcons": 8106674,
+        "contexts": 29063,
+        "beta_cache": 221,
+        "transform_hits": 1420777,
+        "transform_misses": 361024,
+        "transform_resets": 5
+      },
+      "source_sha256": "9bc0b034c60b9be3f587c3cf0a17412781a9fb2198ee7e34cec5357b24ef73de",
+      "elapsed_seconds": 38.50874895812012,
+      "exit_code": 0,
+      "olean_bytes": 831120
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2083553280,
+      "prep": {
+        "optimize_ms": 33936,
+        "hashcons": 7293990,
+        "contexts": 17761,
+        "beta_cache": 252,
+        "transform_hits": 1985837,
+        "transform_misses": 93033,
+        "transform_resets": 1
+      },
+      "source_sha256": "9939b1f4c3160625d19e03dad7a735e74e0fc8cd4498323d8c71eda169f99581",
+      "elapsed_seconds": 36.25278787501156,
+      "exit_code": 0,
+      "olean_bytes": 2216120
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1577549824,
+      "prep": {
+        "optimize_ms": 199,
+        "hashcons": 52254,
+        "contexts": 154,
+        "beta_cache": 189,
+        "transform_hits": 561,
+        "transform_misses": 5775,
+        "transform_resets": 0
+      },
+      "source_sha256": "05adfa8df4aaeab945c8ee1521907b5f5388b1c4e22aa9342f2a2dcebf2eb292",
+      "elapsed_seconds": 1.6893667501863092,
+      "exit_code": 0,
+      "olean_bytes": 154464
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/replay2-scout.json
+++ b/Benchmarks/cardano/results/replay2-scout.json
@@ -1,0 +1,134 @@
+{
+  "label": "replay2-scout",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "ab566902c8db430ede4a216451aeaf548049ff6111ceb3143205dbf72b1948f1"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "cc5f37061d519a38a7c009eaa8492028c2a4b4f8b18d370c8da43470d375369e",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 3433299968,
+      "prep": {
+        "optimize_ms": 61541,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 64.92991349985823,
+      "exit_code": 0,
+      "olean_bytes": 633904
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2342158336,
+      "prep": {
+        "optimize_ms": 36417,
+        "hashcons": 8106674,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "9bc0b034c60b9be3f587c3cf0a17412781a9fb2198ee7e34cec5357b24ef73de",
+      "elapsed_seconds": 38.934717832831666,
+      "exit_code": 0,
+      "olean_bytes": 831120
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1757642752,
+      "prep": {
+        "optimize_ms": 6067,
+        "hashcons": 1682983,
+        "contexts": 7575,
+        "beta_cache": 237
+      },
+      "source_sha256": "ba23c32c1953bec198fe9d3d6f510a253d9b0f2956126132c688e6321dd4d0c6",
+      "elapsed_seconds": 7.792102958075702,
+      "exit_code": 0,
+      "olean_bytes": 475424
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2078670848,
+      "prep": {
+        "optimize_ms": 35566,
+        "hashcons": 7293990,
+        "contexts": 17761,
+        "beta_cache": 252
+      },
+      "source_sha256": "9939b1f4c3160625d19e03dad7a735e74e0fc8cd4498323d8c71eda169f99581",
+      "elapsed_seconds": 38.241305040894076,
+      "exit_code": 0,
+      "olean_bytes": 2216120
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1577025536,
+      "prep": {
+        "optimize_ms": 207,
+        "hashcons": 52254,
+        "contexts": 154,
+        "beta_cache": 189
+      },
+      "source_sha256": "05adfa8df4aaeab945c8ee1521907b5f5388b1c4e22aa9342f2a2dcebf2eb292",
+      "elapsed_seconds": 1.6742602498270571,
+      "exit_code": 0,
+      "olean_bytes": 154464
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/selective-scout.json
+++ b/Benchmarks/cardano/results/selective-scout.json
@@ -1,0 +1,138 @@
+{
+  "label": "selective-scout",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "36c3a15a9fdc9f3237ad376f8d67665e3742d3f8",
+      "tracked_patch_sha256": "bb193bc4f3bf231d1e72222064af5c9346a1895da4fc066268e47a5b016f866c"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "cc5f37061d519a38a7c009eaa8492028c2a4b4f8b18d370c8da43470d375369e",
+  "retain_choice_types": [
+    "List",
+    "Prod",
+    "PlutusCore.Data.Data"
+  ],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 2581708800,
+      "prep": {
+        "optimize_ms": 107123,
+        "hashcons": 8273518,
+        "contexts": 95488,
+        "beta_cache": 1184
+      },
+      "source_sha256": "8c221f37fd3cfb225292745e146de2dd4e9aa651edf18029ecd01526f39844a4",
+      "elapsed_seconds": 109.61884495802224,
+      "exit_code": 0,
+      "olean_bytes": 634096
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2339323904,
+      "prep": {
+        "optimize_ms": 36142,
+        "hashcons": 8106483,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "d84a1a116b0372c58f51c107ddd17c6bd746430ea105c1d4e3984c086d0e22cb",
+      "elapsed_seconds": 38.48148729093373,
+      "exit_code": 0,
+      "olean_bytes": 831312
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2081800192,
+      "prep": {
+        "optimize_ms": 34897,
+        "hashcons": 7289707,
+        "contexts": 17761,
+        "beta_cache": 252
+      },
+      "source_sha256": "f323cfa9101b178a77d32252584e7f574bc8ccf268ea39106468bf4119c79620",
+      "elapsed_seconds": 37.30225404212251,
+      "exit_code": 0,
+      "olean_bytes": 2216312
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1747812352,
+      "prep": {
+        "optimize_ms": 5920,
+        "hashcons": 1678689,
+        "contexts": 7575,
+        "beta_cache": 237
+      },
+      "source_sha256": "47d1756261b0644bfda18a451b78fcaa002aa6e976dafbba467851d43d2b13cd",
+      "elapsed_seconds": 7.7627166248857975,
+      "exit_code": 0,
+      "olean_bytes": 475616
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1576845312,
+      "prep": {
+        "optimize_ms": 207,
+        "hashcons": 47927,
+        "contexts": 154,
+        "beta_cache": 189
+      },
+      "source_sha256": "0a30a35a67a8c3a7fa60b4cbd382df0240b60914e82f70b57aed98e6f7716b74",
+      "elapsed_seconds": 1.6861544998828322,
+      "exit_code": 0,
+      "olean_bytes": 154656
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/values-paramfeed-proof.json
+++ b/Benchmarks/cardano/results/values-paramfeed-proof.json
@@ -1,0 +1,66 @@
+{
+  "label": "values-paramfeed-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "e6b32fc378fcb7e756f49b12c05d7ec90ad6ece0",
+      "tracked_patch_sha256": "b209e020379933efb2300b7a83427e0c444471e8820a724100c33908348f20f8"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "cc5f37061d519a38a7c009eaa8492028c2a4b4f8b18d370c8da43470d375369e",
+  "retain_choice_types": [
+    "PlutusCore.UPLC.Term.Const",
+    "PlutusCore.UPLC.Term.Term",
+    "PlutusCore.UPLC.CekValue.CekValue",
+    "PlutusCore.UPLC.CekValue.Environment",
+    "PlutusCore.Data.Data"
+  ],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1585152000,
+      "prep": {},
+      "source_sha256": "32179fa549f12ef97b83fe568f0e45a4846b5ccce14d10a38c0d0be992995c87",
+      "elapsed_seconds": 1.6630727499723434,
+      "exit_code": 0,
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:21:63: \u2705 Valid"
+      ],
+      "olean_bytes": 140016
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/values-scout.json
+++ b/Benchmarks/cardano/results/values-scout.json
@@ -1,0 +1,140 @@
+{
+  "label": "values-scout",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "e6b32fc378fcb7e756f49b12c05d7ec90ad6ece0",
+      "tracked_patch_sha256": "b209e020379933efb2300b7a83427e0c444471e8820a724100c33908348f20f8"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "6c56363bbf8c2e3cf4a4b03612c7aece4282be2d1de79fb20b47db3696388a2d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "42ea3efa0b12837fca6d35916ad6483e157876f7f767949342a3a24bc64890ac"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "cc5f37061d519a38a7c009eaa8492028c2a4b4f8b18d370c8da43470d375369e",
+  "retain_choice_types": [
+    "PlutusCore.UPLC.Term.Const",
+    "PlutusCore.UPLC.Term.Term",
+    "PlutusCore.UPLC.CekValue.CekValue",
+    "PlutusCore.UPLC.CekValue.Environment",
+    "PlutusCore.Data.Data"
+  ],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2311618560,
+      "prep": {
+        "optimize_ms": 33815,
+        "hashcons": 7822374,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "d116b1f969f5460a99e09580fbaefb19e254ffd44ad91b8daf3f6216c423c987",
+      "elapsed_seconds": 36.365789792034775,
+      "exit_code": 0,
+      "olean_bytes": 831312
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 2572075008,
+      "prep": {
+        "optimize_ms": 99777,
+        "hashcons": 8099229,
+        "contexts": 95422,
+        "beta_cache": 1184
+      },
+      "source_sha256": "d6b02a569e9d522d0ea9ef101813085f57842ff4072181a7ae945e97222dae94",
+      "elapsed_seconds": 102.1105927079916,
+      "exit_code": 0,
+      "olean_bytes": 634096
+    },
+    {
+      "case": "minting",
+      "budget": 1200,
+      "repeat": 1,
+      "status": "completed",
+      "log": "minting-1200-1.log",
+      "sampled_peak_rss_bytes": 1752891392,
+      "prep": {
+        "optimize_ms": 5777,
+        "hashcons": 1625957,
+        "contexts": 7575,
+        "beta_cache": 237
+      },
+      "source_sha256": "0aad10c73069c192b38a11f9e65037a4cf3fa1c44fd21f1fde7463a6c564c02c",
+      "elapsed_seconds": 7.35228474996984,
+      "exit_code": 0,
+      "olean_bytes": 475616
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2071560192,
+      "prep": {
+        "optimize_ms": 33886,
+        "hashcons": 7221024,
+        "contexts": 17759,
+        "beta_cache": 252
+      },
+      "source_sha256": "1f7ccf3e8a6a36de10e595478c98100608b2058b9a3c0bcc427f208e11019041",
+      "elapsed_seconds": 36.77347491681576,
+      "exit_code": 0,
+      "olean_bytes": 2216312
+    },
+    {
+      "case": "paramfeed",
+      "budget": 10000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "paramfeed-10000-1.log",
+      "sampled_peak_rss_bytes": 1575305216,
+      "prep": {
+        "optimize_ms": 193,
+        "hashcons": 47898,
+        "contexts": 154,
+        "beta_cache": 189
+      },
+      "source_sha256": "ea6aa86275c0a3527d04c34dcaebd9973fc59659582103f4ab13436b4a4472fc",
+      "elapsed_seconds": 1.6962694157846272,
+      "exit_code": 0,
+      "olean_bytes": 154656
+    }
+  ]
+}

--- a/Benchmarks/cardano_bench.py
+++ b/Benchmarks/cardano_bench.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Run native Lake Cardano prep benchmarks, serially, with resource bounds.
+
+Dependencies must already be built. Every run regenerates just the target
+module, preserving its Lean names and deleting only its own compiled output.
+"""
+import argparse
+import hashlib
+import json
+import os
+import platform
+from pathlib import Path
+import re
+import signal
+import subprocess
+import time
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--root', type=Path, required=True, help='Directory containing cardano/, wsc/, blaster/ and the two PlutusCore copies')
+parser.add_argument('--label', required=True)
+parser.add_argument('--cases', nargs='+', default=['sellnft:1800','minting:1200','paramfeed:10000','governance:9000','global:1600'])
+parser.add_argument('--repeat', type=int, default=1)
+parser.add_argument('--timeout', type=float, default=300)
+parser.add_argument('--max-rss-gib', type=float, default=16)
+parser.add_argument('--sample', action='store_true', help='Take one macOS CPU sample; use separate runs from timing comparisons')
+parser.add_argument('--reduce-before-arguments', action='store_true', help='Reduce functions and projections before normalizing their arguments')
+parser.add_argument('--retain-constructor-choices', action='store_true', help='Keep conditionals and matches inside constructor fields during preparation')
+parser.add_argument('--retain-choice-types', nargs='*', default=[], help='Label selected inductive types or constructors to retain field choices')
+parser.add_argument('--proofs-only', action='store_true', help='Check properties against the existing, exactly matching prepared benchmark module')
+a=parser.parse_args()
+if a.repeat < 1 or a.timeout <= 0 or a.max_rss_gib <= 0:
+    parser.error('repeat, timeout and memory limit must be positive')
+if not re.fullmatch(r'[A-Za-z0-9_-]+', a.label):
+    parser.error('label must contain only letters, digits, underscore or hyphen')
+if any(not re.fullmatch(r'[A-Za-z_][A-Za-z0-9_.]*', n) for n in a.retain_choice_types):
+    parser.error('retain-choice-types must be fully qualified Lean declaration names')
+root=a.root.resolve()
+logs=root/'results'/a.label
+logs.mkdir(parents=True,exist_ok=True)
+fixture_names={'sellnft':'SellNFT','minting':'MintingPolicy','paramfeed':'ParamFeed','governance':'Governance','hello':'HelloWorld','unlock':'UnlockPIN'}
+
+def output(cmd,cwd=None):
+    return subprocess.check_output(cmd,cwd=cwd,text=True).strip()
+
+def snapshot(parent):
+    lines=output(['ps','-axo','pid=,ppid=,rss=,comm=']).splitlines()
+    entries=[]
+    for line in lines:
+        cols=line.split(None,3)
+        if len(cols)==4:
+            entries.append((int(cols[0]),int(cols[1]),int(cols[2])*1024,cols[3]))
+    ids={parent}
+    while True:
+        more={pid for pid,ppid,_,_ in entries if ppid in ids}
+        if more<=ids: break
+        ids|=more
+    return [e for e in entries if e[0] in ids]
+
+def pin(pkg):
+    path=root/pkg
+    diff=subprocess.check_output(['git','-c','core.fsmonitor=false','diff','HEAD'],cwd=path)
+    return {'commit':output(['git','rev-parse','HEAD'],path),'tracked_patch_sha256':hashlib.sha256(diff).hexdigest()}
+
+result={'label':a.label,'repeat':a.repeat,'timeout_seconds':a.timeout,'rss_limit_bytes':int(a.max_rss_gib*2**30),
+        'lean':output(['lake','env','lean','--version'],root/'cardano'),
+        'pins':{p:pin(p) for p in ['cardano','wsc','blaster','plutuscore','plutuscore-wsc']},
+        'machine':{'system':platform.system(),'release':platform.release(),'architecture':platform.machine(),'logical_cpus':os.cpu_count()},
+        'runner_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        'retain_choice_types':a.retain_choice_types,'retain_constructor_choices':a.retain_constructor_choices,'reduce_before_arguments':a.reduce_before_arguments,
+        'cpu_sample':a.sample,'phase':'proof' if a.proofs_only else 'prep',
+        'allocator_env':{k:v for k,v in os.environ.items() if k.startswith('MIMALLOC_')},'runs':[]}
+
+def save():
+    (logs/'results.json').write_text(json.dumps(result,indent=2)+'\n')
+
+for case in a.cases:
+    name,raw_budget=case.split(':');budget=int(raw_budget)
+    if name=='global':
+        cwd=root/'wsc'
+        text=f'''import WSC.Prep.GlobalImport
+import Blaster
+set_option maxHeartbeats 0
+namespace WSC.Benchmark
+#prep_uplc appliedGlobalPerf programmableLogicGlobal1600 WSC.globalInputs1600 {budget}
+end WSC.Benchmark
+'''
+    else:
+        cwd=root/'cardano';fixture=fixture_names[name]
+        text=(cwd/f'Tests/Scripts/{fixture}/{fixture}.lean').read_text()
+        text=re.sub(r'\(stats-file: [^)]*\)|\(stats-interval: [^)]*\)','',text)
+        text=re.sub(r'(#prep_uplc[^\n]*?)\d+\s*\n',lambda m:m[1]+str(budget)+'\n',text)
+        text=text.replace('\nnamespace ', '\nset_option maxHeartbeats 0\nnamespace ',1)
+    if a.reduce_before_arguments:
+        text=text.replace('set_option maxHeartbeats 0', 'set_option blaster.reduceBeforeArguments true\nset_option maxHeartbeats 0')
+    if a.retain_constructor_choices:
+        text=text.replace('set_option maxHeartbeats 0', 'set_option blaster.hoistConstructorChoices false\nset_option maxHeartbeats 0')
+    if a.retain_choice_types:
+        text=text.replace('set_option maxHeartbeats 0', 'attribute [local blaster_keep_choices] ' + ' '.join(a.retain_choice_types) + '\nset_option maxHeartbeats 0')
+    source=cwd/'Tests/Benchmarks/CardanoPerfCase.lean'
+    source.parent.mkdir(parents=True,exist_ok=True)
+    module='CardanoPerfCase'
+    if a.proofs_only:
+        if not source.exists() or source.read_text()!=text:
+            raise SystemExit('Prepare the requested case and budget first; the existing module does not match.')
+        if name=='global':
+            text='''import Tests.Benchmarks.CardanoPerfCase
+import Blaster
+set_option maxHeartbeats 0
+set_option warn.sorry false
+namespace WSC.Benchmark
+open CardanoLedgerApi.V3 (CurrencySymbol ScriptContext ScriptInfo TxInfo)
+open PlutusCore.Data (Data)
+open PlutusCore.UPLC.Utils (isSuccessful isUnsuccessful)
+-- The production global validator rejects the SeizeAct redeemer arm.
+-- Other fields, transaction info, purpose and parameter remain symbolic.
+theorem seize_arm_rejected :
+    ∀ (ppCS : CurrencySymbol) (tin : TxInfo) (sinfo : ScriptInfo) (flds : List Data),
+      isUnsuccessful (appliedGlobalPerf.prop ppCS ⟨tin, Data.Constr 1 flds, sinfo⟩) := by
+  blaster (timeout: 30)
+end WSC.Benchmark
+'''
+        else:
+            text=(cwd/f'Tests/Scripts/{fixture}/Properties.lean').read_text()
+            text=text.replace(f'import Tests.Scripts.{fixture}.{fixture}', 'import Tests.Benchmarks.CardanoPerfCase')
+            if name=='governance':
+                text=text[:text.index('/-- Governance script successful for a minFeeB')]+'end Tests.Scripts.Governance\n'
+            text=text.replace('\nnamespace ', '\nset_option maxHeartbeats 0\nnamespace ',1)
+            text=re.sub(r'\bblaster\b', 'blaster (timeout: 30)', text)
+        module='CardanoPerfProofs'
+        source=cwd/f'Tests/Benchmarks/{module}.lean'
+    for rep in range(a.repeat):
+        source.write_text(text)
+        # This file belongs exclusively to this runner in the isolated checkout.
+        for suffix in ['olean','olean.hash','ilean','ilean.hash','trace']:
+            (cwd/f'.lake/build/lib/lean/Tests/Benchmarks/{module}.{suffix}').unlink(missing_ok=True)
+        tag=f'{name}-{budget}-{rep+1}'
+        log=logs/(tag+'.log')
+        row={'case':name,'budget':budget,'repeat':rep+1,'status':'running','log':str(log),
+             'sampled_peak_rss_bytes':0,'prep':{},'source_sha256':hashlib.sha256(text.encode()).hexdigest()}
+        result['runs'].append(row);save()
+        env=os.environ.copy();env['BLASTER_PREP_METRICS']='1'
+        started=time.monotonic();sampler=None;sampled=False;next_checkpoint=started+5
+        with log.open('w') as f:
+            proc=subprocess.Popen(['lake','build',f'Tests.Benchmarks.{module}'],cwd=cwd,env=env,
+                stdout=f,stderr=subprocess.STDOUT,start_new_session=True)
+            try:
+                while proc.poll() is None:
+                    entries=snapshot(proc.pid)
+                    rss=sum(e[2] for e in entries)
+                    row['sampled_peak_rss_bytes']=max(row['sampled_peak_rss_bytes'],rss)
+                    elapsed=time.monotonic()-started
+                    if time.monotonic() >= next_checkpoint:
+                        row['elapsed_seconds']=elapsed
+                        save()
+                        next_checkpoint=time.monotonic()+5
+                    if a.sample and not sampled and elapsed>10:
+                        lean=[e for e in entries if Path(e[3]).name=='lean']
+                        if lean:
+                            target=max(lean,key=lambda e:e[2])[0]
+                            sampler=subprocess.Popen(['/usr/bin/sample',str(target),'5','10','-file',str(logs/(tag+'.sample.txt'))],stdout=f,stderr=subprocess.STDOUT)
+                            sampled=True
+                    if elapsed>a.timeout or rss>result['rss_limit_bytes']:
+                        row['status']='timeout' if elapsed>a.timeout else 'memory_limit'
+                        os.killpg(proc.pid,signal.SIGKILL)
+                        proc.wait()
+                        break
+                    time.sleep(0.5)
+            except BaseException as exc:
+                row['status']='interrupted'
+                row['reason']=type(exc).__name__
+                row['elapsed_seconds']=time.monotonic()-started
+                save()
+                raise
+            finally:
+                if proc.poll() is None:
+                    os.killpg(proc.pid,signal.SIGKILL)
+                    proc.wait()
+            row['elapsed_seconds']=time.monotonic()-started
+            row['exit_code']=proc.returncode
+            if row['status']=='running': row['status']='completed' if proc.returncode==0 else 'error'
+            if sampler is not None: sampler.wait(timeout=15)
+        content=log.read_text()
+        if not a.proofs_only:
+            for m in re.finditer(r'PREP_METRICS (.+)',content):
+                row['prep']={k:int(v) for k,v in re.findall(r'(\w+)=(\d+)',m[1])}
+        else:
+            row['verdicts']=[line for line in content.splitlines() if 'CardanoPerfProofs.lean:' in line and ('✅' in line or line.startswith('error:'))]
+        artifact=cwd/f'.lake/build/lib/lean/Tests/Benchmarks/{module}.olean'
+        if row['status']=='completed' and artifact.exists(): row['olean_bytes']=artifact.stat().st_size
+        save();print(json.dumps(row),flush=True)

--- a/docs/design/cardano-staged-preparation.md
+++ b/docs/design/cardano-staged-preparation.md
@@ -1,0 +1,111 @@
+# Staged preparation for fixed UPLC programs
+
+Status: proposed architecture, not an implemented or measured speedup.
+
+The [Cardano review](../reviews/cardano-preparation-2026-09-09.md) measures a
+nonlinear preparation cliff: the production global validator takes 11 s in the
+optimizer at fuel 1,400, 59 s at 1,600, and exceeds 240 s wall time at 1,800.
+The conservative cache experiments do not remove that cliff. The next prototype
+should avoid repeatedly interpreting the same static program and expanding
+independent data choices through its machine state.
+
+## First implementation slice
+
+Compile a fixed decoded UPLC program into a graph of residual blocks. The static
+part consists of the program's syntax, known builtin identity, and known
+continuation shape. Dynamic values remain typed residual expressions. Give
+static syntax and continuations stable node IDs, so execution does not repeatedly
+copy, abstract and instantiate the complete syntax/environment representation.
+
+Start with a bounded fragment: variables, lambdas, application, delay/force,
+constants, error, and the builtins needed by one small Cardano script. An
+unsupported instruction must fall back to the existing interpreter with the
+exact remaining state and fuel. It must not be treated as an arbitrary value,
+success, or error merely to finish preparation.
+
+Use this first slice to answer a concrete question: how much preparation work
+comes from repeatedly walking static CEK control, versus dynamic ledger data?
+Do not build loop summaries, a new SMT theory, and a new symbolic executor at the
+same time.
+
+## Data representation and branching
+
+Keep symbolic values as shared expressions. Constructing a record or list with
+independent choices should not enumerate their Cartesian product. Split a path
+when an operation needs to inspect a choice's discriminator. When paths join,
+share the common continuation and represent differing values with conditional
+fields where their types permit it.
+
+Interpreter values and control structures require different treatment. The
+measured global switch disabling all constructor hoisting improves some
+preparation-only times but regresses other workloads and proof time. A new
+representation must make the distinction explicit rather than assume that a
+normalization flag implements a complete demand-driven evaluator.
+
+Input serialization is another boundary to preserve. A deferred `toData` field
+must denote exactly the same total Lean conversion as the eager version.
+Proving which fields a builtin demands can avoid constructing unrelated fields;
+replacing an unsupported conversion with unconstrained data would change the
+property being proved.
+
+## Semantic obligations
+
+For the first prototype, preserve the bounded semantics exactly:
+
+- Count original CEK transitions, not residual-block dispatches. A block may
+  consume several original steps; reaching fuel zero must match `runSteps`,
+  including its error behavior and already-halted cases.
+- Preserve builtin semantics, language/semantics variant, evaluation order,
+  errors and the distinction between halting and fuel exhaustion.
+- Keep binders and closure environments explicit. State sharing must not reuse
+  a value under sibling hypotheses or capture a variable from a closed scope.
+- Relate each residual block to its original CEK fragment. Prefer kernel-checked
+  local simulation lemmas that compose; do not infer equivalence from matching
+  solver verdicts on a sample.
+- Keep the existing `.exec` semantics available as the reference. A certificate
+  may be reused only for the same program, imports/definitions, semantics
+  variant and conversion definition. A fuel-specific residual must include
+  that fuel in its cache identity.
+
+The current prepared `.prop` is not supplied with such an equivalence theorem.
+This proposal must not describe existing trusted Blaster verdicts as a new
+kernel-checked proof of compilation correctness.
+
+## Telemetry and gates
+
+Record compile-once cost, per-property specialization cost, SMT translation,
+solver time and peak memory separately. Useful structural counters include
+static block count, block visits, residual value nodes, distinct symbolic
+states, forks/joins, expanded constructor choices, and cache hits whose reuse
+actually skips work. A high cache hit count alone was not predictive in the
+measured substitution experiment.
+
+Use the same source/bytecode pins and native build configuration as the existing
+harness. The first performance gates are SellNFT, Governance and production
+CIP-153 global at fuel 1,400/1,600/1,800. Include ParamFeed to expose fixed-cost
+regressions. A later gate should reach enough fuel for a known accepting global
+witness, not merely a larger number in a rejecting theorem.
+
+For each proposed improvement, require:
+
+1. The original positive properties and expected counterexamples, including a
+   non-vacuity/acceptance control where the workload supplies one.
+2. Small differential cases covering fuel boundaries, errors, constructor
+   choices, dependent binders and closure capture.
+3. At least three uncontended, paired timing runs on representative cases.
+4. Full preparation-plus-proof comparisons. A faster preparation that leaves
+   much more work in the proof phase is not the target improvement.
+
+Only after this bounded implementation is validated should recurrence summaries
+or cross-path memoization be attempted. A summary requires an explicit inductive
+invariant/simulation proof; it cannot silently replace bounded semantics with
+an unbounded approximation.
+
+## Research basis
+
+[GenSym (ICSE 2023)](https://continuation.passing.style/static/papers/icse23.pdf)
+uses staged compilation and continuations for symbolic execution.
+[GenWasym](https://arxiv.org/abs/2608.18327) specializes a definitional
+WebAssembly interpreter and uses continuations and snapshots. These support
+trying a staged representation, but their concolic/test-generation performance
+results do not predict a speedup for universally quantified Cardano proofs.

--- a/docs/reviews/cardano-preparation-2026-09-09.md
+++ b/docs/reviews/cardano-preparation-2026-09-09.md
@@ -61,6 +61,13 @@ higher-priority experiment than changing the SMT solver.
   normalization regressions. This port was removed; its speedup is not a ready
   optimization. PR #160 also contains GC/retention and allocator work which this
   experiment did not port.
+- **Renormalize ancestor rewrites in the child context.** A second version
+  disables further ancestor reuse throughout each replayed subtree. It passes
+  the normalization regressions, but global retains exactly the baseline's
+  15,595,053 nodes and takes 61.54 s in the optimizer. SellNFT likewise retains
+  the baseline node count and takes 36.42 s. The full suite hit the 30 s cap on
+  one arithmetic test; isolated reruns pass on both baseline and candidate.
+  This version was also removed because it provides no speedup.
 - **Bounded memoization of pure substitution/abstraction.** It produced roughly
   1.89 M hits on global 1,600, but optimizer time was 60.10 s and the retained
   hash-cons count was unchanged. A high cache hit rate did not translate into a
@@ -77,6 +84,12 @@ higher-priority experiment than changing the SMT solver.
 - **Retain choices only for List, Prod and Plutus Data.** This preserved the
   ordinary examples' preparation cost, but global still took 107.12 s inside the
   optimizer. Naming selected types did not resolve the production regression.
+- **Retain choices in interpreter values and their containers.** Keeping
+  CekValue, Environment, Const, Term and Data choices while leaving other
+  control constructors alone still regressed global preparation to 99.78 s.
+  SellNFT retained 7.82 M nodes rather than 8.11 M, but its small timing change
+  is unconfirmed. The ParamFeed property passed in 1.66 s. This remains a
+  scoped representation experiment, not a Cardano performance recommendation.
 - **Unfold functions before normalizing their arguments.** Small unused-argument
   and projection tests passed, but global 1,600 exceeded 120 s, and SellNFT hit
   the 16 GiB memory cap after about 51 s. Governance was cancelled when this
@@ -105,7 +118,9 @@ that the proof phase uses exactly the requested prepared source.
 
 ## Direction for larger gains
 
-The more ambitious route is to specialize the fixed UPLC program into reusable
+The [staged-preparation proposal](../design/cardano-staged-preparation.md)
+defines a bounded first implementation, semantic obligations and measurement
+gates. The more ambitious route is to specialize the fixed UPLC program into reusable
 blocks while retaining dynamic data and path conditions separately. This would
 avoid repeatedly walking the interpreter and distributing independent data
 choices through every state. A sound implementation must preserve CEK step

--- a/docs/reviews/cardano-preparation-2026-09-09.md
+++ b/docs/reviews/cardano-preparation-2026-09-09.md
@@ -1,0 +1,129 @@
+# Cardano preparation: measurements and experiments, 2026-09-09
+
+## Scope and method
+
+Preparation is the dominant measured phase. On the production CIP-153 global
+validator at 1,600 CEK steps, preparation takes 63.08 s, of which 59.46 s is
+inside `Optimize.main`. A subsequent symbolic rejection property takes 1.67 s.
+That property covers the rejected SeizeAct arm only; it does not establish
+acceptance coverage or the validator's other properties.
+
+The baseline is the reviewed beta stack at `36c3a15a9fdc9f3237ad376f8d67665e3742d3f8`
+(PR #235), not a new revision of the beta branch. Measurements use native Lake
+builds on an Apple M2 Max, 12 cores, 64 GiB RAM, Lean 4.24.0. Dependencies were
+built first. Timed cases ran serially, with no concurrent test/build jobs.
+The runner samples aggregate descendant RSS every 0.5 s. This is not a process
+high-water mark. No allocator tuning was applied.
+
+The [reproduction guide](../../Benchmarks/cardano/README.md) and
+[pins](../../Benchmarks/cardano/pins.json) identify all five repositories.
+Two pins are local investigation commits unavailable on GitHub when checked;
+reproduction requires local repositories containing those commits. The setup
+helper copies committed source only. The WSC script uses the CIP-153-capable
+PlutusCore revision; ordinary Cardano examples use upstream PlutusCore.
+
+## Baseline
+
+These are single scout observations, except SellNFT which was repeated for a
+paired proof check. They identify bottlenecks; they are not confidence intervals.
+
+| Case | CEK fuel | Preparation wall | Optimizer | Hash-cons entries | Context IDs |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| SellNFT | 1,800 | 38.53 s | 35.62 s | 8,106,674 | 29,063 |
+| MintingPolicy | 1,200 | 7.84 s | 5.98 s | 1,682,983 | 7,575 |
+| ParamFeed | 10,000 | 1.70 s | 0.20 s | 52,254 | 154 |
+| Governance | 9,000 | 37.51 s | 34.59 s | 7,293,990 | 17,761 |
+| CIP-153 global | 1,400 | 12.81 s | 11.09 s | 3,131,631 | 22,056 |
+| CIP-153 global | 1,600 | 63.08 s | 59.46 s | 15,595,053 | 103,138 |
+| CIP-153 global | 1,800 | >240 s (timeout) | — | — | — |
+
+The 1,800-step run reached a sampled 6.90 GiB before its time limit; it did not
+hit the 16 GiB memory limit. The subsequent 2,000-step scout was deliberately
+cancelled. Its partial time must not be used as a benchmark result.
+
+Increasing global fuel by 14% (1,400 to 1,600) increased optimizer time by 5.4×
+and retained hash-cons entries by 5.0×. Fuel bounds evaluation work, but the
+symbolic preparation cost is highly nonlinear. Hash-cons entries count retained
+optimizer nodes, not the final residual expression's live nodes.
+
+A separate five-second CPU sample during global preparation showed expression
+abstraction/substitution, hash-consing, context membership, allocation and
+reference counting. It is a short diagnostic window, not a whole-run attribution.
+The large retained expression/context counts make avoiding repeated expansion a
+higher-priority experiment than changing the SMT solver.
+
+## Experiments that failed their gates
+
+- **Ancestor rewrite reuse, adapted from existing PR #160.** A small port reduced
+  global 1,600 optimizer time from 59.46 to 35.34 s and retained nodes from 15.60 M
+  to 9.83 M. However, returning an ancestor normal form directly skipped
+  simplifications enabled by a child's hypotheses. The full test suite reported
+  normalization regressions. This port was removed; its speedup is not a ready
+  optimization. PR #160 also contains GC/retention and allocator work which this
+  experiment did not port.
+- **Bounded memoization of pure substitution/abstraction.** It produced roughly
+  1.89 M hits on global 1,600, but optimizer time was 60.10 s and the retained
+  hash-cons count was unchanged. A high cache hit rate did not translate into a
+  useful speedup. This prototype was removed.
+- **Retain every constructor's field choices.** SellNFT optimizer time fell to
+  1.62 s and Governance to 1.65 s. Global 1,600 instead regressed to 105.85 s;
+  ParamFeed regressed from 0.20 to 1.63 s. The paired SellNFT proof phase grew
+  from 37.45 to 157.27 s. Both versions proved the same two positive properties,
+  found the same two counterexamples, and hit the 30 s solver cap on the
+  multi-satisfaction check. The preparation-only gain therefore moved substantial
+  work into proving. Some retained-choice preparations also introduced existing
+  `sorry`-fallback warnings in hypothesis proof reconstruction. This mode is not
+  a general recommendation.
+- **Retain choices only for List, Prod and Plutus Data.** This preserved the
+  ordinary examples' preparation cost, but global still took 107.12 s inside the
+  optimizer. Naming selected types did not resolve the production regression.
+- **Unfold functions before normalizing their arguments.** Small unused-argument
+  and projection tests passed, but global 1,600 exceeded 120 s, and SellNFT hit
+  the 16 GiB memory cap after about 51 s. Governance was cancelled when this
+  approach was rejected. This prototype was removed.
+
+The constructor experiment exposed an independently reproducible scaling issue:
+[issue #238](https://github.com/input-output-hk/Lean-blaster/issues/238). A list
+of 12 independent conditional elements creates 16,379 contexts with unconditional
+constructor hoisting, versus 47 when those field choices remain inside their
+constructors. The corresponding retained node counts are 117,084 and 2,817.
+The issue was filed before the proposed regression test `Issue238.lean`.
+
+## Proof coverage and fuel
+
+Each candidate must be checked against the same properties and solver cap after
+preparation. A small `.olean` or a fast rejecting property is insufficient:
+CEK fuel exhaustion produces `State.Error`, so under-fuelled preparation can
+make rejection vacuous. Larger fuel must be paired with accepting witnesses or
+negative controls that distinguish meaningful acceptance from always-error.
+The runner preserves fuel and input conversion for paired comparisons.
+
+Blaster's current `Valid` verdict is its trusted solver result. These experiments
+do not add a kernel-checked equivalence between a prepared `.prop` and `.exec`.
+The harness records separate preparation and proof measurements and verifies
+that the proof phase uses exactly the requested prepared source.
+
+## Direction for larger gains
+
+The more ambitious route is to specialize the fixed UPLC program into reusable
+blocks while retaining dynamic data and path conditions separately. This would
+avoid repeatedly walking the interpreter and distributing independent data
+choices through every state. A sound implementation must preserve CEK step
+accounting, errors, builtin semantics and binder scope; loop summaries need
+explicit proof obligations rather than an assumed relationship to unrolling.
+
+This direction is supported by staged symbolic-execution work such as
+[GenSym (ICSE 2023)](https://continuation.passing.style/static/papers/icse23.pdf)
+and the newer [GenWasym preprint](https://arxiv.org/abs/2608.18327), which stages
+a definitional WebAssembly interpreter and uses continuations and snapshots.
+Their results motivate an architecture experiment, not a predicted Blaster
+speedup: concolic path exploration differs from universally quantified Cardano
+proofs. No breakthrough or published speedup from those systems is claimed here.
+
+The [archived prototype patches](../../Benchmarks/cardano/experiments/README.md)
+make the rejected algorithm experiments inspectable and reproducible separately
+from the unchanged production optimizer in this benchmark branch.
+
+Raw measurement records are in [Benchmarks/cardano/results](../../Benchmarks/cardano/results).
+Status fields distinguish successful runs, setup errors, timeouts, memory limits
+and deliberate interruptions. Profiling times are excluded from comparisons.


### PR DESCRIPTION
Cardano preparation dominates the measured workload: the production CIP-153 global validator takes 63.08 s to prepare at 1,600 CEK steps, followed by 1.67 s for a symbolic rejection property. At 1,800 steps, preparation exceeds 240 s. This PR adds a way to measure that phase consistently before changing the optimizer.

- Add isolated, pinned workspace setup, native serial Lake benchmarks, time/memory limits, and coarse optimizer/context/hash-cons telemetry.
- Measure proof checks separately against the exact prepared source, including positive properties and expected counterexamples where available.
- Record the baseline and rejected optimization experiments, including the relationship to existing PR #160. Archived patches are evidence and are not imported by Blaster.

Validation: recreated all five source checkouts and verified their tracked patch hashes against the benchmark workspaces; ran the real Cardano/WSC preparation cases and separate proof checks; checked both Python scripts. Two dependency pins are local investigation commits, documented explicitly. The global rejection check does not establish acceptance coverage. The SellNFT multi-satisfaction check reaches the same 30-second solver cap in both compared versions.

Stacked on #235. Related to #138 and #238. This PR does not change the production optimizer or claim a general Cardano speedup.
