### PR TITLE
Experiment with scoped constructor-choice retention (Issue238)

### DIFF
--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
+++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
@@ -3,7 +3,18 @@ import Blaster.Optimize.Rewriting.NormalizeMatch
 import Blaster.Optimize.Rewriting.OptimizeMatch
 
 open Lean Meta Elab
+
 namespace Blaster.Optimize
+
+initialize keepChoicesExt : LabelExtension ← registerLabelAttr `blaster_keep_choices "Keep symbolic choices inside constructors of the labelled inductive type or constructor."
+syntax (name := _root_.Parser.Attr.blaster_keep_choices) "blaster_keep_choices" : attr
+
+/-- A selected datatype also keeps choices in containers parameterized by it,
+    such as `List Value`, without affecting `List Frame`. -/
+private partial def hasKeptChoiceType (kept : Array Name) (e : Expr) : Bool :=
+  match e.getAppFn with
+  | .const n _ => kept.contains n || e.getAppArgs.any (hasKeptChoiceType kept)
+  | _ => false
 
 /-- Given application `f x₁ ... xₙ`, apply the following normalization rules:
      - When `f := Blaster.dite' c (fun h : c => t₁) (fun h : ¬ c => t₂)`
@@ -95,7 +106,7 @@ def normChoiceApplication?
           ...
           | p₍ₘ₎₍₁₎, ..., p₍ₘ₎₍ₚ₎ => fn g₍ₘ₎₍₁₎, ..., g₍ₘ₎₍ₙ₎`
 
-    with:
+    with (unless fn is a constructor selected for choice retention):
       propagate fn e₁ ... eₙ :=
         isCtorExpr fn ∨
         allExplicitParamsAreCtor fn e₁ ... eₙ (funPropagation := true) ∨
@@ -145,7 +156,12 @@ def funPropagation?
     @[always_inline, inline]
     propagate (f : Expr) (n : Name) (args : Array Expr) : TranslateEnvT Bool := do
       if !(← hasMatchITEArgs args) then return false
-      else if (← isCtorName n) then return true
+      else if (← isCtorName n) then
+        let kept := keepChoicesExt.getState (← getEnv)
+        if kept.isEmpty then return true
+        let .ctorInfo info ← getConstEnvInfo n | return true
+        return !(kept.contains n || kept.contains info.induct ||
+          (args.take info.numParams).any (hasKeptChoiceType kept))
       else if (← allExplicitParamsAreCtor f args (funPropagation := true)) then return true
       else
         match n with

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -40,3 +40,5 @@ import Tests.FixedIssues.Issue228
 import Tests.FixedIssues.Issue233
 import Tests.FixedIssues.Issue231
 import Tests.FixedIssues.Issue232
+
+import Tests.FixedIssues.Issue238

--- a/Tests/FixedIssues/Issue238.lean
+++ b/Tests/FixedIssues/Issue238.lean
@@ -1,0 +1,51 @@
+import Tests.Utils
+
+namespace Tests.FixedIssues.Issue238
+
+section Collections
+attribute [local blaster_keep_choices] List Option Prod
+
+#testOptimize ["KeepChoiceInConstructor"] (norm-result: 1)
+  (fun b : Bool => some (if b then (3 : Nat) else 4)) ===>
+  (fun b : Bool => some (Blaster.dite' (true = b) (fun _ => 3) (fun _ => 4)))
+
+#testOptimize ["ConsumeConstructorChoice"]
+  (∀ b : Bool, (some (if b then (3 : Nat) else 4)).getD 5 = (if b then 3 else 4)) ===> True
+
+#blaster (gen-cex: 0)
+  [∀ b c : Bool, ((if b then (3 : Nat) else 4), (if c then (5 : Nat) else 6)).1 = (if b then 3 else 4)]
+
+#blaster (gen-cex: 0) (solve-result: 1)
+  [∀ b c : Bool, ((if b then (3 : Nat) else 4), (if c then (5 : Nat) else 6)).1 = 3]
+
+-- Independent fields must not create one context for every Boolean assignment.
+-- This checks growth, not a machine-dependent wall-clock threshold.
+open Lean Meta Elab Command in
+run_cmd liftTermElabM do
+  let e ← Tests.parseTerm (← `(fun (b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 : Bool) =>
+    [if b0 then (1 : Nat) else 0, if b1 then 1 else 0, if b2 then 1 else 0,
+     if b3 then 1 else 0, if b4 then 1 else 0, if b5 then 1 else 0,
+     if b6 then 1 else 0, if b7 then 1 else 0, if b8 then 1 else 0,
+     if b9 then 1 else 0, if b10 then 1 else 0, if b11 then 1 else 0]))
+  let (_, env) ← Blaster.Optimize.command default e
+  unless env.optEnv.options.nextCtxId < 100 && env.optEnv.hashConsCache.size < 5000 do
+    throwError "Independent choices expanded: contexts={env.optEnv.options.nextCtxId}, hashcons={env.optEnv.hashConsCache.size}"
+
+end Collections
+
+section Values
+inductive Datum where
+  | nat : Nat → Datum
+
+attribute [local blaster_keep_choices] Datum
+
+#testOptimize ["KeepChoicesInValueContainers"] (norm-result: 1)
+  (fun b : Bool => [if b then Datum.nat 3 else Datum.nat 4]) ===>
+  (fun b : Bool => [Blaster.dite' (true = b) (fun _ => Datum.nat 3) (fun _ => Datum.nat 4)])
+
+#testOptimize ["UnmarkedControlStillHoists"] (norm-result: 1)
+  (fun b : Bool => some (if b then (3 : Nat) else 4)) ===>
+  (fun b : Bool => Blaster.dite' (true = b) (fun _ => some 3) (fun _ => some 4))
+end Values
+
+end Tests.FixedIssues.Issue238

--- a/docs/experiments/constructor-choice-retention.md
+++ b/docs/experiments/constructor-choice-retention.md
@@ -1,0 +1,63 @@
+# Scoped constructor-choice retention
+
+Status: experimental, opt-in. This fixes the compact-representation example in
+[issue #238](https://github.com/input-output-hk/Lean-blaster/issues/238), but it
+is not a recommended Cardano performance setting.
+
+The optimizer normally moves a conditional out of a constructor application.
+For independent fields, repeated distribution can enumerate combinations that
+a consumer never needs. The minimal 12-element example in issue #238 allocates
+16,379 contexts and 117,084 hash-cons entries at baseline, versus 47 contexts and
+2,817 entries with field choices retained.
+
+Use a local attribute on an inductive type or constructor:
+
+```lean
+import Blaster
+
+section
+attribute [local blaster_keep_choices] List
+-- Optimizer calls here can keep conditional elements inside List.cons.
+end
+```
+
+A labelled datatype also affects containers parameterized by it. Labelling
+`Value` therefore affects `List Value` and `Option Value`, while leaving
+`List Frame` alone. Type abbreviations are not unfolded by this label lookup;
+label the underlying inductive type. Labelling an unrelated declaration has no
+effect. Local attributes do not change the policy in importing modules.
+
+The attribute disables only the constructor-hoisting decision. Consumers may
+still split on choices, and other normalization rules still run. It does not
+provide a complete lazy evaluator, new datatype support, or a proof of
+correctness for preparation. Without labels, the existing policy is unchanged.
+
+`Tests/FixedIssues/Issue238.lean` checks the compact normal form, consuming a
+choice, positive and negative Blaster verdicts, a structural growth bound,
+container propagation, and preservation of the policy for unmarked types.
+The growth test uses node/context bounds instead of machine-dependent timing.
+
+## Cardano gate
+
+The [benchmark review](../reviews/cardano-preparation-2026-09-09.md) records the
+complete investigation. On the production global validator at fuel 1,600:
+
+| Policy | Optimizer time |
+| --- | ---: |
+| Baseline | 59.46 s |
+| Retain choices in every constructor (earlier prototype) | 105.85 s |
+| Label List, Prod and Plutus Data | 107.12 s |
+| Label interpreter values, environments, constants, terms and Data | 99.78 s |
+
+These are single scouts, not repeated speedup estimates. The last policy
+reduced SellNFT's retained nodes from 8.11 M to 7.82 M, but its small timing
+change is unconfirmed and does not outweigh the global regression. Its
+ParamFeed proof passed; full Cardano proof comparisons were not pursued after
+the preparation gate failed. The earlier all-constructor prototype also made
+the SellNFT proof phase substantially slower.
+
+This experiment isolates a useful control over representation growth. It must
+not be promoted as a general speedup until a demand-driven consumer policy
+passes preparation-plus-proof and acceptance/non-vacuity gates. The
+[staged-preparation design](../design/cardano-staged-preparation.md) describes
+that next architectural investigation.


### PR DESCRIPTION
Independent conditional fields can make constructor hoisting enumerate exponentially many combinations. This adds the local `blaster_keep_choices` attribute to retain those fields inside selected constructors/types and their parameterized containers. Unlabelled constructors keep the existing policy.

`Tests/FixedIssues/Issue238.lean` includes `#testOptimize` checks, positive and negative Blaster queries, and a structural growth bound for the minimal example filed first in #238. It also checks container propagation and that the local policy does not affect unmarked control types.

**Draft: this is not a recommended Cardano performance setting.** The production CIP-153 global case regresses from 59.46 s in the optimizer to 99.78 s with interpreter values selected. The earlier global switch also shifted substantial work from preparation into SellNFT proofs. The scoped experiment isolates the representation issue but does not implement a complete demand-driven evaluator.

Validation: focused regression checks and `lake test` passed. The first parallel full-suite run reached the 30-second cap on one arithmetic solver test; the retry passed. The final value-selection scout covers five real Cardano cases, and its ParamFeed proof passes. Further full proof comparisons were not pursued after the preparation gate failed.

Stacked on #239, which contains the reproduction harness, raw measurements, rejected experiments and a staged-preparation design. Related to #238; the issue remains open while the general performance problem is unresolved.
