### PR TITLE
Profile Cardano preparation and gate accepting global executions

### DIFF
--- a/Benchmarks/cardano/README.md
+++ b/Benchmarks/cardano/README.md
@@ -72,7 +72,9 @@ python3 Benchmarks/cardano_bench.py --root /tmp/cardano-baseline \
 The existing preparation source must exactly match the requested case and
 budget. No preparation is regenerated in this phase. The global check rejects
 the production validator's `SeizeAct` arm with symbolic fields, transaction
-info, purpose and parameter. It does not establish non-vacuity or all global
+info, purpose and parameter. At fuel 1453 or higher it also checks acceptance
+of the existing `transfer-nonmember-covering-node` golden against the measured
+residual with Blaster. This establishes one accepting execution, not all global
 validator properties. SellNFT checks the two positive properties and three
 expected counterexamples, including acceptance/non-vacuity. MintingPolicy
 checks its two positive properties and negative control; ParamFeed checks its
@@ -99,3 +101,78 @@ applying a patch, before starting any timed run.
 Checked-in result JSON uses relative log basenames. Complete logs remain local;
 re-running the harness produces fresh logs. Do not include setup errors,
 interruptions, timeouts or profiling runs in successful-run speedup averages.
+
+## Attribute preparation work
+
+Use a checkout containing the normalization profiler (pass its revision with
+`--blaster-rev` to `prepare_local.py`). The default pinned baseline predates it.
+Build dependencies first and keep profiling separate from timing comparisons:
+
+```sh
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-candidate \
+  --label global-profile --cases global:1400 global:1600 \
+  --profile-normalize --timeout 300
+python3 Benchmarks/cardano/summarize_profile.py \
+  /tmp/cardano-candidate/results/global-profile/results.json
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-candidate \
+  --label conversion --cases global:1600 sellnft:1800 --conversion-only
+```
+
+`--conversion-only` normalizes the same input conversion function, with all its
+arguments symbolic, without applying the interpreter. It is an isolation
+experiment, not a subtraction that can be assumed additive: conversion may
+interact with later symbolic branch contexts.
+
+`set_option blaster.profileNormalize true` enables the profiler for an
+`Optimize.main` invocation. The profiler records exclusive wall time under the
+innermost uncached expression's constant head; anonymous expressions inherit
+the enclosing head. Cache-hit processing is charged to its enclosing head.
+Names are retained; expression graphs and hypothesis contexts are not.
+
+Times sum to the profiled interval, but **include instrumentation overhead**.
+Head names describe which normalization was in progress, not whether that work
+was static or dynamic. In particular, time under a CEK matcher is not a CEK
+transition count, and time under a constructor can include normalization of its
+fields. Raw heads are emitted so readers can inspect the attribution rather
+than relying on a heuristic namespace classification.
+
+Rewrite-cache hits, misses and metavariable bypasses are counted separately.
+Choice-propagation events name the function or constructor across whose argument
+an `ite` or `match` was distributed. They count optimizer rewrites, not feasible
+execution paths. The existing context and hash-cons sizes remain separate.
+
+The runner sets `BLASTER_PROFILE_FILE` to a dedicated JSONL file. A snapshot is
+flushed every million uncached normalization entries and on completion or error;
+without this environment variable, snapshots go to command stdout. This avoids
+losing every observation when Lean buffers stdout or the runner kills a slow
+command. A killed run has only a partial profile. The summarizer checks exact
+time accounting and, for completed profiles, balanced normalization frames.
+The feature is disabled by default and profile state is local to one invocation.
+
+`PREP_PHASE` reports construction of the interpreter application, final declaration
+checking/compilation, and the complete `#prep_uplc` command. The existing
+`PREP_METRICS.optimize_ms` measures normalization itself. Whole-module wall time
+also includes decoding, other elaboration, and teardown.
+
+## Gate accepting executions
+
+```sh
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-candidate \
+  --label global-acceptance --cases global:1600 --acceptance-only
+```
+
+This copies `fixtures/GlobalAcceptance.lean` to an owned benchmark module and
+checks four existing post-#112 global goldens through the exact benchmark script
+and `globalInputs1600` conversion. Successful decoding and a data round-trip are
+mandatory. Three goldens must halt with **unit**, not merely halt with a closure;
+the negative control must reach a genuine CEK error. Their expected terminal step
+counts are 1453, 2782, 3441, and 2370, respectively. Each is also checked one step
+short and at ten times its terminal budget. A bounded iteration of real `step`
+distinguishes exhaustion from an error that the script actually reaches.
+
+These are executable checks using `native_decide`, which trusts native compilation;
+they are not kernel-reduced optimizer equivalence certificates. `--proofs-only`
+adds the Blaster acceptance check against the prepared `.prop` at fuel >=1453.
+Prepare that case without profiling immediately before running its proof phase,
+as the runner requires an exact preparation-source match. The gate does not
+claim that every accepting witness satisfies every ledger validity condition.

--- a/Benchmarks/cardano/README.md
+++ b/Benchmarks/cardano/README.md
@@ -172,7 +172,7 @@ distinguishes exhaustion from an error that the script actually reaches.
 
 These are executable checks using `native_decide`, which trusts native compilation;
 they are not kernel-reduced optimizer equivalence certificates. `--proofs-only`
-adds the Blaster acceptance check against the prepared `.prop` at fuel >=1453.
+adds Blaster acceptance and unit-return checks against the prepared `.prop` at fuel >=1453.
 Prepare that case without profiling immediately before running its proof phase,
 as the runner requires an exact preparation-source match. The gate does not
 claim that every accepting witness satisfies every ledger validity condition.

--- a/Benchmarks/cardano/fixtures/GlobalAcceptance.lean
+++ b/Benchmarks/cardano/fixtures/GlobalAcceptance.lean
@@ -1,0 +1,96 @@
+import WSC.Prep.GlobalImport
+import WSC.Goldens.TermsCheck
+
+set_option maxHeartbeats 0
+namespace WSC.Benchmark.Acceptance
+
+open PlutusCore.Data (Data)
+open PlutusCore.UPLC.Term (Term)
+open PlutusCore.UPLC.CekMachine
+open CardanoLedgerApi.V3 (CurrencySymbol ScriptContext)
+open CardanoLedgerApi.IsData.Class (IsData)
+open WSC.Goldens.Terms
+
+/-- These are the existing post-#112 goldens, not synthetic accepting programs.
+`TermsCheck` checks their literals against the original serialized payloads.
+-/
+def decodeInputs (params : List Data) (ctx : Data) : Option (CurrencySymbol × ScriptContext) := do
+  let [param] := params | none
+  return (← IsData.fromData param, ← IsData.fromData ctx)
+
+def nonmemberData := programmableLogicGlobal_transfer_nonmember_covering_node_ctx
+def nonmemberParams := programmableLogicGlobal_transfer_nonmember_covering_node_params
+def nonmember := decodeInputs nonmemberParams nonmemberData
+
+-- Failed decoding is a build failure, never a substituted default context.
+theorem nonmember_decodes : nonmember.isSome = true := by native_decide
+def nonmemberCS : CurrencySymbol := (nonmember.get nonmember_decodes).1
+def nonmemberCtx : ScriptContext := (nonmember.get nonmember_decodes).2
+
+def encodedData (inputs : List Term) : Option (List Data) := inputs.mapM fun t =>
+  match t with
+  | .Const (.Data d) => some d
+  | _ => none
+
+def exactInputs (params : List Data) (ctx : Data) : Bool :=
+  match decodeInputs params ctx with
+  | none => false
+  | some (cs, context) =>
+      encodedData (globalInputs1600 cs context) == some (params ++ [ctx])
+
+inductive Outcome | unit | error | exhausted | otherHalt
+deriving BEq, Repr, DecidableEq
+
+def outcome : State → Outcome
+  | .Halt (.VCon .Unit) => .unit
+  | .Halt _ => .otherHalt
+  | .Error => .error
+  | _ => .exhausted
+
+/-- Exhaustion is distinct from an actual CEK error. Count the real `step`
+transitions without invoking `runSteps`' fuel-exhaustion-to-error conversion.
+-/
+def measure (s0 : State) (limit : Nat) : Nat × Outcome := Id.run do
+  let mut s := s0
+  let mut steps := 0
+  for _ in [0:limit] do
+    match s with
+    | .Halt _ | .Error => return (steps, outcome s)
+    | _ =>
+      s := step default s
+      steps := steps + 1
+  return (steps, outcome s)
+
+def start (params : List Data) (ctx : Data) : State :=
+  match programmableLogicGlobal1600.script with
+  | .Program _ body => initialState (applyParams body ((params ++ [ctx]).map (Term.Const ∘ .Data)))
+
+def exec (fuel : Nat) : State := cekExecuteProgram programmableLogicGlobal1600.script
+  (globalInputs1600 nonmemberCS nonmemberCtx) fuel
+
+def checkGolden (params : List Data) (ctx : Data) (k : Nat) (expected : Outcome) : Bool :=
+  let s := start params ctx
+  exactInputs params ctx &&
+  measure s (10 * k) == (k, expected) &&
+  measure s (k - 1) == (k - 1, .exhausted) &&
+  outcome (runSteps default s k) == expected &&
+  outcome (runSteps default s (10 * k)) == expected &&
+  outcome (runSteps default s (k - 1)) == .error
+
+-- Executable validation through native_decide; this is a compiler-backed
+-- regression gate, not a kernel-reduced equivalence certificate for the optimizer.
+example : checkGolden nonmemberParams nonmemberData 1453 .unit = true := by native_decide
+example : checkGolden programmableLogicGlobal_transfer_member_single_policy_params
+    programmableLogicGlobal_transfer_member_single_policy_ctx 2782 .unit = true := by native_decide
+example : checkGolden programmableLogicGlobal_transfer_mixed_many_policies_params
+    programmableLogicGlobal_transfer_mixed_many_policies_ctx 3441 .unit = true := by native_decide
+example : checkGolden programmableLogicGlobal_transfer_containment_violation_REJECT_params
+    programmableLogicGlobal_transfer_containment_violation_REJECT_ctx 2370 .error = true := by native_decide
+
+example : outcome (exec 1452) = .error ∧ outcome (exec 1453) = .unit ∧
+    outcome (exec 1600) = .unit := by native_decide
+
+#eval do
+  IO.println "CARDANO_ACCEPTANCE nonmember_k=1453 member_k=2782 mixed_k=3441 rejection_k=2370 roundtrip=true unit_halts=true"
+
+end WSC.Benchmark.Acceptance

--- a/Benchmarks/cardano/patches/plutuscore-wsc.patch
+++ b/Benchmarks/cardano/patches/plutuscore-wsc.patch
@@ -1,5 +1,5 @@
 diff --git a/PlutusCore/UPLC/PreProcess.lean b/PlutusCore/UPLC/PreProcess.lean
-index d5ce4dd2..0df14953 100644
+index d5ce4dd2..e631d634 100644
 --- a/PlutusCore/UPLC/PreProcess.lean
 +++ b/PlutusCore/UPLC/PreProcess.lean
 @@ -2,7 +2,6 @@ import Lean
@@ -10,9 +10,19 @@ index d5ce4dd2..0df14953 100644
  import Blaster.Command.Syntax
  open Lean Elab Command Term Meta Blaster.Optimize Blaster.Syntax
  
-@@ -46,7 +45,12 @@ def preprocessImp : CommandElab := fun stx => do
+@@ -40,13 +39,22 @@ def parseMaxSteps : TSyntax `uplcMaxSteps → TermElabM Nat
+ 
+ @[command_elab preprocess]
+ def preprocessImp : CommandElab := fun stx => do
++  let commandStarted ← IO.monoMsNow
++  let metrics := (← IO.getEnv "BLASTER_PREP_METRICS") == some "1"
+   let (propDecl, execDecl, structDef, structDescr, structInst) ←
+       withoutModifyingEnv $ runTermElabM fun _ => do
+         let sOpts ← parseSolveOptions stx[1].getArgs default
          let plutusScript ← validUplcProg stx[3]
++        let inputStarted ← IO.monoMsNow
          let app ← mkUplcApply stx plutusScript
++        if metrics then IO.println s!"PREP_PHASE input_construct_ms={(← IO.monoMsNow) - inputStarted}"
          let env := {(default : TranslateEnv) with optEnv.options.solverOptions := sOpts}
 -        let (e, _) ← (withOptimizeStats <| Optimize.main app)|>.run env
 +        let prepStarted ← IO.monoMsNow
@@ -24,6 +34,23 @@ index d5ce4dd2..0df14953 100644
          let t ← inferType e
          let baseName ← validNewDef stx[2]
          let propName := Name.append baseName `prop
+@@ -65,6 +73,7 @@ def preprocessImp : CommandElab := fun stx => do
+             hints := .abbrev,
+             safety := .safe }
+         return (propDef, execDef, structDef, structDescr, structInst)
++  let declarationStarted ← IO.monoMsNow
+   modifyEnv (addNoncomputable · propDecl.definitionVal!.name)
+   liftCoreM <| addDecl propDecl
+   liftCoreM <| addAndCompile execDecl
+@@ -72,6 +81,8 @@ def preprocessImp : CommandElab := fun stx => do
+   liftCoreM <| modifyEnv (λ env => registerStructure env structDescr)
+   modifyEnv (addNoncomputable · structInst.definitionVal!.name)
+   liftCoreM <| addDecl structInst
++  if metrics then
++    IO.println s!"PREP_PHASE declaration_ms={(← IO.monoMsNow) - declarationStarted} command_ms={(← IO.monoMsNow) - commandStarted}"
+ 
+   where
+     createDefinition (n : Name) (t : Expr) (e : Expr) : Declaration :=
 diff --git a/lake-manifest.json b/lake-manifest.json
 index 216f05fd..c01e98c3 100644
 --- a/lake-manifest.json

--- a/Benchmarks/cardano/patches/plutuscore.patch
+++ b/Benchmarks/cardano/patches/plutuscore.patch
@@ -1,12 +1,20 @@
 diff --git a/PlutusCore/UPLC/PreProcess.lean b/PlutusCore/UPLC/PreProcess.lean
-index ddbaa30d..40cd2697 100644
+index ddbaa30d..45157a7b 100644
 --- a/PlutusCore/UPLC/PreProcess.lean
 +++ b/PlutusCore/UPLC/PreProcess.lean
-@@ -37,7 +37,12 @@ def preprocessImp : CommandElab := fun stx => do
+@@ -33,11 +33,20 @@ def parseMaxSteps : TSyntax `uplcMaxSteps → TermElabM Nat
+ 
+ @[command_elab preprocess]
+ def preprocessImp : CommandElab := fun stx => do
++  let commandStarted ← IO.monoMsNow
++  let metrics := (← IO.getEnv "BLASTER_PREP_METRICS") == some "1"
+   let (propDecl, execDecl, structDef, structDescr, structInst) ←
        withoutModifyingEnv $ runTermElabM fun _ => do
          let plutusScript ← validUplcProg stx[2]
++        let inputStarted ← IO.monoMsNow
          let app ← mkUplcApply stx plutusScript
 -        let (e, _) ← Optimize.main app|>.run default
++        if metrics then IO.println s!"PREP_PHASE input_construct_ms={(← IO.monoMsNow) - inputStarted}"
 +        let prepStarted ← IO.monoMsNow
 +        let (e, prepEnv) ← Optimize.main app|>.run default
 +        if (← IO.getEnv "BLASTER_PREP_METRICS") == some "1" then
@@ -16,6 +24,23 @@ index ddbaa30d..40cd2697 100644
          let t ← inferType e
          let baseName ← validNewDef stx[1]
          let propName := Name.append baseName `prop
+@@ -56,6 +65,7 @@ def preprocessImp : CommandElab := fun stx => do
+             hints := .abbrev,
+             safety := .safe }
+         return (propDef, execDef, structDef, structDescr, structInst)
++  let declarationStarted ← IO.monoMsNow
+   modifyEnv (addNoncomputable · propDecl.definitionVal!.name)
+   liftCoreM <| addDecl propDecl
+   liftCoreM <| addAndCompile execDecl
+@@ -63,6 +73,8 @@ def preprocessImp : CommandElab := fun stx => do
+   liftCoreM <| modifyEnv (λ env => registerStructure env structDescr)
+   modifyEnv (addNoncomputable · structInst.definitionVal!.name)
+   liftCoreM <| addDecl structInst
++  if metrics then
++    IO.println s!"PREP_PHASE declaration_ms={(← IO.monoMsNow) - declarationStarted} command_ms={(← IO.monoMsNow) - commandStarted}"
+ 
+   where
+     createDefinition (n : Name) (t : Expr) (e : Expr) : Declaration :=
 diff --git a/lake-manifest.json b/lake-manifest.json
 index 57d627cc..c01e98c3 100644
 --- a/lake-manifest.json

--- a/Benchmarks/cardano/results/attribution/acceptance-gate.json
+++ b/Benchmarks/cardano/results/attribution/acceptance-gate.json
@@ -1,0 +1,66 @@
+{
+  "label": "acceptance-gate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "6575b13cb65a060c03b31103f300d26acda80374",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "bc8ecf6013b195227b9f08b138b44650c2b2c4b19d820c01f8db36a1416cd7bb",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "acceptance",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 1590312960,
+      "prep": {},
+      "source_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+      "elapsed_seconds": 2.2158202088903636,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [
+        "nonmember_k=1453 member_k=2782 mixed_k=3441 rejection_k=2370 roundtrip=true unit_halts=true"
+      ],
+      "olean_bytes": 1928720,
+      "profile_snapshot_count": 0
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/results/attribution/conversion-isolation.json
+++ b/Benchmarks/cardano/results/attribution/conversion-isolation.json
@@ -1,0 +1,245 @@
+{
+  "label": "conversion-isolation",
+  "repeat": 3,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "6575b13cb65a060c03b31103f300d26acda80374",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "bc8ecf6013b195227b9f08b138b44650c2b2c4b19d820c01f8db36a1416cd7bb",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "conversion",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 1574158336,
+      "prep": {
+        "optimize_ms": 116,
+        "hashcons": 41460,
+        "contexts": 531,
+        "beta_cache": 91
+      },
+      "source_sha256": "59bd89396ecc84e759bcd0486b31ba89dd732797b775aa591023b1572d59058d",
+      "elapsed_seconds": 1.6672244172077626,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 245440,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 2,
+      "status": "completed",
+      "log": "global-1600-2.log",
+      "sampled_peak_rss_bytes": 1571405824,
+      "prep": {
+        "optimize_ms": 110,
+        "hashcons": 41460,
+        "contexts": 531,
+        "beta_cache": 91
+      },
+      "source_sha256": "59bd89396ecc84e759bcd0486b31ba89dd732797b775aa591023b1572d59058d",
+      "elapsed_seconds": 1.6645632500294596,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 245440,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 3,
+      "status": "completed",
+      "log": "global-1600-3.log",
+      "sampled_peak_rss_bytes": 1577271296,
+      "prep": {
+        "optimize_ms": 117,
+        "hashcons": 41460,
+        "contexts": 531,
+        "beta_cache": 91
+      },
+      "source_sha256": "59bd89396ecc84e759bcd0486b31ba89dd732797b775aa591023b1572d59058d",
+      "elapsed_seconds": 1.6770079170819372,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 245440,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 1564950528,
+      "prep": {
+        "optimize_ms": 58,
+        "hashcons": 7317,
+        "contexts": 68,
+        "beta_cache": 64
+      },
+      "source_sha256": "fb8ccd5d1b5c22c32fd880548cecb1cd008975ff4fe8f1066a542b7b063859bf",
+      "elapsed_seconds": 1.6783837920520455,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 842504,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 2,
+      "status": "completed",
+      "log": "sellnft-1800-2.log",
+      "sampled_peak_rss_bytes": 1571536896,
+      "prep": {
+        "optimize_ms": 56,
+        "hashcons": 7317,
+        "contexts": 68,
+        "beta_cache": 64
+      },
+      "source_sha256": "fb8ccd5d1b5c22c32fd880548cecb1cd008975ff4fe8f1066a542b7b063859bf",
+      "elapsed_seconds": 1.6663844590075314,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 842504,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 3,
+      "status": "completed",
+      "log": "sellnft-1800-3.log",
+      "sampled_peak_rss_bytes": 1566670848,
+      "prep": {
+        "optimize_ms": 58,
+        "hashcons": 7317,
+        "contexts": 68,
+        "beta_cache": 64
+      },
+      "source_sha256": "fb8ccd5d1b5c22c32fd880548cecb1cd008975ff4fe8f1066a542b7b063859bf",
+      "elapsed_seconds": 1.6717262919992208,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 842504,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1557348352,
+      "prep": {
+        "optimize_ms": 80,
+        "hashcons": 15652,
+        "contexts": 132,
+        "beta_cache": 84
+      },
+      "source_sha256": "28f29b0dd4fdd1145566aab961ea264f50c83c4e6198fc22afba66a2f8a3a1e3",
+      "elapsed_seconds": 1.674078042153269,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 2355296,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 2,
+      "status": "completed",
+      "log": "governance-9000-2.log",
+      "sampled_peak_rss_bytes": 1558151168,
+      "prep": {
+        "optimize_ms": 76,
+        "hashcons": 15652,
+        "contexts": 132,
+        "beta_cache": 84
+      },
+      "source_sha256": "28f29b0dd4fdd1145566aab961ea264f50c83c4e6198fc22afba66a2f8a3a1e3",
+      "elapsed_seconds": 1.6681236249860376,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 2355296,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 3,
+      "status": "completed",
+      "log": "governance-9000-3.log",
+      "sampled_peak_rss_bytes": 1564377088,
+      "prep": {
+        "optimize_ms": 80,
+        "hashcons": 15652,
+        "contexts": 132,
+        "beta_cache": 84
+      },
+      "source_sha256": "28f29b0dd4fdd1145566aab961ea264f50c83c4e6198fc22afba66a2f8a3a1e3",
+      "elapsed_seconds": 1.66991808405146,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "olean_bytes": 2355296,
+      "profile_snapshot_count": 0
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/results/attribution/global-unit-proof.json
+++ b/Benchmarks/cardano/results/attribution/global-unit-proof.json
@@ -1,0 +1,119 @@
+{
+  "label": "global-unit-proof",
+  "repeat": 3,
+  "timeout_seconds": 180.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "4b0ddd06368cd68149074768ed279753fd3e0802",
+      "tracked_patch_sha256": "5d37f25c1346cb9e8d9af020a2fabbc704b9cb7cf403f39f6eaefae5fc299845"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "4029c6f75ee465b33d90fb208390e4894bd03d52da04940e11f895d841ccf016",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 1562689536,
+      "prep": {},
+      "source_sha256": "b2e99ca705c8b1ae10e3b5c09fb1752afcb2cae8bfd62b16b4c47d4fb8521874",
+      "elapsed_seconds": 1.6722775408998132,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [
+        "nonmember_k=1453 member_k=2782 mixed_k=3441 rejection_k=2370 roundtrip=true unit_halts=true"
+      ],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:15:2: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:22:2: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:26:2: \u2705 Valid"
+      ],
+      "olean_bytes": 440576,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 2,
+      "status": "completed",
+      "log": "global-1600-2.log",
+      "sampled_peak_rss_bytes": 1576009728,
+      "prep": {},
+      "source_sha256": "b2e99ca705c8b1ae10e3b5c09fb1752afcb2cae8bfd62b16b4c47d4fb8521874",
+      "elapsed_seconds": 1.6684011248871684,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [
+        "nonmember_k=1453 member_k=2782 mixed_k=3441 rejection_k=2370 roundtrip=true unit_halts=true"
+      ],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:15:2: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:22:2: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:26:2: \u2705 Valid"
+      ],
+      "olean_bytes": 440576,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 3,
+      "status": "completed",
+      "log": "global-1600-3.log",
+      "sampled_peak_rss_bytes": 1579270144,
+      "prep": {},
+      "source_sha256": "b2e99ca705c8b1ae10e3b5c09fb1752afcb2cae8bfd62b16b4c47d4fb8521874",
+      "elapsed_seconds": 1.673758083023131,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [],
+      "acceptance": [
+        "nonmember_k=1453 member_k=2782 mixed_k=3441 rejection_k=2370 roundtrip=true unit_halts=true"
+      ],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:15:2: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:22:2: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:26:2: \u2705 Valid"
+      ],
+      "olean_bytes": 440576,
+      "profile_snapshot_count": 0
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/results/attribution/normalization-attribution.json
+++ b/Benchmarks/cardano/results/attribution/normalization-attribution.json
@@ -86,2891 +86,583 @@
           },
           "hashcons": 3131631,
           "heads": [
-            {
-              "calls": 199,
-              "head": "Add.add",
-              "self_ns": 1433627
-            },
-            {
-              "calls": 8,
-              "head": "And",
-              "self_ns": 75541
-            },
-            {
-              "calls": 1919,
-              "head": "BEq.beq",
-              "self_ns": 42259883
-            },
-            {
-              "calls": 1219,
-              "head": "Blaster.decide'",
-              "self_ns": 3685124
-            },
-            {
-              "calls": 14202,
-              "head": "Blaster.dite'",
-              "self_ns": 124567098
-            },
-            {
-              "calls": 1,
-              "head": "Bool",
-              "self_ns": 2333
-            },
-            {
-              "calls": 63,
-              "head": "Bool.and",
-              "self_ns": 332923
-            },
-            {
-              "calls": 1,
-              "head": "Bool.false",
-              "self_ns": 1084
-            },
-            {
-              "calls": 143,
-              "head": "Bool.or",
-              "self_ns": 767002
-            },
-            {
-              "calls": 1,
-              "head": "Bool.true",
-              "self_ns": 1625
-            },
-            {
-              "calls": 239,
-              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
-              "self_ns": 1578385
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
-              "self_ns": 3208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
-              "self_ns": 2666
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
-              "self_ns": 17876
-            },
-            {
-              "calls": 15,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1",
-              "self_ns": 313711
-            },
-            {
-              "calls": 328,
-              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
-              "self_ns": 378045
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.IsData.Class.toTerm",
-              "self_ns": 34000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.Address",
-              "self_ns": 1541
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
-              "self_ns": 14459
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
-              "self_ns": 15499
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
-              "self_ns": 2459
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
-              "self_ns": 3542
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
-              "self_ns": 12708
-            },
-            {
-              "calls": 10665,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 33328196
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 170292
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.Credential",
-              "self_ns": 1166
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
-              "self_ns": 7250
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
-              "self_ns": 7000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
-              "self_ns": 6583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
-              "self_ns": 1208
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
-              "self_ns": 6583
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
-              "self_ns": 9459
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
-              "self_ns": 2791
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
-              "self_ns": 2500
-            },
-            {
-              "calls": 46,
-              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
-              "self_ns": 1031957
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
-              "self_ns": 158081
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Datum",
-              "self_ns": 4125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
-              "self_ns": 5541
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
-              "self_ns": 5583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
-              "self_ns": 4959
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
-              "self_ns": 3041
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
-              "self_ns": 9792
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.Value",
-              "self_ns": 8209
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
-              "self_ns": 2917
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
-              "self_ns": 10001
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
-              "self_ns": 3167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
-              "self_ns": 3833
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
-              "self_ns": 13583
-            },
-            {
-              "calls": 19989,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
-              "self_ns": 42584525
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
-              "self_ns": 157792
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
-              "self_ns": 14375
-            },
-            {
-              "calls": 17673,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
-              "self_ns": 110671315
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
-              "self_ns": 231833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
-              "self_ns": 1584
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
-              "self_ns": 1167
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
-              "self_ns": 6333
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
-              "self_ns": 6583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut",
-              "self_ns": 1208
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
-              "self_ns": 14791
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
-              "self_ns": 14751
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
-              "self_ns": 16333
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
-              "self_ns": 14875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
-              "self_ns": 2375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
-              "self_ns": 2834
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
-              "self_ns": 155708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap",
-              "self_ns": 5958
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.MintValue",
-              "self_ns": 7000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap",
-              "self_ns": 10750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext",
-              "self_ns": 1083
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer",
-              "self_ns": 12792
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo",
-              "self_ns": 19500
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo",
-              "self_ns": 11458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo",
-              "self_ns": 1333
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript",
-              "self_ns": 9209
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript",
-              "self_ns": 7250
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript",
-              "self_ns": 8083
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript",
-              "self_ns": 9542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript",
-              "self_ns": 10000
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript",
-              "self_ns": 5958
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose",
-              "self_ns": 1833
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying",
-              "self_ns": 8833
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting",
-              "self_ns": 7125
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing",
-              "self_ns": 8542
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding",
-              "self_ns": 6208
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending",
-              "self_ns": 6625
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting",
-              "self_ns": 6625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo",
-              "self_ns": 1417
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef",
-              "self_ns": 13167
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved",
-              "self_ns": 10416
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo",
-              "self_ns": 1458
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount",
-              "self_ns": 15625
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData",
-              "self_ns": 12625
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee",
-              "self_ns": 13959
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId",
-              "self_ns": 14000
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs",
-              "self_ns": 12042
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint",
-              "self_ns": 10958
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs",
-              "self_ns": 12250
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures",
-              "self_ns": 13959
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers",
-              "self_ns": 15417
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs",
-              "self_ns": 14084
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories",
-              "self_ns": 12292
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation",
-              "self_ns": 15708
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts",
-              "self_ns": 11041
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange",
-              "self_ns": 13834
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes",
-              "self_ns": 10959
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl",
-              "self_ns": 18250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.VoterMap",
-              "self_ns": 7708
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData",
-              "self_ns": 14750
-            },
-            {
-              "calls": 26,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19",
-              "self_ns": 3024500
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1",
-              "self_ns": 166585
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap",
-              "self_ns": 3208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure",
-              "self_ns": 3209
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert",
-              "self_ns": 3042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo",
-              "self_ns": 2667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap",
-              "self_ns": 3083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext",
-              "self_ns": 3417
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo",
-              "self_ns": 3125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose",
-              "self_ns": 3083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo",
-              "self_ns": 3042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo",
-              "self_ns": 2667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap",
-              "self_ns": 2708
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1",
-              "self_ns": 231625
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1",
-              "self_ns": 408918
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs",
-              "self_ns": 28333
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1",
-              "self_ns": 200041
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData",
-              "self_ns": 13707
-            },
-            {
-              "calls": 39304,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14",
-              "self_ns": 60824106
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1",
-              "self_ns": 281792
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData",
-              "self_ns": 19501
-            },
-            {
-              "calls": 19993,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14",
-              "self_ns": 40534431
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1",
-              "self_ns": 167668
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData",
-              "self_ns": 18750
-            },
-            {
-              "calls": 20127,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19",
-              "self_ns": 43625531
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1",
-              "self_ns": 251542
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData",
-              "self_ns": 12167
-            },
-            {
-              "calls": 20105,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14",
-              "self_ns": 40708348
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1",
-              "self_ns": 223125
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData",
-              "self_ns": 12084
-            },
-            {
-              "calls": 19999,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19",
-              "self_ns": 41461317
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1",
-              "self_ns": 173291
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId",
-              "self_ns": 1833
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx",
-              "self_ns": 14000
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId",
-              "self_ns": 14417
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure",
-              "self_ns": 1167
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit",
-              "self_ns": 16875
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction",
-              "self_ns": 14750
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr",
-              "self_ns": 14916
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Voter",
-              "self_ns": 1500
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter",
-              "self_ns": 6708
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter",
-              "self_ns": 5958
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter",
-              "self_ns": 5791
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Withdrawals",
-              "self_ns": 9501
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId",
-              "self_ns": 3208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers",
-              "self_ns": 3500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure",
-              "self_ns": 3166
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataVote",
-              "self_ns": 2833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter",
-              "self_ns": 3500
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1",
-              "self_ns": 106999
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1",
-              "self_ns": 189127
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData",
-              "self_ns": 14124
-            },
-            {
-              "calls": 161,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19",
-              "self_ns": 3493084
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1",
-              "self_ns": 148708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.TxId",
-              "self_ns": 6500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef",
-              "self_ns": 1333
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId",
-              "self_ns": 15125
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx",
-              "self_ns": 14333
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId",
-              "self_ns": 4209
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef",
-              "self_ns": 2583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential",
-              "self_ns": 6000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep",
-              "self_ns": 1333
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep",
-              "self_ns": 6292
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRepCredential",
-              "self_ns": 5291
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee",
-              "self_ns": 7792
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake",
-              "self_ns": 8833
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote",
-              "self_ns": 8333
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote",
-              "self_ns": 10042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential",
-              "self_ns": 4875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert",
-              "self_ns": 2083
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee",
-              "self_ns": 9292
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking",
-              "self_ns": 9458
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister",
-              "self_ns": 7875
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire",
-              "self_ns": 7792
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep",
-              "self_ns": 12000
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg",
-              "self_ns": 13833
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking",
-              "self_ns": 11750
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee",
-              "self_ns": 5875
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep",
-              "self_ns": 7958
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking",
-              "self_ns": 9625
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep",
-              "self_ns": 7833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep",
-              "self_ns": 2791
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee",
-              "self_ns": 2917
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert",
-              "self_ns": 4334
-            },
-            {
-              "calls": 14,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1",
-              "self_ns": 315582
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1",
-              "self_ns": 290750
-            },
-            {
-              "calls": 16,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1",
-              "self_ns": 1390792
-            },
-            {
-              "calls": 943,
-              "head": "Decidable.decide",
-              "self_ns": 1189548
-            },
-            {
-              "calls": 5904,
-              "head": "Eq",
-              "self_ns": 49272815
-            },
-            {
-              "calls": 13,
-              "head": "Function.comp",
-              "self_ns": 86500
-            },
-            {
-              "calls": 205,
-              "head": "HAdd.hAdd",
-              "self_ns": 1462458
-            },
-            {
-              "calls": 340,
-              "head": "HMul.hMul",
-              "self_ns": 1808666
-            },
-            {
-              "calls": 2,
-              "head": "HPow.hPow",
-              "self_ns": 52625
-            },
-            {
-              "calls": 2,
-              "head": "Inhabited.default",
-              "self_ns": 28125
-            },
-            {
-              "calls": 1,
-              "head": "Int",
-              "self_ns": 2375
-            },
-            {
-              "calls": 595,
-              "head": "Int.add",
-              "self_ns": 2038208
-            },
-            {
-              "calls": 1,
-              "head": "Int.instAdd",
-              "self_ns": 3667
-            },
-            {
-              "calls": 1,
-              "head": "Int.instDecidableEq",
-              "self_ns": 5542
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLEInt",
-              "self_ns": 4459
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLTInt",
-              "self_ns": 3833
-            },
-            {
-              "calls": 1,
-              "head": "Int.instMul",
-              "self_ns": 2833
-            },
-            {
-              "calls": 975,
-              "head": "Int.mul",
-              "self_ns": 2849256
-            },
-            {
-              "calls": 390,
-              "head": "Int.natAbs",
-              "self_ns": 502378
-            },
-            {
-              "calls": 197,
-              "head": "Int.neg",
-              "self_ns": 461737
-            },
-            {
-              "calls": 200,
-              "head": "Int.neg.match_1",
-              "self_ns": 7043491
-            },
-            {
-              "calls": 7,
-              "head": "Int.negOfNat.match_1",
-              "self_ns": 113834
-            },
-            {
-              "calls": 5,
-              "head": "Int.negSucc",
-              "self_ns": 16584
-            },
-            {
-              "calls": 15,
-              "head": "Int.ofNat",
-              "self_ns": 37126
-            },
-            {
-              "calls": 3,
-              "head": "Int.pow",
-              "self_ns": 7666
-            },
-            {
-              "calls": 595,
-              "head": "Int.toNat",
-              "self_ns": 1792286
-            },
-            {
-              "calls": 452,
-              "head": "LE.le",
-              "self_ns": 2513742
-            },
-            {
-              "calls": 2712,
-              "head": "LT.lt",
-              "self_ns": 11615843
-            },
-            {
-              "calls": 946,
-              "head": "List",
-              "self_ns": 1547758
-            },
-            {
-              "calls": 1303882,
-              "head": "List.cons",
-              "self_ns": 2572110066
-            },
-            {
-              "calls": 215,
-              "head": "List.drop",
-              "self_ns": 9421542
-            },
-            {
-              "calls": 34205,
-              "head": "List.get?Internal",
-              "self_ns": 150078295
-            },
-            {
-              "calls": 2718,
-              "head": "List.getLast?.match_1",
-              "self_ns": 35704345
-            },
-            {
-              "calls": 1791,
-              "head": "List.isEmpty",
-              "self_ns": 4967319
-            },
-            {
-              "calls": 4309,
-              "head": "List.nil",
-              "self_ns": 7127191
-            },
-            {
-              "calls": 4289,
-              "head": "List.reverse",
-              "self_ns": 12911672
-            },
-            {
-              "calls": 4289,
-              "head": "List.reverseAux",
-              "self_ns": 24380874
-            },
-            {
-              "calls": 20,
-              "head": "List.take.match_1",
-              "self_ns": 597835
-            },
-            {
-              "calls": 197,
-              "head": "Mul.mul",
-              "self_ns": 1384996
-            },
-            {
-              "calls": 1,
-              "head": "Nat",
-              "self_ns": 35625
-            },
-            {
-              "calls": 225,
-              "head": "Nat.add",
-              "self_ns": 915199
-            },
-            {
-              "calls": 12,
-              "head": "Nat.add.match_1",
-              "self_ns": 294168
-            },
-            {
-              "calls": 2,
-              "head": "Nat.beq",
-              "self_ns": 6500
-            },
-            {
-              "calls": 14,
-              "head": "Nat.beq.match_1",
-              "self_ns": 333959
-            },
-            {
-              "calls": 2,
-              "head": "Nat.ble",
-              "self_ns": 7167
-            },
-            {
-              "calls": 4,
-              "head": "Nat.mul",
-              "self_ns": 14708
-            },
-            {
-              "calls": 12,
-              "head": "Nat.mul.match_1",
-              "self_ns": 212126
-            },
-            {
-              "calls": 4,
-              "head": "Nat.pow",
-              "self_ns": 14624
-            },
-            {
-              "calls": 6,
-              "head": "Nat.pow.match_1",
-              "self_ns": 132750
-            },
-            {
-              "calls": 2,
-              "head": "Nat.pred",
-              "self_ns": 7542
-            },
-            {
-              "calls": 227,
-              "head": "Nat.sub",
-              "self_ns": 4226962
-            },
-            {
-              "calls": 208,
-              "head": "Nat.succ",
-              "self_ns": 352383
-            },
-            {
-              "calls": 1,
-              "head": "Nat.zero",
-              "self_ns": 2208
-            },
-            {
-              "calls": 2,
-              "head": "NatPow.pow",
-              "self_ns": 29501
-            },
-            {
-              "calls": 650,
-              "head": "Not",
-              "self_ns": 1893034
-            },
-            {
-              "calls": 21,
-              "head": "OfNat.ofNat",
-              "self_ns": 257666
-            },
-            {
-              "calls": 2043,
-              "head": "Option",
-              "self_ns": 3194044
-            },
-            {
-              "calls": 5596,
-              "head": "Option.getD.match_1",
-              "self_ns": 98020094
-            },
-            {
-              "calls": 1017,
-              "head": "Option.map",
-              "self_ns": 4102272
-            },
-            {
-              "calls": 1681,
-              "head": "Option.none",
-              "self_ns": 2987457
-            },
-            {
-              "calls": 29821,
-              "head": "Option.some",
-              "self_ns": 131919653
-            },
-            {
-              "calls": 74,
-              "head": "Or",
-              "self_ns": 538258
-            },
-            {
-              "calls": 2071,
-              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
-              "self_ns": 7912312
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
-              "self_ns": 3792
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
-              "self_ns": 1166
-            },
-            {
-              "calls": 3731,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data",
-              "self_ns": 3999032
-            },
-            {
-              "calls": 838,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length",
-              "self_ns": 836758
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
-              "self_ns": 6291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString",
-              "self_ns": 4041
-            },
-            {
-              "calls": 188,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
-              "self_ns": 284166
-            },
-            {
-              "calls": 204,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString",
-              "self_ns": 288516
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
-              "self_ns": 12875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
-              "self_ns": 1500
-            },
-            {
-              "calls": 72536,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
-              "self_ns": 78458741
-            },
-            {
-              "calls": 237385,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
-              "self_ns": 330078765
-            },
-            {
-              "calls": 55672,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
-              "self_ns": 62536235
-            },
-            {
-              "calls": 96949,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
-              "self_ns": 137956799
-            },
-            {
-              "calls": 65494,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
-              "self_ns": 154104237
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
-              "self_ns": 21500
-            },
-            {
-              "calls": 91,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
-              "self_ns": 1065920
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
-              "self_ns": 89791
-            },
-            {
-              "calls": 19,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
-              "self_ns": 171584
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
-              "self_ns": 73834
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
-              "self_ns": 308042
-            },
-            {
-              "calls": 85,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
-              "self_ns": 490584
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
-              "self_ns": 374708
-            },
-            {
-              "calls": 1140,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
-              "self_ns": 1422758
-            },
-            {
-              "calls": 1020,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
-              "self_ns": 1117008
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
-              "self_ns": 3542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Integer.Integer",
-              "self_ns": 6250
-            },
-            {
-              "calls": 16,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger",
-              "self_ns": 57541
-            },
-            {
-              "calls": 872,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
-              "self_ns": 1067082
-            },
-            {
-              "calls": 60,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
-              "self_ns": 101624
-            },
-            {
-              "calls": 73,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
-              "self_ns": 319416
-            },
-            {
-              "calls": 339,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.nullList",
-              "self_ns": 1050082
-            },
-            {
-              "calls": 805,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
-              "self_ns": 2757976
-            },
-            {
-              "calls": 1737,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
-              "self_ns": 5578044
-            },
-            {
-              "calls": 4140,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
-              "self_ns": 4542964
-            },
-            {
-              "calls": 2075,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
-              "self_ns": 9843347
-            },
-            {
-              "calls": 201,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
-              "self_ns": 1576669
-            },
-            {
-              "calls": 188,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
-              "self_ns": 275837
-            },
-            {
-              "calls": 204,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString",
-              "self_ns": 312158
-            },
-            {
-              "calls": 1140,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
-              "self_ns": 1299735
-            },
-            {
-              "calls": 575,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
-              "self_ns": 3249476
-            },
-            {
-              "calls": 1020,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
-              "self_ns": 1139009
-            },
-            {
-              "calls": 515,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
-              "self_ns": 2517757
-            },
-            {
-              "calls": 928,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
-              "self_ns": 1033606
-            },
-            {
-              "calls": 469,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1",
-              "self_ns": 12405594
-            },
-            {
-              "calls": 3512,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
-              "self_ns": 3688307
-            },
-            {
-              "calls": 1762,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
-              "self_ns": 60816251
-            },
-            {
-              "calls": 4112,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
-              "self_ns": 17946987
-            },
-            {
-              "calls": 460,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
-              "self_ns": 589168
-            },
-            {
-              "calls": 235,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1",
-              "self_ns": 6512370
-            },
-            {
-              "calls": 1484,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
-              "self_ns": 1670566
-            },
-            {
-              "calls": 747,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1",
-              "self_ns": 16497509
-            },
-            {
-              "calls": 1828,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
-              "self_ns": 1963160
-            },
-            {
-              "calls": 919,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1",
-              "self_ns": 9790134
-            },
-            {
-              "calls": 41940,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
-              "self_ns": 39558252
-            },
-            {
-              "calls": 21070,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
-              "self_ns": 208796268
-            },
-            {
-              "calls": 16,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger",
-              "self_ns": 37082
-            },
-            {
-              "calls": 479,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
-              "self_ns": 2687528
-            },
-            {
-              "calls": 872,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
-              "self_ns": 946357
-            },
-            {
-              "calls": 60,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
-              "self_ns": 108044
-            },
-            {
-              "calls": 2904,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
-              "self_ns": 3146246
-            },
-            {
-              "calls": 1459,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
-              "self_ns": 9103887
-            },
-            {
-              "calls": 408,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList",
-              "self_ns": 537874
-            },
-            {
-              "calls": 211,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1",
-              "self_ns": 2036124
-            },
-            {
-              "calls": 9120,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
-              "self_ns": 8801041
-            },
-            {
-              "calls": 9064,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3",
-              "self_ns": 129084294
-            },
-            {
-              "calls": 2010,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5",
-              "self_ns": 27445895
-            },
-            {
-              "calls": 7437,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7",
-              "self_ns": 36213015
-            },
-            {
-              "calls": 144,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
-              "self_ns": 233793
-            },
-            {
-              "calls": 79,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
-              "self_ns": 1285380
-            },
-            {
-              "calls": 676,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList",
-              "self_ns": 775289
-            },
-            {
-              "calls": 5064,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
-              "self_ns": 4889818
-            },
-            {
-              "calls": 1608,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
-              "self_ns": 1765133
-            },
-            {
-              "calls": 2546,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
-              "self_ns": 11787544
-            },
-            {
-              "calls": 3472,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
-              "self_ns": 3545426
-            },
-            {
-              "calls": 100,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin",
-              "self_ns": 181537
-            },
-            {
-              "calls": 55,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin.match_1",
-              "self_ns": 1364511
-            },
-            {
-              "calls": 1092,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData",
-              "self_ns": 1258251
-            },
-            {
-              "calls": 551,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1",
-              "self_ns": 2607852
-            },
-            {
-              "calls": 752,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue",
-              "self_ns": 954283
-            },
-            {
-              "calls": 425,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1",
-              "self_ns": 2477281
-            },
-            {
-              "calls": 88,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains",
-              "self_ns": 161672
-            },
-            {
-              "calls": 660,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData",
-              "self_ns": 741085
-            },
-            {
-              "calls": 335,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1",
-              "self_ns": 1693091
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
-              "self_ns": 1208
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
-              "self_ns": 37498
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
-              "self_ns": 7709
-            },
-            {
-              "calls": 14798,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
-              "self_ns": 14390713
-            },
-            {
-              "calls": 7499,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
-              "self_ns": 90707748
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame",
-              "self_ns": 1334
-            },
-            {
-              "calls": 9682,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
-              "self_ns": 20770824
-            },
-            {
-              "calls": 19156,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
-              "self_ns": 66183436
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
-              "self_ns": 1250
-            },
-            {
-              "calls": 32913,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
-              "self_ns": 75431948
-            },
-            {
-              "calls": 13357,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
-              "self_ns": 24218961
-            },
-            {
-              "calls": 41742,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
-              "self_ns": 70024539
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State.Error",
-              "self_ns": 1291
-            },
-            {
-              "calls": 97703,
-              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
-              "self_ns": 302551107
-            },
-            {
-              "calls": 141,
-              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
-              "self_ns": 354619
-            },
-            {
-              "calls": 91162,
-              "head": "PlutusCore.UPLC.CekMachine.State.Return",
-              "self_ns": 271222791
-            },
-            {
-              "calls": 14,
-              "head": "PlutusCore.UPLC.CekMachine.applyParams",
-              "self_ns": 3149500
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
-              "self_ns": 50833
-            },
-            {
-              "calls": 4,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
-              "self_ns": 83375
-            },
-            {
-              "calls": 41940,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
-              "self_ns": 44115857
-            },
-            {
-              "calls": 69673,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
-              "self_ns": 1060629176
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.CekMachine.initialState",
-              "self_ns": 12292
-            },
-            {
-              "calls": 200707,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps",
-              "self_ns": 1194681782
-            },
-            {
-              "calls": 191252,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
-              "self_ns": 620226248
-            },
-            {
-              "calls": 374984,
-              "head": "PlutusCore.UPLC.CekMachine.step",
-              "self_ns": 346386157
-            },
-            {
-              "calls": 17627,
-              "head": "PlutusCore.UPLC.CekMachine.step.folding",
-              "self_ns": 75964457
-            },
-            {
-              "calls": 21902,
-              "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1",
-              "self_ns": 48496495
-            },
-            {
-              "calls": 18452,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_1",
-              "self_ns": 47603803
-            },
-            {
-              "calls": 4289,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_11",
-              "self_ns": 13363743
-            },
-            {
-              "calls": 90445,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_13",
-              "self_ns": 247461507
-            },
-            {
-              "calls": 187499,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_15",
-              "self_ns": 491042694
-            },
-            {
-              "calls": 96929,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
-              "self_ns": 294011483
-            },
-            {
-              "calls": 39771,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_5",
-              "self_ns": 113615833
-            },
-            {
-              "calls": 4843,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_7",
-              "self_ns": 12736573
-            },
-            {
-              "calls": 4277,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_9",
-              "self_ns": 15843828
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekValue.CekValue",
-              "self_ns": 1375
-            },
-            {
-              "calls": 18492,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
-              "self_ns": 45379718
-            },
-            {
-              "calls": 290575,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
-              "self_ns": 449640797
-            },
-            {
-              "calls": 4292,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
-              "self_ns": 9729336
-            },
-            {
-              "calls": 9994,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
-              "self_ns": 23047045
-            },
-            {
-              "calls": 60642,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
-              "self_ns": 139647836
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3",
-              "self_ns": 1333
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
-              "self_ns": 10209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun",
-              "self_ns": 1416
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
-              "self_ns": 917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
-              "self_ns": 12875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
-              "self_ns": 916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
-              "self_ns": 1541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const",
-              "self_ns": 1125
-            },
-            {
-              "calls": 2013,
-              "head": "PlutusCore.UPLC.Term.Const.Bool",
-              "self_ns": 7426977
-            },
-            {
-              "calls": 2236,
-              "head": "PlutusCore.UPLC.Term.Const.ByteString",
-              "self_ns": 2913366
-            },
-            {
-              "calls": 191173,
-              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
-              "self_ns": 289106527
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.UPLC.Term.Const.ConstList",
-              "self_ns": 22540
-            },
-            {
-              "calls": 22701,
-              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
-              "self_ns": 34462409
-            },
-            {
-              "calls": 101896,
-              "head": "PlutusCore.UPLC.Term.Const.Data",
-              "self_ns": 127972334
-            },
-            {
-              "calls": 10787,
-              "head": "PlutusCore.UPLC.Term.Const.Integer",
-              "self_ns": 13133253
-            },
-            {
-              "calls": 19367,
-              "head": "PlutusCore.UPLC.Term.Const.Pair",
-              "self_ns": 32726519
-            },
-            {
-              "calls": 2115,
-              "head": "PlutusCore.UPLC.Term.Const.PairData",
-              "self_ns": 3236361
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const.Unit",
-              "self_ns": 1167
-            },
-            {
-              "calls": 4109,
-              "head": "PlutusCore.UPLC.Term.Const.Value",
-              "self_ns": 5069804
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Program",
-              "self_ns": 1750
-            },
-            {
-              "calls": 5,
-              "head": "PlutusCore.UPLC.Term.Program.Program",
-              "self_ns": 14500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term",
-              "self_ns": 1000
-            },
-            {
-              "calls": 532,
-              "head": "PlutusCore.UPLC.Term.Term.Apply",
-              "self_ns": 958420
-            },
-            {
-              "calls": 29,
-              "head": "PlutusCore.UPLC.Term.Term.Builtin",
-              "self_ns": 42915
-            },
-            {
-              "calls": 78,
-              "head": "PlutusCore.UPLC.Term.Term.Case",
-              "self_ns": 138249
-            },
-            {
-              "calls": 17,
-              "head": "PlutusCore.UPLC.Term.Term.Const",
-              "self_ns": 71374
-            },
-            {
-              "calls": 78,
-              "head": "PlutusCore.UPLC.Term.Term.Constr",
-              "self_ns": 135078
-            },
-            {
-              "calls": 83,
-              "head": "PlutusCore.UPLC.Term.Term.Delay",
-              "self_ns": 116953
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term.Error",
-              "self_ns": 917
-            },
-            {
-              "calls": 70,
-              "head": "PlutusCore.UPLC.Term.Term.Force",
-              "self_ns": 100050
-            },
-            {
-              "calls": 199,
-              "head": "PlutusCore.UPLC.Term.Term.Lam",
-              "self_ns": 268321
-            },
-            {
-              "calls": 125,
-              "head": "PlutusCore.UPLC.Term.Term.Var",
-              "self_ns": 110129
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.Term.Version.Version",
-              "self_ns": 9000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Value.ValueRep",
-              "self_ns": 15500
-            },
-            {
-              "calls": 838,
-              "head": "PlutusCore.Value.ascendingFrom",
-              "self_ns": 1099281
-            },
-            {
-              "calls": 426,
-              "head": "PlutusCore.Value.ascendingFrom.match_1",
-              "self_ns": 1512001
-            },
-            {
-              "calls": 60,
-              "head": "PlutusCore.Value.containedInner",
-              "self_ns": 2309415
-            },
-            {
-              "calls": 99,
-              "head": "PlutusCore.Value.containedOuter",
-              "self_ns": 1859574
-            },
-            {
-              "calls": 282,
-              "head": "PlutusCore.Value.deleteCoin",
-              "self_ns": 4546960
-            },
-            {
-              "calls": 6,
-              "head": "PlutusCore.Value.deleteCoin.match_1",
-              "self_ns": 144167
-            },
-            {
-              "calls": 154,
-              "head": "PlutusCore.Value.hasNegativeAmount",
-              "self_ns": 2289535
-            },
-            {
-              "calls": 15,
-              "head": "PlutusCore.Value.innerDelete",
-              "self_ns": 2785333
-            },
-            {
-              "calls": 144,
-              "head": "PlutusCore.Value.innerHasNegative",
-              "self_ns": 2367632
-            },
-            {
-              "calls": 604,
-              "head": "PlutusCore.Value.innerHasNegative.match_1",
-              "self_ns": 2223870
-            },
-            {
-              "calls": 2450,
-              "head": "PlutusCore.Value.innerToData",
-              "self_ns": 8620832
-            },
-            {
-              "calls": 100,
-              "head": "PlutusCore.Value.insertCoin",
-              "self_ns": 212461
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.Value.lookupCoin",
-              "self_ns": 3206583
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.Value.lookupInner",
-              "self_ns": 3020751
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Value.maxKeyLen",
-              "self_ns": 8833
-            },
-            {
-              "calls": 934,
-              "head": "PlutusCore.Value.outerToData",
-              "self_ns": 5933856
-            },
-            {
-              "calls": 1024,
-              "head": "PlutusCore.Value.totalSize.match_1",
-              "self_ns": 3439409
-            },
-            {
-              "calls": 1092,
-              "head": "PlutusCore.Value.unValueData",
-              "self_ns": 1285297
-            },
-            {
-              "calls": 551,
-              "head": "PlutusCore.Value.unValueData.match_1",
-              "self_ns": 6994922
-            },
-            {
-              "calls": 1291,
-              "head": "PlutusCore.Value.unValueDataCurrencies",
-              "self_ns": 45858115
-            },
-            {
-              "calls": 352,
-              "head": "PlutusCore.Value.unValueDataCurrencies.match_1",
-              "self_ns": 7785333
-            },
-            {
-              "calls": 352,
-              "head": "PlutusCore.Value.unValueDataCurrencies.match_3",
-              "self_ns": 8762971
-            },
-            {
-              "calls": 512,
-              "head": "PlutusCore.Value.unValueDataTokens",
-              "self_ns": 14632621
-            },
-            {
-              "calls": 486,
-              "head": "PlutusCore.Value.unValueDataTokens.match_1",
-              "self_ns": 10750956
-            },
-            {
-              "calls": 873,
-              "head": "PlutusCore.Value.unValueDataTokens.match_3",
-              "self_ns": 15956947
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.Value.unionInner",
-              "self_ns": 366168
-            },
-            {
-              "calls": 2458,
-              "head": "PlutusCore.Value.unionInner.match_1",
-              "self_ns": 50598922
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Value.unionInner.match_3",
-              "self_ns": 609833
-            },
-            {
-              "calls": 386,
-              "head": "PlutusCore.Value.unionOuter",
-              "self_ns": 1997376
-            },
-            {
-              "calls": 3295,
-              "head": "PlutusCore.Value.unionOuter.match_1",
-              "self_ns": 77071999
-            },
-            {
-              "calls": 8,
-              "head": "PlutusCore.Value.unionOuter.match_3",
-              "self_ns": 179917
-            },
-            {
-              "calls": 303,
-              "head": "PlutusCore.Value.unionOuter.match_5",
-              "self_ns": 1547634
-            },
-            {
-              "calls": 752,
-              "head": "PlutusCore.Value.unionValue",
-              "self_ns": 885743
-            },
-            {
-              "calls": 838,
-              "head": "PlutusCore.Value.validKey",
-              "self_ns": 981318
-            },
-            {
-              "calls": 390,
-              "head": "PlutusCore.Value.validQuantity",
-              "self_ns": 519330
-            },
-            {
-              "calls": 88,
-              "head": "PlutusCore.Value.valueContains",
-              "self_ns": 127288
-            },
-            {
-              "calls": 660,
-              "head": "PlutusCore.Value.valueData",
-              "self_ns": 726212
-            },
-            {
-              "calls": 2,
-              "head": "Pow.pow",
-              "self_ns": 49541
-            },
-            {
-              "calls": 10,
-              "head": "Prod",
-              "self_ns": 32086
-            },
-            {
-              "calls": 1389,
-              "head": "Prod.fst",
-              "self_ns": 7045746
-            },
-            {
-              "calls": 31056,
-              "head": "Prod.mk",
-              "self_ns": 73418028
-            },
-            {
-              "calls": 1756,
-              "head": "Prod.snd",
-              "self_ns": 15522234
-            },
-            {
-              "calls": 1,
-              "head": "String",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "String.instLT",
-              "self_ns": 2833
-            },
-            {
-              "calls": 420,
-              "head": "String.length",
-              "self_ns": 1511919
-            },
-            {
-              "calls": 2,
-              "head": "WSC.globalInputs1600",
-              "self_ns": 17249
-            },
-            {
-              "calls": 14,
-              "head": "_normalizer",
-              "self_ns": 26795082
-            },
-            {
-              "calls": 2,
-              "head": "instBEqOfDecidableEq",
-              "self_ns": 19708
-            },
-            {
-              "calls": 2,
-              "head": "instHAdd",
-              "self_ns": 17708
-            },
-            {
-              "calls": 3,
-              "head": "instHMul",
-              "self_ns": 17876
-            },
-            {
-              "calls": 2,
-              "head": "instHPow",
-              "self_ns": 19291
-            },
-            {
-              "calls": 1,
-              "head": "instLENat",
-              "self_ns": 3458
-            },
-            {
-              "calls": 1,
-              "head": "instLTNat",
-              "self_ns": 4334
-            },
-            {
-              "calls": 1,
-              "head": "instNatPowNat",
-              "self_ns": 3625
-            },
-            {
-              "calls": 12,
-              "head": "instOfNat",
-              "self_ns": 25667
-            },
-            {
-              "calls": 9,
-              "head": "instOfNatNat",
-              "self_ns": 23708
-            },
-            {
-              "calls": 2,
-              "head": "instPowNat",
-              "self_ns": 14750
-            },
-            {
-              "calls": 4897,
-              "head": "ite",
-              "self_ns": 7022870
-            },
-            {
-              "calls": 1,
-              "head": "programmableLogicGlobal1600",
-              "self_ns": 841542
-            }
+            {"calls": 199, "head": "Add.add", "self_ns": 1433627},
+            {"calls": 8, "head": "And", "self_ns": 75541},
+            {"calls": 1919, "head": "BEq.beq", "self_ns": 42259883},
+            {"calls": 1219, "head": "Blaster.decide'", "self_ns": 3685124},
+            {"calls": 14202, "head": "Blaster.dite'", "self_ns": 124567098},
+            {"calls": 1, "head": "Bool", "self_ns": 2333},
+            {"calls": 63, "head": "Bool.and", "self_ns": 332923},
+            {"calls": 1, "head": "Bool.false", "self_ns": 1084},
+            {"calls": 143, "head": "Bool.or", "self_ns": 767002},
+            {"calls": 1, "head": "Bool.true", "self_ns": 1625},
+            {"calls": 239, "head": "CardanoLedgerApi.IsData.Class.IsData.toData", "self_ns": 1578385},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataData", "self_ns": 3208},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger", "self_ns": 2666},
+            {"calls": 4, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption", "self_ns": 17876},
+            {"calls": 15, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1", "self_ns": 313711},
+            {"calls": 328, "head": "CardanoLedgerApi.IsData.Class.mkDataConstr", "self_ns": 378045},
+            {"calls": 5, "head": "CardanoLedgerApi.IsData.Class.toTerm", "self_ns": 34000},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.Address", "self_ns": 1541},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressCredential", "self_ns": 14459},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential", "self_ns": 15499},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.instIsDataAddress", "self_ns": 2459},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash", "self_ns": 3542},
+            {"calls": 2, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData", "self_ns": 12708},
+            {"calls": 10665, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 33328196},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 170292},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.Credential", "self_ns": 1166},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential", "self_ns": 7250},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential", "self_ns": 7000},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.PubKeyHash", "self_ns": 6583},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.StakingCredential", "self_ns": 1208},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash", "self_ns": 6583},
+            {"calls": 5, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr", "self_ns": 9459},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential", "self_ns": 2791},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential", "self_ns": 2500},
+            {"calls": 46, "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1", "self_ns": 1031957},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1", "self_ns": 158081},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Datum", "self_ns": 4125},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.DatumHash", "self_ns": 5541},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Redeemer", "self_ns": 5583},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.ScriptHash", "self_ns": 4959},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId", "self_ns": 3041},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.CurrencySymbol", "self_ns": 9792},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.Value", "self_ns": 8209},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.instIsDataValue", "self_ns": 2917},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.DatumMap", "self_ns": 10001},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap", "self_ns": 3167},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut", "self_ns": 3833},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData", "self_ns": 13583},
+            {"calls": 19989, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19", "self_ns": 42584525},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1", "self_ns": 157792},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData", "self_ns": 14375},
+            {"calls": 17673, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14", "self_ns": 110671315},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1", "self_ns": 231833},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum", "self_ns": 1584},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum", "self_ns": 1167},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum", "self_ns": 6333},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash", "self_ns": 6583},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.TxOut", "self_ns": 1208},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress", "self_ns": 14791},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum", "self_ns": 14751},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript", "self_ns": 16333},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue", "self_ns": 14875},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum", "self_ns": 2375},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut", "self_ns": 2834},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1", "self_ns": 155708},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap", "self_ns": 5958},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.MintValue", "self_ns": 7000},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap", "self_ns": 10750},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext", "self_ns": 1083},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer", "self_ns": 12792},
+            {"calls": 9, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo", "self_ns": 19500},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo", "self_ns": 11458},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo", "self_ns": 1333},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript", "self_ns": 9209},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript", "self_ns": 7250},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript", "self_ns": 8083},
+            {"calls": 5, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript", "self_ns": 9542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript", "self_ns": 10000},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript", "self_ns": 5958},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose", "self_ns": 1833},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying", "self_ns": 8833},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting", "self_ns": 7125},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing", "self_ns": 8542},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding", "self_ns": 6208},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending", "self_ns": 6625},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting", "self_ns": 6625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo", "self_ns": 1417},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef", "self_ns": 13167},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved", "self_ns": 10416},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.TxInfo", "self_ns": 1458},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount", "self_ns": 15625},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData", "self_ns": 12625},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee", "self_ns": 13959},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId", "self_ns": 14000},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs", "self_ns": 12042},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint", "self_ns": 10958},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs", "self_ns": 12250},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures", "self_ns": 13959},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers", "self_ns": 15417},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs", "self_ns": 14084},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories", "self_ns": 12292},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation", "self_ns": 15708},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts", "self_ns": 11041},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange", "self_ns": 13834},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes", "self_ns": 10959},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl", "self_ns": 18250},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.VoterMap", "self_ns": 7708},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData", "self_ns": 14750},
+            {"calls": 26, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19", "self_ns": 3024500},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1", "self_ns": 166585},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap", "self_ns": 3208},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure", "self_ns": 3209},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert", "self_ns": 3042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo", "self_ns": 2667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap", "self_ns": 3083},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext", "self_ns": 3417},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo", "self_ns": 3125},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose", "self_ns": 3083},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo", "self_ns": 3042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo", "self_ns": 2667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap", "self_ns": 2708},
+            {"calls": 9, "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1", "self_ns": 231625},
+            {"calls": 10, "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1", "self_ns": 408918},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs", "self_ns": 28333},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1", "self_ns": 200041},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData", "self_ns": 13707},
+            {"calls": 39304, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14", "self_ns": 60824106},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1", "self_ns": 281792},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData", "self_ns": 19501},
+            {"calls": 19993, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14", "self_ns": 40534431},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1", "self_ns": 167668},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData", "self_ns": 18750},
+            {"calls": 20127, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19", "self_ns": 43625531},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1", "self_ns": 251542},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData", "self_ns": 12167},
+            {"calls": 20105, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14", "self_ns": 40708348},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1", "self_ns": 223125},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData", "self_ns": 12084},
+            {"calls": 19999, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19", "self_ns": 41461317},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1", "self_ns": 173291},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId", "self_ns": 1833},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx", "self_ns": 14000},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId", "self_ns": 14417},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure", "self_ns": 1167},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit", "self_ns": 16875},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction", "self_ns": 14750},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr", "self_ns": 14916},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote", "self_ns": 1250},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain", "self_ns": 1042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo", "self_ns": 1292},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes", "self_ns": 1042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Voter", "self_ns": 1500},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter", "self_ns": 6708},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter", "self_ns": 5958},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter", "self_ns": 5791},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Withdrawals", "self_ns": 9501},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId", "self_ns": 3208},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers", "self_ns": 3500},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure", "self_ns": 3166},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataVote", "self_ns": 2833},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter", "self_ns": 3500},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1", "self_ns": 106999},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1", "self_ns": 189127},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData", "self_ns": 14124},
+            {"calls": 161, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19", "self_ns": 3493084},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1", "self_ns": 148708},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.TxId", "self_ns": 6500},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.TxOutRef", "self_ns": 1333},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId", "self_ns": 15125},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx", "self_ns": 14333},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId", "self_ns": 4209},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef", "self_ns": 2583},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential", "self_ns": 6000},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep", "self_ns": 1333},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep", "self_ns": 6292},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain", "self_ns": 1083},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence", "self_ns": 1250},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRepCredential", "self_ns": 5291},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.Delegatee", "self_ns": 7792},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake", "self_ns": 8833},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote", "self_ns": 8333},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote", "self_ns": 10042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential", "self_ns": 4875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.TxCert", "self_ns": 2083},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee", "self_ns": 9292},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking", "self_ns": 9458},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister", "self_ns": 7875},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire", "self_ns": 7792},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep", "self_ns": 12000},
+            {"calls": 5, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg", "self_ns": 13833},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking", "self_ns": 11750},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee", "self_ns": 5875},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep", "self_ns": 7958},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking", "self_ns": 9625},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep", "self_ns": 7833},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep", "self_ns": 2791},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee", "self_ns": 2917},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert", "self_ns": 4334},
+            {"calls": 14, "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1", "self_ns": 315582},
+            {"calls": 10, "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1", "self_ns": 290750},
+            {"calls": 16, "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1", "self_ns": 1390792},
+            {"calls": 943, "head": "Decidable.decide", "self_ns": 1189548},
+            {"calls": 5904, "head": "Eq", "self_ns": 49272815},
+            {"calls": 13, "head": "Function.comp", "self_ns": 86500},
+            {"calls": 205, "head": "HAdd.hAdd", "self_ns": 1462458},
+            {"calls": 340, "head": "HMul.hMul", "self_ns": 1808666},
+            {"calls": 2, "head": "HPow.hPow", "self_ns": 52625},
+            {"calls": 2, "head": "Inhabited.default", "self_ns": 28125},
+            {"calls": 1, "head": "Int", "self_ns": 2375},
+            {"calls": 595, "head": "Int.add", "self_ns": 2038208},
+            {"calls": 1, "head": "Int.instAdd", "self_ns": 3667},
+            {"calls": 1, "head": "Int.instDecidableEq", "self_ns": 5542},
+            {"calls": 1, "head": "Int.instLEInt", "self_ns": 4459},
+            {"calls": 1, "head": "Int.instLTInt", "self_ns": 3833},
+            {"calls": 1, "head": "Int.instMul", "self_ns": 2833},
+            {"calls": 975, "head": "Int.mul", "self_ns": 2849256},
+            {"calls": 390, "head": "Int.natAbs", "self_ns": 502378},
+            {"calls": 197, "head": "Int.neg", "self_ns": 461737},
+            {"calls": 200, "head": "Int.neg.match_1", "self_ns": 7043491},
+            {"calls": 7, "head": "Int.negOfNat.match_1", "self_ns": 113834},
+            {"calls": 5, "head": "Int.negSucc", "self_ns": 16584},
+            {"calls": 15, "head": "Int.ofNat", "self_ns": 37126},
+            {"calls": 3, "head": "Int.pow", "self_ns": 7666},
+            {"calls": 595, "head": "Int.toNat", "self_ns": 1792286},
+            {"calls": 452, "head": "LE.le", "self_ns": 2513742},
+            {"calls": 2712, "head": "LT.lt", "self_ns": 11615843},
+            {"calls": 946, "head": "List", "self_ns": 1547758},
+            {"calls": 1303882, "head": "List.cons", "self_ns": 2572110066},
+            {"calls": 215, "head": "List.drop", "self_ns": 9421542},
+            {"calls": 34205, "head": "List.get?Internal", "self_ns": 150078295},
+            {"calls": 2718, "head": "List.getLast?.match_1", "self_ns": 35704345},
+            {"calls": 1791, "head": "List.isEmpty", "self_ns": 4967319},
+            {"calls": 4309, "head": "List.nil", "self_ns": 7127191},
+            {"calls": 4289, "head": "List.reverse", "self_ns": 12911672},
+            {"calls": 4289, "head": "List.reverseAux", "self_ns": 24380874},
+            {"calls": 20, "head": "List.take.match_1", "self_ns": 597835},
+            {"calls": 197, "head": "Mul.mul", "self_ns": 1384996},
+            {"calls": 1, "head": "Nat", "self_ns": 35625},
+            {"calls": 225, "head": "Nat.add", "self_ns": 915199},
+            {"calls": 12, "head": "Nat.add.match_1", "self_ns": 294168},
+            {"calls": 2, "head": "Nat.beq", "self_ns": 6500},
+            {"calls": 14, "head": "Nat.beq.match_1", "self_ns": 333959},
+            {"calls": 2, "head": "Nat.ble", "self_ns": 7167},
+            {"calls": 4, "head": "Nat.mul", "self_ns": 14708},
+            {"calls": 12, "head": "Nat.mul.match_1", "self_ns": 212126},
+            {"calls": 4, "head": "Nat.pow", "self_ns": 14624},
+            {"calls": 6, "head": "Nat.pow.match_1", "self_ns": 132750},
+            {"calls": 2, "head": "Nat.pred", "self_ns": 7542},
+            {"calls": 227, "head": "Nat.sub", "self_ns": 4226962},
+            {"calls": 208, "head": "Nat.succ", "self_ns": 352383},
+            {"calls": 1, "head": "Nat.zero", "self_ns": 2208},
+            {"calls": 2, "head": "NatPow.pow", "self_ns": 29501},
+            {"calls": 650, "head": "Not", "self_ns": 1893034},
+            {"calls": 21, "head": "OfNat.ofNat", "self_ns": 257666},
+            {"calls": 2043, "head": "Option", "self_ns": 3194044},
+            {"calls": 5596, "head": "Option.getD.match_1", "self_ns": 98020094},
+            {"calls": 1017, "head": "Option.map", "self_ns": 4102272},
+            {"calls": 1681, "head": "Option.none", "self_ns": 2987457},
+            {"calls": 29821, "head": "Option.some", "self_ns": 131919653},
+            {"calls": 74, "head": "Or", "self_ns": 538258},
+            {"calls": 2071, "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse", "self_ns": 7912312},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString", "self_ns": 3792},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString", "self_ns": 1166},
+            {"calls": 3731, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data", "self_ns": 3999032},
+            {"calls": 838, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length", "self_ns": 836758},
+            {"calls": 3, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk", "self_ns": 6291},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString", "self_ns": 4041},
+            {"calls": 188, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString", "self_ns": 284166},
+            {"calls": 204, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString", "self_ns": 288516},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData", "self_ns": 12875},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data", "self_ns": 1500},
+            {"calls": 72536, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B", "self_ns": 78458741},
+            {"calls": 237385, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr", "self_ns": 330078765},
+            {"calls": 55672, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I", "self_ns": 62536235},
+            {"calls": 96949, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List", "self_ns": 137956799},
+            {"calls": 65494, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map", "self_ns": 154104237},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData", "self_ns": 21500},
+            {"calls": 91, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1", "self_ns": 1065920},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr", "self_ns": 89791},
+            {"calls": 19, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1", "self_ns": 171584},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList", "self_ns": 73834},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1", "self_ns": 308042},
+            {"calls": 85, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap", "self_ns": 490584},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1", "self_ns": 374708},
+            {"calls": 1140, "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData", "self_ns": 1422758},
+            {"calls": 1020, "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData", "self_ns": 1117008},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant", "self_ns": 3542},
+            {"calls": 1, "head": "PlutusCore.Integer.Integer", "self_ns": 6250},
+            {"calls": 16, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger", "self_ns": 57541},
+            {"calls": 872, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger", "self_ns": 1067082},
+            {"calls": 60, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger", "self_ns": 101624},
+            {"calls": 73, "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons", "self_ns": 319416},
+            {"calls": 339, "head": "PlutusCore.List.PlutusCore.ListInternal.nullList", "self_ns": 1050082},
+            {"calls": 805, "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair", "self_ns": 2757976},
+            {"calls": 1737, "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair", "self_ns": 5578044},
+            {"calls": 4140, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse", "self_ns": 4542964},
+            {"calls": 2075, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1", "self_ns": 9843347},
+            {"calls": 201, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1", "self_ns": 1576669},
+            {"calls": 188, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString", "self_ns": 275837},
+            {"calls": 204, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString", "self_ns": 312158},
+            {"calls": 1140, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData", "self_ns": 1299735},
+            {"calls": 575, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1", "self_ns": 3249476},
+            {"calls": 1020, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData", "self_ns": 1139009},
+            {"calls": 515, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1", "self_ns": 2517757},
+            {"calls": 928, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData", "self_ns": 1033606},
+            {"calls": 469, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1", "self_ns": 12405594},
+            {"calls": 3512, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData", "self_ns": 3688307},
+            {"calls": 1762, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1", "self_ns": 60816251},
+            {"calls": 4112, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3", "self_ns": 17946987},
+            {"calls": 460, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData", "self_ns": 589168},
+            {"calls": 235, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1", "self_ns": 6512370},
+            {"calls": 1484, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData", "self_ns": 1670566},
+            {"calls": 747, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1", "self_ns": 16497509},
+            {"calls": 1828, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData", "self_ns": 1963160},
+            {"calls": 919, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1", "self_ns": 9790134},
+            {"calls": 41940, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction", "self_ns": 39558252},
+            {"calls": 21070, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1", "self_ns": 208796268},
+            {"calls": 16, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger", "self_ns": 37082},
+            {"calls": 479, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1", "self_ns": 2687528},
+            {"calls": 872, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger", "self_ns": 946357},
+            {"calls": 60, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger", "self_ns": 108044},
+            {"calls": 2904, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList", "self_ns": 3146246},
+            {"calls": 1459, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1", "self_ns": 9103887},
+            {"calls": 408, "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList", "self_ns": 537874},
+            {"calls": 211, "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1", "self_ns": 2036124},
+            {"calls": 9120, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList", "self_ns": 8801041},
+            {"calls": 9064, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3", "self_ns": 129084294},
+            {"calls": 2010, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5", "self_ns": 27445895},
+            {"calls": 7437, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7", "self_ns": 36213015},
+            {"calls": 144, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons", "self_ns": 233793},
+            {"calls": 79, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1", "self_ns": 1285380},
+            {"calls": 676, "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList", "self_ns": 775289},
+            {"calls": 5064, "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList", "self_ns": 4889818},
+            {"calls": 1608, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair", "self_ns": 1765133},
+            {"calls": 2546, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1", "self_ns": 11787544},
+            {"calls": 3472, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair", "self_ns": 3545426},
+            {"calls": 100, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin", "self_ns": 181537},
+            {"calls": 55, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin.match_1", "self_ns": 1364511},
+            {"calls": 1092, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData", "self_ns": 1258251},
+            {"calls": 551, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1", "self_ns": 2607852},
+            {"calls": 752, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue", "self_ns": 954283},
+            {"calls": 425, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1", "self_ns": 2477281},
+            {"calls": 88, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains", "self_ns": 161672},
+            {"calls": 660, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData", "self_ns": 741085},
+            {"calls": 335, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1", "self_ns": 1693091},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV", "self_ns": 1208},
+            {"calls": 13, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More", "self_ns": 37498},
+            {"calls": 3, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One", "self_ns": 7709},
+            {"calls": 14798, "head": "PlutusCore.UPLC.Builtins.expectedArgs", "self_ns": 14390713},
+            {"calls": 7499, "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1", "self_ns": 90707748},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame", "self_ns": 1334},
+            {"calls": 9682, "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee", "self_ns": 20770824},
+            {"calls": 19156, "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument", "self_ns": 66183436},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame", "self_ns": 1250},
+            {"calls": 32913, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm", "self_ns": 75431948},
+            {"calls": 13357, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue", "self_ns": 24218961},
+            {"calls": 41742, "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue", "self_ns": 70024539},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State.Error", "self_ns": 1291},
+            {"calls": 97703, "head": "PlutusCore.UPLC.CekMachine.State.Eval", "self_ns": 302551107},
+            {"calls": 141, "head": "PlutusCore.UPLC.CekMachine.State.Halt", "self_ns": 354619},
+            {"calls": 91162, "head": "PlutusCore.UPLC.CekMachine.State.Return", "self_ns": 271222791},
+            {"calls": 14, "head": "PlutusCore.UPLC.CekMachine.applyParams", "self_ns": 3149500},
+            {"calls": 3, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram", "self_ns": 50833},
+            {"calls": 4, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1", "self_ns": 83375},
+            {"calls": 41940, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin", "self_ns": 44115857},
+            {"calls": 69673, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1", "self_ns": 1060629176},
+            {"calls": 2, "head": "PlutusCore.UPLC.CekMachine.initialState", "self_ns": 12292},
+            {"calls": 200707, "head": "PlutusCore.UPLC.CekMachine.runSteps", "self_ns": 1194681782},
+            {"calls": 191252, "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1", "self_ns": 620226248},
+            {"calls": 374984, "head": "PlutusCore.UPLC.CekMachine.step", "self_ns": 346386157},
+            {"calls": 17627, "head": "PlutusCore.UPLC.CekMachine.step.folding", "self_ns": 75964457},
+            {"calls": 21902, "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1", "self_ns": 48496495},
+            {"calls": 18452, "head": "PlutusCore.UPLC.CekMachine.step.match_1", "self_ns": 47603803},
+            {"calls": 4289, "head": "PlutusCore.UPLC.CekMachine.step.match_11", "self_ns": 13363743},
+            {"calls": 90445, "head": "PlutusCore.UPLC.CekMachine.step.match_13", "self_ns": 247461507},
+            {"calls": 187499, "head": "PlutusCore.UPLC.CekMachine.step.match_15", "self_ns": 491042694},
+            {"calls": 96929, "head": "PlutusCore.UPLC.CekMachine.step.match_3", "self_ns": 294011483},
+            {"calls": 39771, "head": "PlutusCore.UPLC.CekMachine.step.match_5", "self_ns": 113615833},
+            {"calls": 4843, "head": "PlutusCore.UPLC.CekMachine.step.match_7", "self_ns": 12736573},
+            {"calls": 4277, "head": "PlutusCore.UPLC.CekMachine.step.match_9", "self_ns": 15843828},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekValue.CekValue", "self_ns": 1375},
+            {"calls": 18492, "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin", "self_ns": 45379718},
+            {"calls": 290575, "head": "PlutusCore.UPLC.CekValue.CekValue.VCon", "self_ns": 449640797},
+            {"calls": 4292, "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr", "self_ns": 9729336},
+            {"calls": 9994, "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay", "self_ns": 23047045},
+            {"calls": 60642, "head": "PlutusCore.UPLC.CekValue.CekValue.VLam", "self_ns": 139647836},
+            {"calls": 1, "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3", "self_ns": 1333},
+            {"calls": 2, "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk", "self_ns": 10209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun", "self_ns": 1416},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.BData", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString", "self_ns": 917},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IData", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString", "self_ns": 12875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData", "self_ns": 916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData", "self_ns": 1541},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const", "self_ns": 1125},
+            {"calls": 2013, "head": "PlutusCore.UPLC.Term.Const.Bool", "self_ns": 7426977},
+            {"calls": 2236, "head": "PlutusCore.UPLC.Term.Const.ByteString", "self_ns": 2913366},
+            {"calls": 191173, "head": "PlutusCore.UPLC.Term.Const.ConstDataList", "self_ns": 289106527},
+            {"calls": 11, "head": "PlutusCore.UPLC.Term.Const.ConstList", "self_ns": 22540},
+            {"calls": 22701, "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList", "self_ns": 34462409},
+            {"calls": 101896, "head": "PlutusCore.UPLC.Term.Const.Data", "self_ns": 127972334},
+            {"calls": 10787, "head": "PlutusCore.UPLC.Term.Const.Integer", "self_ns": 13133253},
+            {"calls": 19367, "head": "PlutusCore.UPLC.Term.Const.Pair", "self_ns": 32726519},
+            {"calls": 2115, "head": "PlutusCore.UPLC.Term.Const.PairData", "self_ns": 3236361},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const.Unit", "self_ns": 1167},
+            {"calls": 4109, "head": "PlutusCore.UPLC.Term.Const.Value", "self_ns": 5069804},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Program", "self_ns": 1750},
+            {"calls": 5, "head": "PlutusCore.UPLC.Term.Program.Program", "self_ns": 14500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term", "self_ns": 1000},
+            {"calls": 532, "head": "PlutusCore.UPLC.Term.Term.Apply", "self_ns": 958420},
+            {"calls": 29, "head": "PlutusCore.UPLC.Term.Term.Builtin", "self_ns": 42915},
+            {"calls": 78, "head": "PlutusCore.UPLC.Term.Term.Case", "self_ns": 138249},
+            {"calls": 17, "head": "PlutusCore.UPLC.Term.Term.Const", "self_ns": 71374},
+            {"calls": 78, "head": "PlutusCore.UPLC.Term.Term.Constr", "self_ns": 135078},
+            {"calls": 83, "head": "PlutusCore.UPLC.Term.Term.Delay", "self_ns": 116953},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term.Error", "self_ns": 917},
+            {"calls": 70, "head": "PlutusCore.UPLC.Term.Term.Force", "self_ns": 100050},
+            {"calls": 199, "head": "PlutusCore.UPLC.Term.Term.Lam", "self_ns": 268321},
+            {"calls": 125, "head": "PlutusCore.UPLC.Term.Term.Var", "self_ns": 110129},
+            {"calls": 2, "head": "PlutusCore.UPLC.Term.Version.Version", "self_ns": 9000},
+            {"calls": 1, "head": "PlutusCore.Value.ValueRep", "self_ns": 15500},
+            {"calls": 838, "head": "PlutusCore.Value.ascendingFrom", "self_ns": 1099281},
+            {"calls": 426, "head": "PlutusCore.Value.ascendingFrom.match_1", "self_ns": 1512001},
+            {"calls": 60, "head": "PlutusCore.Value.containedInner", "self_ns": 2309415},
+            {"calls": 99, "head": "PlutusCore.Value.containedOuter", "self_ns": 1859574},
+            {"calls": 282, "head": "PlutusCore.Value.deleteCoin", "self_ns": 4546960},
+            {"calls": 6, "head": "PlutusCore.Value.deleteCoin.match_1", "self_ns": 144167},
+            {"calls": 154, "head": "PlutusCore.Value.hasNegativeAmount", "self_ns": 2289535},
+            {"calls": 15, "head": "PlutusCore.Value.innerDelete", "self_ns": 2785333},
+            {"calls": 144, "head": "PlutusCore.Value.innerHasNegative", "self_ns": 2367632},
+            {"calls": 604, "head": "PlutusCore.Value.innerHasNegative.match_1", "self_ns": 2223870},
+            {"calls": 2450, "head": "PlutusCore.Value.innerToData", "self_ns": 8620832},
+            {"calls": 100, "head": "PlutusCore.Value.insertCoin", "self_ns": 212461},
+            {"calls": 12, "head": "PlutusCore.Value.lookupCoin", "self_ns": 3206583},
+            {"calls": 9, "head": "PlutusCore.Value.lookupInner", "self_ns": 3020751},
+            {"calls": 1, "head": "PlutusCore.Value.maxKeyLen", "self_ns": 8833},
+            {"calls": 934, "head": "PlutusCore.Value.outerToData", "self_ns": 5933856},
+            {"calls": 1024, "head": "PlutusCore.Value.totalSize.match_1", "self_ns": 3439409},
+            {"calls": 1092, "head": "PlutusCore.Value.unValueData", "self_ns": 1285297},
+            {"calls": 551, "head": "PlutusCore.Value.unValueData.match_1", "self_ns": 6994922},
+            {"calls": 1291, "head": "PlutusCore.Value.unValueDataCurrencies", "self_ns": 45858115},
+            {"calls": 352, "head": "PlutusCore.Value.unValueDataCurrencies.match_1", "self_ns": 7785333},
+            {"calls": 352, "head": "PlutusCore.Value.unValueDataCurrencies.match_3", "self_ns": 8762971},
+            {"calls": 512, "head": "PlutusCore.Value.unValueDataTokens", "self_ns": 14632621},
+            {"calls": 486, "head": "PlutusCore.Value.unValueDataTokens.match_1", "self_ns": 10750956},
+            {"calls": 873, "head": "PlutusCore.Value.unValueDataTokens.match_3", "self_ns": 15956947},
+            {"calls": 13, "head": "PlutusCore.Value.unionInner", "self_ns": 366168},
+            {"calls": 2458, "head": "PlutusCore.Value.unionInner.match_1", "self_ns": 50598922},
+            {"calls": 11, "head": "PlutusCore.Value.unionInner.match_3", "self_ns": 609833},
+            {"calls": 386, "head": "PlutusCore.Value.unionOuter", "self_ns": 1997376},
+            {"calls": 3295, "head": "PlutusCore.Value.unionOuter.match_1", "self_ns": 77071999},
+            {"calls": 8, "head": "PlutusCore.Value.unionOuter.match_3", "self_ns": 179917},
+            {"calls": 303, "head": "PlutusCore.Value.unionOuter.match_5", "self_ns": 1547634},
+            {"calls": 752, "head": "PlutusCore.Value.unionValue", "self_ns": 885743},
+            {"calls": 838, "head": "PlutusCore.Value.validKey", "self_ns": 981318},
+            {"calls": 390, "head": "PlutusCore.Value.validQuantity", "self_ns": 519330},
+            {"calls": 88, "head": "PlutusCore.Value.valueContains", "self_ns": 127288},
+            {"calls": 660, "head": "PlutusCore.Value.valueData", "self_ns": 726212},
+            {"calls": 2, "head": "Pow.pow", "self_ns": 49541},
+            {"calls": 10, "head": "Prod", "self_ns": 32086},
+            {"calls": 1389, "head": "Prod.fst", "self_ns": 7045746},
+            {"calls": 31056, "head": "Prod.mk", "self_ns": 73418028},
+            {"calls": 1756, "head": "Prod.snd", "self_ns": 15522234},
+            {"calls": 1, "head": "String", "self_ns": 1292},
+            {"calls": 1, "head": "String.instLT", "self_ns": 2833},
+            {"calls": 420, "head": "String.length", "self_ns": 1511919},
+            {"calls": 2, "head": "WSC.globalInputs1600", "self_ns": 17249},
+            {"calls": 14, "head": "_normalizer", "self_ns": 26795082},
+            {"calls": 2, "head": "instBEqOfDecidableEq", "self_ns": 19708},
+            {"calls": 2, "head": "instHAdd", "self_ns": 17708},
+            {"calls": 3, "head": "instHMul", "self_ns": 17876},
+            {"calls": 2, "head": "instHPow", "self_ns": 19291},
+            {"calls": 1, "head": "instLENat", "self_ns": 3458},
+            {"calls": 1, "head": "instLTNat", "self_ns": 4334},
+            {"calls": 1, "head": "instNatPowNat", "self_ns": 3625},
+            {"calls": 12, "head": "instOfNat", "self_ns": 25667},
+            {"calls": 9, "head": "instOfNatNat", "self_ns": 23708},
+            {"calls": 2, "head": "instPowNat", "self_ns": 14750},
+            {"calls": 4897, "head": "ite", "self_ns": 7022870},
+            {"calls": 1, "head": "programmableLogicGlobal1600", "self_ns": 841542}
           ],
           "imbalances": 0,
           "schema": 1,
@@ -3034,2891 +726,583 @@
           },
           "hashcons": 15595053,
           "heads": [
-            {
-              "calls": 1423,
-              "head": "Add.add",
-              "self_ns": 9452403
-            },
-            {
-              "calls": 8,
-              "head": "And",
-              "self_ns": 75789
-            },
-            {
-              "calls": 9841,
-              "head": "BEq.beq",
-              "self_ns": 205471933
-            },
-            {
-              "calls": 8093,
-              "head": "Blaster.decide'",
-              "self_ns": 24609419
-            },
-            {
-              "calls": 79680,
-              "head": "Blaster.dite'",
-              "self_ns": 676621788
-            },
-            {
-              "calls": 1,
-              "head": "Bool",
-              "self_ns": 2250
-            },
-            {
-              "calls": 323,
-              "head": "Bool.and",
-              "self_ns": 1671115
-            },
-            {
-              "calls": 1,
-              "head": "Bool.false",
-              "self_ns": 1125
-            },
-            {
-              "calls": 957,
-              "head": "Bool.or",
-              "self_ns": 5106386
-            },
-            {
-              "calls": 1,
-              "head": "Bool.true",
-              "self_ns": 1375
-            },
-            {
-              "calls": 239,
-              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
-              "self_ns": 1685207
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
-              "self_ns": 3709
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
-              "self_ns": 2833
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
-              "self_ns": 18460
-            },
-            {
-              "calls": 15,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1",
-              "self_ns": 325960
-            },
-            {
-              "calls": 328,
-              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
-              "self_ns": 386270
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.IsData.Class.toTerm",
-              "self_ns": 32375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.Address",
-              "self_ns": 1708
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
-              "self_ns": 16000
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
-              "self_ns": 16958
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
-              "self_ns": 2625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
-              "self_ns": 4000
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
-              "self_ns": 17750
-            },
-            {
-              "calls": 43805,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 161033090
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 159625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.Credential",
-              "self_ns": 1292
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
-              "self_ns": 7291
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
-              "self_ns": 11042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
-              "self_ns": 10916
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
-              "self_ns": 1292
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
-              "self_ns": 6541
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
-              "self_ns": 9584
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
-              "self_ns": 2709
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
-              "self_ns": 2375
-            },
-            {
-              "calls": 46,
-              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
-              "self_ns": 1114616
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
-              "self_ns": 162292
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Datum",
-              "self_ns": 8333
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
-              "self_ns": 5500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
-              "self_ns": 6000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
-              "self_ns": 5458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
-              "self_ns": 3583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
-              "self_ns": 9375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.Value",
-              "self_ns": 9084
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
-              "self_ns": 3041
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
-              "self_ns": 12875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
-              "self_ns": 3459
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
-              "self_ns": 6917
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
-              "self_ns": 16624
-            },
-            {
-              "calls": 87797,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
-              "self_ns": 182130939
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
-              "self_ns": 167417
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
-              "self_ns": 18374
-            },
-            {
-              "calls": 70225,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
-              "self_ns": 2247854218
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
-              "self_ns": 271082
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
-              "self_ns": 1334
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
-              "self_ns": 7208
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
-              "self_ns": 7500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut",
-              "self_ns": 1291
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
-              "self_ns": 16250
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
-              "self_ns": 16292
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
-              "self_ns": 17583
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
-              "self_ns": 16209
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
-              "self_ns": 2584
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
-              "self_ns": 2958
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
-              "self_ns": 170499
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap",
-              "self_ns": 7125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.MintValue",
-              "self_ns": 13458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap",
-              "self_ns": 9083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext",
-              "self_ns": 1125
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer",
-              "self_ns": 14375
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo",
-              "self_ns": 20709
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo",
-              "self_ns": 11042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo",
-              "self_ns": 1250
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript",
-              "self_ns": 9625
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript",
-              "self_ns": 9459
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript",
-              "self_ns": 8541
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript",
-              "self_ns": 10375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript",
-              "self_ns": 12167
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript",
-              "self_ns": 6833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose",
-              "self_ns": 1750
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying",
-              "self_ns": 9292
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting",
-              "self_ns": 20417
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing",
-              "self_ns": 8584
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding",
-              "self_ns": 6375
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending",
-              "self_ns": 6792
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting",
-              "self_ns": 7167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo",
-              "self_ns": 1375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef",
-              "self_ns": 14500
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved",
-              "self_ns": 10667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo",
-              "self_ns": 1500
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount",
-              "self_ns": 15666
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData",
-              "self_ns": 13208
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee",
-              "self_ns": 20500
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId",
-              "self_ns": 16875
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs",
-              "self_ns": 12584
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint",
-              "self_ns": 17417
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs",
-              "self_ns": 14791
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures",
-              "self_ns": 17541
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers",
-              "self_ns": 13083
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs",
-              "self_ns": 29375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories",
-              "self_ns": 17625
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation",
-              "self_ns": 13667
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts",
-              "self_ns": 13208
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange",
-              "self_ns": 16542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes",
-              "self_ns": 12542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl",
-              "self_ns": 21125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.VoterMap",
-              "self_ns": 8791
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData",
-              "self_ns": 16208
-            },
-            {
-              "calls": 26,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19",
-              "self_ns": 2965958
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1",
-              "self_ns": 179167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap",
-              "self_ns": 6292
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure",
-              "self_ns": 6542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert",
-              "self_ns": 4208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo",
-              "self_ns": 2375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap",
-              "self_ns": 3667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext",
-              "self_ns": 3500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo",
-              "self_ns": 3416
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose",
-              "self_ns": 3375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo",
-              "self_ns": 3209
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo",
-              "self_ns": 2666
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap",
-              "self_ns": 2958
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1",
-              "self_ns": 246875
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1",
-              "self_ns": 451539
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs",
-              "self_ns": 23541
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1",
-              "self_ns": 183666
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData",
-              "self_ns": 14793
-            },
-            {
-              "calls": 171432,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14",
-              "self_ns": 260920365
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1",
-              "self_ns": 293374
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData",
-              "self_ns": 23249
-            },
-            {
-              "calls": 87801,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14",
-              "self_ns": 172054718
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1",
-              "self_ns": 156333
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData",
-              "self_ns": 13791
-            },
-            {
-              "calls": 87935,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19",
-              "self_ns": 184508528
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1",
-              "self_ns": 252208
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData",
-              "self_ns": 19166
-            },
-            {
-              "calls": 87913,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14",
-              "self_ns": 173998726
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1",
-              "self_ns": 228583
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData",
-              "self_ns": 19959
-            },
-            {
-              "calls": 87807,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19",
-              "self_ns": 174383131
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1",
-              "self_ns": 181166
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId",
-              "self_ns": 1959
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx",
-              "self_ns": 16542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId",
-              "self_ns": 17292
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure",
-              "self_ns": 5042
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit",
-              "self_ns": 19542
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction",
-              "self_ns": 17292
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr",
-              "self_ns": 18875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Voter",
-              "self_ns": 1709
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter",
-              "self_ns": 7792
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter",
-              "self_ns": 9167
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter",
-              "self_ns": 7083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Withdrawals",
-              "self_ns": 10166
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId",
-              "self_ns": 8583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers",
-              "self_ns": 4375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure",
-              "self_ns": 4250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataVote",
-              "self_ns": 5917
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter",
-              "self_ns": 3667
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1",
-              "self_ns": 115291
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1",
-              "self_ns": 220458
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData",
-              "self_ns": 15874
-            },
-            {
-              "calls": 161,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19",
-              "self_ns": 3620582
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1",
-              "self_ns": 160833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.TxId",
-              "self_ns": 6625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef",
-              "self_ns": 1500
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId",
-              "self_ns": 20083
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx",
-              "self_ns": 15625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId",
-              "self_ns": 4000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef",
-              "self_ns": 2750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential",
-              "self_ns": 10084
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep",
-              "self_ns": 1208
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep",
-              "self_ns": 6750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRepCredential",
-              "self_ns": 5667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee",
-              "self_ns": 9417
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake",
-              "self_ns": 6875
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote",
-              "self_ns": 8167
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote",
-              "self_ns": 9916
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential",
-              "self_ns": 6625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert",
-              "self_ns": 2375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee",
-              "self_ns": 11500
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking",
-              "self_ns": 9917
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister",
-              "self_ns": 11209
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire",
-              "self_ns": 18250
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep",
-              "self_ns": 13875
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg",
-              "self_ns": 11250
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking",
-              "self_ns": 12333
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee",
-              "self_ns": 6125
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep",
-              "self_ns": 8542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking",
-              "self_ns": 9292
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep",
-              "self_ns": 6708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep",
-              "self_ns": 3208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee",
-              "self_ns": 2750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert",
-              "self_ns": 4500
-            },
-            {
-              "calls": 14,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1",
-              "self_ns": 322209
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1",
-              "self_ns": 284169
-            },
-            {
-              "calls": 16,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1",
-              "self_ns": 1468039
-            },
-            {
-              "calls": 6737,
-              "head": "Decidable.decide",
-              "self_ns": 8262470
-            },
-            {
-              "calls": 31538,
-              "head": "Eq",
-              "self_ns": 283926346
-            },
-            {
-              "calls": 13,
-              "head": "Function.comp",
-              "self_ns": 84042
-            },
-            {
-              "calls": 1429,
-              "head": "HAdd.hAdd",
-              "self_ns": 9605845
-            },
-            {
-              "calls": 2438,
-              "head": "HMul.hMul",
-              "self_ns": 12279735
-            },
-            {
-              "calls": 2,
-              "head": "HPow.hPow",
-              "self_ns": 56043
-            },
-            {
-              "calls": 2,
-              "head": "Inhabited.default",
-              "self_ns": 29667
-            },
-            {
-              "calls": 1,
-              "head": "Int",
-              "self_ns": 3458
-            },
-            {
-              "calls": 4267,
-              "head": "Int.add",
-              "self_ns": 14852346
-            },
-            {
-              "calls": 1,
-              "head": "Int.instAdd",
-              "self_ns": 4292
-            },
-            {
-              "calls": 1,
-              "head": "Int.instDecidableEq",
-              "self_ns": 5792
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLEInt",
-              "self_ns": 5875
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLTInt",
-              "self_ns": 7208
-            },
-            {
-              "calls": 1,
-              "head": "Int.instMul",
-              "self_ns": 2833
-            },
-            {
-              "calls": 7095,
-              "head": "Int.mul",
-              "self_ns": 18719195
-            },
-            {
-              "calls": 2838,
-              "head": "Int.natAbs",
-              "self_ns": 3295610
-            },
-            {
-              "calls": 1421,
-              "head": "Int.neg",
-              "self_ns": 3485785
-            },
-            {
-              "calls": 1424,
-              "head": "Int.neg.match_1",
-              "self_ns": 49045480
-            },
-            {
-              "calls": 7,
-              "head": "Int.negOfNat.match_1",
-              "self_ns": 119584
-            },
-            {
-              "calls": 5,
-              "head": "Int.negSucc",
-              "self_ns": 17292
-            },
-            {
-              "calls": 15,
-              "head": "Int.ofNat",
-              "self_ns": 41126
-            },
-            {
-              "calls": 3,
-              "head": "Int.pow",
-              "self_ns": 12667
-            },
-            {
-              "calls": 3675,
-              "head": "Int.toNat",
-              "self_ns": 10521160
-            },
-            {
-              "calls": 3392,
-              "head": "LE.le",
-              "self_ns": 16614128
-            },
-            {
-              "calls": 16414,
-              "head": "LT.lt",
-              "self_ns": 75880863
-            },
-            {
-              "calls": 4310,
-              "head": "List",
-              "self_ns": 7697385
-            },
-            {
-              "calls": 6129244,
-              "head": "List.cons",
-              "self_ns": 12609388444
-            },
-            {
-              "calls": 847,
-              "head": "List.drop",
-              "self_ns": 25675001
-            },
-            {
-              "calls": 158227,
-              "head": "List.get?Internal",
-              "self_ns": 717875624
-            },
-            {
-              "calls": 12778,
-              "head": "List.getLast?.match_1",
-              "self_ns": 271794235
-            },
-            {
-              "calls": 8487,
-              "head": "List.isEmpty",
-              "self_ns": 24956278
-            },
-            {
-              "calls": 20231,
-              "head": "List.nil",
-              "self_ns": 33841199
-            },
-            {
-              "calls": 20211,
-              "head": "List.reverse",
-              "self_ns": 60710864
-            },
-            {
-              "calls": 20211,
-              "head": "List.reverseAux",
-              "self_ns": 116902808
-            },
-            {
-              "calls": 20,
-              "head": "List.take.match_1",
-              "self_ns": 470332
-            },
-            {
-              "calls": 1421,
-              "head": "Mul.mul",
-              "self_ns": 9589607
-            },
-            {
-              "calls": 1,
-              "head": "Nat",
-              "self_ns": 39292
-            },
-            {
-              "calls": 1449,
-              "head": "Nat.add",
-              "self_ns": 5950771
-            },
-            {
-              "calls": 12,
-              "head": "Nat.add.match_1",
-              "self_ns": 294333
-            },
-            {
-              "calls": 2,
-              "head": "Nat.beq",
-              "self_ns": 6000
-            },
-            {
-              "calls": 14,
-              "head": "Nat.beq.match_1",
-              "self_ns": 314207
-            },
-            {
-              "calls": 2,
-              "head": "Nat.ble",
-              "self_ns": 7000
-            },
-            {
-              "calls": 4,
-              "head": "Nat.mul",
-              "self_ns": 18751
-            },
-            {
-              "calls": 12,
-              "head": "Nat.mul.match_1",
-              "self_ns": 234873
-            },
-            {
-              "calls": 4,
-              "head": "Nat.pow",
-              "self_ns": 16708
-            },
-            {
-              "calls": 6,
-              "head": "Nat.pow.match_1",
-              "self_ns": 113167
-            },
-            {
-              "calls": 2,
-              "head": "Nat.pred",
-              "self_ns": 7292
-            },
-            {
-              "calls": 1451,
-              "head": "Nat.sub",
-              "self_ns": 9489151
-            },
-            {
-              "calls": 1432,
-              "head": "Nat.succ",
-              "self_ns": 2303913
-            },
-            {
-              "calls": 1,
-              "head": "Nat.zero",
-              "self_ns": 2167
-            },
-            {
-              "calls": 2,
-              "head": "NatPow.pow",
-              "self_ns": 41959
-            },
-            {
-              "calls": 4814,
-              "head": "Not",
-              "self_ns": 13830658
-            },
-            {
-              "calls": 21,
-              "head": "OfNat.ofNat",
-              "self_ns": 274791
-            },
-            {
-              "calls": 13731,
-              "head": "Option",
-              "self_ns": 22375116
-            },
-            {
-              "calls": 39712,
-              "head": "Option.getD.match_1",
-              "self_ns": 881783674
-            },
-            {
-              "calls": 6343,
-              "head": "Option.map",
-              "self_ns": 25904409
-            },
-            {
-              "calls": 11821,
-              "head": "Option.none",
-              "self_ns": 21169228
-            },
-            {
-              "calls": 148453,
-              "head": "Option.some",
-              "self_ns": 675311327
-            },
-            {
-              "calls": 506,
-              "head": "Or",
-              "self_ns": 3452960
-            },
-            {
-              "calls": 9189,
-              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
-              "self_ns": 35962910
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
-              "self_ns": 3791
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
-              "self_ns": 1167
-            },
-            {
-              "calls": 25749,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data",
-              "self_ns": 23049722
-            },
-            {
-              "calls": 6262,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length",
-              "self_ns": 10625745
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
-              "self_ns": 5834
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString",
-              "self_ns": 4375
-            },
-            {
-              "calls": 868,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
-              "self_ns": 1162623
-            },
-            {
-              "calls": 924,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString",
-              "self_ns": 1294340
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
-              "self_ns": 4542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
-              "self_ns": 1417
-            },
-            {
-              "calls": 356758,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
-              "self_ns": 390312613
-            },
-            {
-              "calls": 1193823,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
-              "self_ns": 1654241685
-            },
-            {
-              "calls": 263892,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
-              "self_ns": 289054779
-            },
-            {
-              "calls": 448023,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
-              "self_ns": 671140329
-            },
-            {
-              "calls": 304364,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
-              "self_ns": 1273883883
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
-              "self_ns": 17375
-            },
-            {
-              "calls": 383,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
-              "self_ns": 2895441
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
-              "self_ns": 103291
-            },
-            {
-              "calls": 19,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
-              "self_ns": 178542
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
-              "self_ns": 88250
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
-              "self_ns": 321167
-            },
-            {
-              "calls": 377,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
-              "self_ns": 2257922
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
-              "self_ns": 409459
-            },
-            {
-              "calls": 5140,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
-              "self_ns": 6313223
-            },
-            {
-              "calls": 6100,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
-              "self_ns": 6505503
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
-              "self_ns": 3792
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Integer.Integer",
-              "self_ns": 6000
-            },
-            {
-              "calls": 220,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger",
-              "self_ns": 531377
-            },
-            {
-              "calls": 3924,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
-              "self_ns": 4945669
-            },
-            {
-              "calls": 516,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
-              "self_ns": 619667
-            },
-            {
-              "calls": 375,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
-              "self_ns": 1512326
-            },
-            {
-              "calls": 1185,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.nullList",
-              "self_ns": 3824747
-            },
-            {
-              "calls": 3441,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
-              "self_ns": 12571214
-            },
-            {
-              "calls": 8229,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
-              "self_ns": 27840729
-            },
-            {
-              "calls": 18376,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
-              "self_ns": 20415295
-            },
-            {
-              "calls": 9193,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
-              "self_ns": 43244661
-            },
-            {
-              "calls": 901,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
-              "self_ns": 5495621
-            },
-            {
-              "calls": 868,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
-              "self_ns": 1126667
-            },
-            {
-              "calls": 924,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString",
-              "self_ns": 1359418
-            },
-            {
-              "calls": 5140,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
-              "self_ns": 6497898
-            },
-            {
-              "calls": 2575,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
-              "self_ns": 13697084
-            },
-            {
-              "calls": 6100,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
-              "self_ns": 6791777
-            },
-            {
-              "calls": 3055,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
-              "self_ns": 14346627
-            },
-            {
-              "calls": 4004,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
-              "self_ns": 4925630
-            },
-            {
-              "calls": 2007,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1",
-              "self_ns": 1076600875
-            },
-            {
-              "calls": 16272,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
-              "self_ns": 18775092
-            },
-            {
-              "calls": 8142,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
-              "self_ns": 293880095
-            },
-            {
-              "calls": 19316,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
-              "self_ns": 83751799
-            },
-            {
-              "calls": 1908,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
-              "self_ns": 2613560
-            },
-            {
-              "calls": 959,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1",
-              "self_ns": 29129334
-            },
-            {
-              "calls": 7056,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
-              "self_ns": 8354742
-            },
-            {
-              "calls": 3533,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1",
-              "self_ns": 85007928
-            },
-            {
-              "calls": 9380,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
-              "self_ns": 10346805
-            },
-            {
-              "calls": 4695,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1",
-              "self_ns": 42943222
-            },
-            {
-              "calls": 197156,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
-              "self_ns": 196442419
-            },
-            {
-              "calls": 98678,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
-              "self_ns": 982562242
-            },
-            {
-              "calls": 220,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger",
-              "self_ns": 292796
-            },
-            {
-              "calls": 2335,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
-              "self_ns": 12577589
-            },
-            {
-              "calls": 3924,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
-              "self_ns": 5382344
-            },
-            {
-              "calls": 516,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
-              "self_ns": 633292
-            },
-            {
-              "calls": 14604,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
-              "self_ns": 15929983
-            },
-            {
-              "calls": 7309,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
-              "self_ns": 44510048
-            },
-            {
-              "calls": 1672,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList",
-              "self_ns": 2304766
-            },
-            {
-              "calls": 843,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1",
-              "self_ns": 6535918
-            },
-            {
-              "calls": 41740,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
-              "self_ns": 46734008
-            },
-            {
-              "calls": 41596,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3",
-              "self_ns": 676148171
-            },
-            {
-              "calls": 8822,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5",
-              "self_ns": 124513999
-            },
-            {
-              "calls": 32567,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7",
-              "self_ns": 160096675
-            },
-            {
-              "calls": 748,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
-              "self_ns": 1072743
-            },
-            {
-              "calls": 381,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
-              "self_ns": 3308161
-            },
-            {
-              "calls": 2368,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList",
-              "self_ns": 3012100
-            },
-            {
-              "calls": 21012,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
-              "self_ns": 21299844
-            },
-            {
-              "calls": 6880,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
-              "self_ns": 8303861
-            },
-            {
-              "calls": 11674,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
-              "self_ns": 55373603
-            },
-            {
-              "calls": 16456,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
-              "self_ns": 17027887
-            },
-            {
-              "calls": 708,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin",
-              "self_ns": 1118702
-            },
-            {
-              "calls": 359,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin.match_1",
-              "self_ns": 3873931
-            },
-            {
-              "calls": 6388,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData",
-              "self_ns": 7177639
-            },
-            {
-              "calls": 3199,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1",
-              "self_ns": 14496896
-            },
-            {
-              "calls": 5004,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue",
-              "self_ns": 6170206
-            },
-            {
-              "calls": 2799,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1",
-              "self_ns": 14818314
-            },
-            {
-              "calls": 584,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains",
-              "self_ns": 816852
-            },
-            {
-              "calls": 4304,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData",
-              "self_ns": 4934006
-            },
-            {
-              "calls": 2157,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1",
-              "self_ns": 9993215
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
-              "self_ns": 1458
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
-              "self_ns": 34210
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
-              "self_ns": 8125
-            },
-            {
-              "calls": 73066,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
-              "self_ns": 72339231
-            },
-            {
-              "calls": 36633,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
-              "self_ns": 429846536
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame",
-              "self_ns": 1333
-            },
-            {
-              "calls": 48710,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
-              "self_ns": 107254531
-            },
-            {
-              "calls": 92730,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
-              "self_ns": 301241164
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
-              "self_ns": 1417
-            },
-            {
-              "calls": 159013,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
-              "self_ns": 380614629
-            },
-            {
-              "calls": 62445,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
-              "self_ns": 118760626
-            },
-            {
-              "calls": 185712,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
-              "self_ns": 321954085
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State",
-              "self_ns": 1917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State.Error",
-              "self_ns": 1500
-            },
-            {
-              "calls": 456005,
-              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
-              "self_ns": 1459695573
-            },
-            {
-              "calls": 769,
-              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
-              "self_ns": 1963501
-            },
-            {
-              "calls": 425818,
-              "head": "PlutusCore.UPLC.CekMachine.State.Return",
-              "self_ns": 1139184791
-            },
-            {
-              "calls": 14,
-              "head": "PlutusCore.UPLC.CekMachine.applyParams",
-              "self_ns": 3143831
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
-              "self_ns": 52583
-            },
-            {
-              "calls": 4,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
-              "self_ns": 91917
-            },
-            {
-              "calls": 197156,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
-              "self_ns": 211079189
-            },
-            {
-              "calls": 325885,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
-              "self_ns": 6012800433
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.CekMachine.initialState",
-              "self_ns": 13334
-            },
-            {
-              "calls": 931425,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps",
-              "self_ns": 5678339290
-            },
-            {
-              "calls": 889722,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
-              "self_ns": 2962339174
-            },
-            {
-              "calls": 1749864,
-              "head": "PlutusCore.UPLC.CekMachine.step",
-              "self_ns": 1644858360
-            },
-            {
-              "calls": 82517,
-              "head": "PlutusCore.UPLC.CekMachine.step.folding",
-              "self_ns": 341010248
-            },
-            {
-              "calls": 102594,
-              "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1",
-              "self_ns": 227051077
-            },
-            {
-              "calls": 86832,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_1",
-              "self_ns": 230300220
-            },
-            {
-              "calls": 20091,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_11",
-              "self_ns": 63372142
-            },
-            {
-              "calls": 421499,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_13",
-              "self_ns": 1175669950
-            },
-            {
-              "calls": 874939,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_15",
-              "self_ns": 2290179145
-            },
-            {
-              "calls": 452687,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
-              "self_ns": 1411977306
-            },
-            {
-              "calls": 186001,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_5",
-              "self_ns": 532532533
-            },
-            {
-              "calls": 22171,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_7",
-              "self_ns": 58709001
-            },
-            {
-              "calls": 20079,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_9",
-              "self_ns": 76774474
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekValue.CekValue",
-              "self_ns": 1500
-            },
-            {
-              "calls": 88632,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
-              "self_ns": 227531853
-            },
-            {
-              "calls": 1293467,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
-              "self_ns": 2065230118
-            },
-            {
-              "calls": 20214,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
-              "self_ns": 47077760
-            },
-            {
-              "calls": 46346,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
-              "self_ns": 111977957
-            },
-            {
-              "calls": 267852,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
-              "self_ns": 641436541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3",
-              "self_ns": 1333
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
-              "self_ns": 9916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun",
-              "self_ns": 1583
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
-              "self_ns": 1459
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
-              "self_ns": 4083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
-              "self_ns": 4416
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
-              "self_ns": 4958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
-              "self_ns": 1417
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
-              "self_ns": 2291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
-              "self_ns": 4458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
-              "self_ns": 1583
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
-              "self_ns": 4375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
-              "self_ns": 1416
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
-              "self_ns": 1792
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
-              "self_ns": 4584
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
-              "self_ns": 1417
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
-              "self_ns": 16334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
-              "self_ns": 1459
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
-              "self_ns": 1416
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
-              "self_ns": 1708
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
-              "self_ns": 2000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
-              "self_ns": 1459
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
-              "self_ns": 1916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue",
-              "self_ns": 916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
-              "self_ns": 4375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
-              "self_ns": 1417
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
-              "self_ns": 1750
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
-              "self_ns": 1834
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
-              "self_ns": 1750
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
-              "self_ns": 1584
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData",
-              "self_ns": 917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
-              "self_ns": 4416
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
-              "self_ns": 1583
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const",
-              "self_ns": 1250
-            },
-            {
-              "calls": 9063,
-              "head": "PlutusCore.UPLC.Term.Const.Bool",
-              "self_ns": 40338156
-            },
-            {
-              "calls": 12054,
-              "head": "PlutusCore.UPLC.Term.Const.ByteString",
-              "self_ns": 14552509
-            },
-            {
-              "calls": 833727,
-              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
-              "self_ns": 1312638315
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.UPLC.Term.Const.ConstList",
-              "self_ns": 18001
-            },
-            {
-              "calls": 110941,
-              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
-              "self_ns": 175522754
-            },
-            {
-              "calls": 443430,
-              "head": "PlutusCore.UPLC.Term.Const.Data",
-              "self_ns": 579081635
-            },
-            {
-              "calls": 46273,
-              "head": "PlutusCore.UPLC.Term.Const.Integer",
-              "self_ns": 62779034
-            },
-            {
-              "calls": 84317,
-              "head": "PlutusCore.UPLC.Term.Const.Pair",
-              "self_ns": 143512014
-            },
-            {
-              "calls": 9909,
-              "head": "PlutusCore.UPLC.Term.Const.PairData",
-              "self_ns": 15774708
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const.Unit",
-              "self_ns": 1000
-            },
-            {
-              "calls": 28981,
-              "head": "PlutusCore.UPLC.Term.Const.Value",
-              "self_ns": 35698970
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Program",
-              "self_ns": 1583
-            },
-            {
-              "calls": 5,
-              "head": "PlutusCore.UPLC.Term.Program.Program",
-              "self_ns": 14417
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term",
-              "self_ns": 1000
-            },
-            {
-              "calls": 532,
-              "head": "PlutusCore.UPLC.Term.Term.Apply",
-              "self_ns": 899487
-            },
-            {
-              "calls": 29,
-              "head": "PlutusCore.UPLC.Term.Term.Builtin",
-              "self_ns": 43668
-            },
-            {
-              "calls": 78,
-              "head": "PlutusCore.UPLC.Term.Term.Case",
-              "self_ns": 137992
-            },
-            {
-              "calls": 17,
-              "head": "PlutusCore.UPLC.Term.Term.Const",
-              "self_ns": 62584
-            },
-            {
-              "calls": 78,
-              "head": "PlutusCore.UPLC.Term.Term.Constr",
-              "self_ns": 133673
-            },
-            {
-              "calls": 83,
-              "head": "PlutusCore.UPLC.Term.Term.Delay",
-              "self_ns": 119121
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term.Error",
-              "self_ns": 1042
-            },
-            {
-              "calls": 70,
-              "head": "PlutusCore.UPLC.Term.Term.Force",
-              "self_ns": 98843
-            },
-            {
-              "calls": 199,
-              "head": "PlutusCore.UPLC.Term.Term.Lam",
-              "self_ns": 251750
-            },
-            {
-              "calls": 125,
-              "head": "PlutusCore.UPLC.Term.Term.Var",
-              "self_ns": 107041
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.Term.Version.Version",
-              "self_ns": 8584
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Value.ValueRep",
-              "self_ns": 10958
-            },
-            {
-              "calls": 6262,
-              "head": "PlutusCore.Value.ascendingFrom",
-              "self_ns": 11352253
-            },
-            {
-              "calls": 3138,
-              "head": "PlutusCore.Value.ascendingFrom.match_1",
-              "self_ns": 10235515
-            },
-            {
-              "calls": 322,
-              "head": "PlutusCore.Value.containedInner",
-              "self_ns": 3679546
-            },
-            {
-              "calls": 651,
-              "head": "PlutusCore.Value.containedOuter",
-              "self_ns": 4159705
-            },
-            {
-              "calls": 2186,
-              "head": "PlutusCore.Value.deleteCoin",
-              "self_ns": 12036476
-            },
-            {
-              "calls": 6,
-              "head": "PlutusCore.Value.deleteCoin.match_1",
-              "self_ns": 184167
-            },
-            {
-              "calls": 1024,
-              "head": "PlutusCore.Value.hasNegativeAmount",
-              "self_ns": 5515526
-            },
-            {
-              "calls": 15,
-              "head": "PlutusCore.Value.innerDelete",
-              "self_ns": 2742499
-            },
-            {
-              "calls": 958,
-              "head": "PlutusCore.Value.innerHasNegative",
-              "self_ns": 5278647
-            },
-            {
-              "calls": 5374,
-              "head": "PlutusCore.Value.innerHasNegative.match_1",
-              "self_ns": 15730120
-            },
-            {
-              "calls": 24004,
-              "head": "PlutusCore.Value.innerToData",
-              "self_ns": 62015762
-            },
-            {
-              "calls": 708,
-              "head": "PlutusCore.Value.insertCoin",
-              "self_ns": 1199601
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.Value.lookupCoin",
-              "self_ns": 3075792
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.Value.lookupInner",
-              "self_ns": 2976541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Value.maxKeyLen",
-              "self_ns": 8917
-            },
-            {
-              "calls": 7752,
-              "head": "PlutusCore.Value.outerToData",
-              "self_ns": 31006415
-            },
-            {
-              "calls": 7976,
-              "head": "PlutusCore.Value.totalSize.match_1",
-              "self_ns": 27959459
-            },
-            {
-              "calls": 6388,
-              "head": "PlutusCore.Value.unValueData",
-              "self_ns": 7355674
-            },
-            {
-              "calls": 3199,
-              "head": "PlutusCore.Value.unValueData.match_1",
-              "self_ns": 36399394
-            },
-            {
-              "calls": 8135,
-              "head": "PlutusCore.Value.unValueDataCurrencies",
-              "self_ns": 70109801
-            },
-            {
-              "calls": 2616,
-              "head": "PlutusCore.Value.unValueDataCurrencies.match_1",
-              "self_ns": 62670240
-            },
-            {
-              "calls": 2616,
-              "head": "PlutusCore.Value.unValueDataCurrencies.match_3",
-              "self_ns": 73610921
-            },
-            {
-              "calls": 3736,
-              "head": "PlutusCore.Value.unValueDataTokens",
-              "self_ns": 27864978
-            },
-            {
-              "calls": 3458,
-              "head": "PlutusCore.Value.unValueDataTokens.match_1",
-              "self_ns": 79525330
-            },
-            {
-              "calls": 5965,
-              "head": "PlutusCore.Value.unValueDataTokens.match_3",
-              "self_ns": 124869935
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.Value.unionInner",
-              "self_ns": 223709
-            },
-            {
-              "calls": 17368,
-              "head": "PlutusCore.Value.unionInner.match_1",
-              "self_ns": 392628431
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Value.unionInner.match_3",
-              "self_ns": 478334
-            },
-            {
-              "calls": 2512,
-              "head": "PlutusCore.Value.unionOuter",
-              "self_ns": 12158673
-            },
-            {
-              "calls": 37959,
-              "head": "PlutusCore.Value.unionOuter.match_1",
-              "self_ns": 1078203513
-            },
-            {
-              "calls": 8,
-              "head": "PlutusCore.Value.unionOuter.match_3",
-              "self_ns": 164626
-            },
-            {
-              "calls": 2037,
-              "head": "PlutusCore.Value.unionOuter.match_5",
-              "self_ns": 7651659
-            },
-            {
-              "calls": 5004,
-              "head": "PlutusCore.Value.unionValue",
-              "self_ns": 5711306
-            },
-            {
-              "calls": 6262,
-              "head": "PlutusCore.Value.validKey",
-              "self_ns": 7508911
-            },
-            {
-              "calls": 2838,
-              "head": "PlutusCore.Value.validQuantity",
-              "self_ns": 3545997
-            },
-            {
-              "calls": 584,
-              "head": "PlutusCore.Value.valueContains",
-              "self_ns": 776994
-            },
-            {
-              "calls": 4304,
-              "head": "PlutusCore.Value.valueData",
-              "self_ns": 4591439
-            },
-            {
-              "calls": 2,
-              "head": "Pow.pow",
-              "self_ns": 42124
-            },
-            {
-              "calls": 10,
-              "head": "Prod",
-              "self_ns": 33125
-            },
-            {
-              "calls": 5865,
-              "head": "Prod.fst",
-              "self_ns": 32355456
-            },
-            {
-              "calls": 188154,
-              "head": "Prod.mk",
-              "self_ns": 432642225
-            },
-            {
-              "calls": 8360,
-              "head": "Prod.snd",
-              "self_ns": 78303799
-            },
-            {
-              "calls": 1,
-              "head": "String",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "String.instLT",
-              "self_ns": 3083
-            },
-            {
-              "calls": 3132,
-              "head": "String.length",
-              "self_ns": 10975478
-            },
-            {
-              "calls": 2,
-              "head": "WSC.globalInputs1600",
-              "self_ns": 15959
-            },
-            {
-              "calls": 14,
-              "head": "_normalizer",
-              "self_ns": 50201750
-            },
-            {
-              "calls": 2,
-              "head": "instBEqOfDecidableEq",
-              "self_ns": 22041
-            },
-            {
-              "calls": 2,
-              "head": "instHAdd",
-              "self_ns": 24999
-            },
-            {
-              "calls": 3,
-              "head": "instHMul",
-              "self_ns": 17876
-            },
-            {
-              "calls": 2,
-              "head": "instHPow",
-              "self_ns": 22791
-            },
-            {
-              "calls": 1,
-              "head": "instLENat",
-              "self_ns": 3250
-            },
-            {
-              "calls": 1,
-              "head": "instLTNat",
-              "self_ns": 3875
-            },
-            {
-              "calls": 1,
-              "head": "instNatPowNat",
-              "self_ns": 3333
-            },
-            {
-              "calls": 12,
-              "head": "instOfNat",
-              "self_ns": 32042
-            },
-            {
-              "calls": 9,
-              "head": "instOfNatNat",
-              "self_ns": 22333
-            },
-            {
-              "calls": 2,
-              "head": "instPowNat",
-              "self_ns": 19209
-            },
-            {
-              "calls": 26537,
-              "head": "ite",
-              "self_ns": 38160298
-            },
-            {
-              "calls": 1,
-              "head": "programmableLogicGlobal1600",
-              "self_ns": 829708
-            }
+            {"calls": 1423, "head": "Add.add", "self_ns": 9452403},
+            {"calls": 8, "head": "And", "self_ns": 75789},
+            {"calls": 9841, "head": "BEq.beq", "self_ns": 205471933},
+            {"calls": 8093, "head": "Blaster.decide'", "self_ns": 24609419},
+            {"calls": 79680, "head": "Blaster.dite'", "self_ns": 676621788},
+            {"calls": 1, "head": "Bool", "self_ns": 2250},
+            {"calls": 323, "head": "Bool.and", "self_ns": 1671115},
+            {"calls": 1, "head": "Bool.false", "self_ns": 1125},
+            {"calls": 957, "head": "Bool.or", "self_ns": 5106386},
+            {"calls": 1, "head": "Bool.true", "self_ns": 1375},
+            {"calls": 239, "head": "CardanoLedgerApi.IsData.Class.IsData.toData", "self_ns": 1685207},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataData", "self_ns": 3709},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger", "self_ns": 2833},
+            {"calls": 4, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption", "self_ns": 18460},
+            {"calls": 15, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1", "self_ns": 325960},
+            {"calls": 328, "head": "CardanoLedgerApi.IsData.Class.mkDataConstr", "self_ns": 386270},
+            {"calls": 5, "head": "CardanoLedgerApi.IsData.Class.toTerm", "self_ns": 32375},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.Address", "self_ns": 1708},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressCredential", "self_ns": 16000},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential", "self_ns": 16958},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.instIsDataAddress", "self_ns": 2625},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash", "self_ns": 4000},
+            {"calls": 2, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData", "self_ns": 17750},
+            {"calls": 43805, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 161033090},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 159625},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.Credential", "self_ns": 1292},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential", "self_ns": 7291},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential", "self_ns": 11042},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.PubKeyHash", "self_ns": 10916},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.StakingCredential", "self_ns": 1292},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash", "self_ns": 6541},
+            {"calls": 5, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr", "self_ns": 9584},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential", "self_ns": 2709},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential", "self_ns": 2375},
+            {"calls": 46, "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1", "self_ns": 1114616},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1", "self_ns": 162292},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Datum", "self_ns": 8333},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.DatumHash", "self_ns": 5500},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Redeemer", "self_ns": 6000},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.ScriptHash", "self_ns": 5458},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId", "self_ns": 3583},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.CurrencySymbol", "self_ns": 9375},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.Value", "self_ns": 9084},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.instIsDataValue", "self_ns": 3041},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.DatumMap", "self_ns": 12875},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap", "self_ns": 3459},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut", "self_ns": 6917},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData", "self_ns": 16624},
+            {"calls": 87797, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19", "self_ns": 182130939},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1", "self_ns": 167417},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData", "self_ns": 18374},
+            {"calls": 70225, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14", "self_ns": 2247854218},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1", "self_ns": 271082},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum", "self_ns": 1625},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum", "self_ns": 1334},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum", "self_ns": 7208},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash", "self_ns": 7500},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.TxOut", "self_ns": 1291},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress", "self_ns": 16250},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum", "self_ns": 16292},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript", "self_ns": 17583},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue", "self_ns": 16209},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum", "self_ns": 2584},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut", "self_ns": 2958},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1", "self_ns": 170499},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap", "self_ns": 7125},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.MintValue", "self_ns": 13458},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap", "self_ns": 9083},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext", "self_ns": 1125},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer", "self_ns": 14375},
+            {"calls": 9, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo", "self_ns": 20709},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo", "self_ns": 11042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo", "self_ns": 1250},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript", "self_ns": 9625},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript", "self_ns": 9459},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript", "self_ns": 8541},
+            {"calls": 5, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript", "self_ns": 10375},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript", "self_ns": 12167},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript", "self_ns": 6833},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose", "self_ns": 1750},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying", "self_ns": 9292},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting", "self_ns": 20417},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing", "self_ns": 8584},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding", "self_ns": 6375},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending", "self_ns": 6792},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting", "self_ns": 7167},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo", "self_ns": 1375},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef", "self_ns": 14500},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved", "self_ns": 10667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.TxInfo", "self_ns": 1500},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount", "self_ns": 15666},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData", "self_ns": 13208},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee", "self_ns": 20500},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId", "self_ns": 16875},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs", "self_ns": 12584},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint", "self_ns": 17417},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs", "self_ns": 14791},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures", "self_ns": 17541},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers", "self_ns": 13083},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs", "self_ns": 29375},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories", "self_ns": 17625},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation", "self_ns": 13667},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts", "self_ns": 13208},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange", "self_ns": 16542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes", "self_ns": 12542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl", "self_ns": 21125},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.VoterMap", "self_ns": 8791},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData", "self_ns": 16208},
+            {"calls": 26, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19", "self_ns": 2965958},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1", "self_ns": 179167},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap", "self_ns": 6292},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure", "self_ns": 6542},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert", "self_ns": 4208},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo", "self_ns": 2375},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap", "self_ns": 3667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext", "self_ns": 3500},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo", "self_ns": 3416},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose", "self_ns": 3375},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo", "self_ns": 3209},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo", "self_ns": 2666},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap", "self_ns": 2958},
+            {"calls": 9, "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1", "self_ns": 246875},
+            {"calls": 10, "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1", "self_ns": 451539},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs", "self_ns": 23541},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1", "self_ns": 183666},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData", "self_ns": 14793},
+            {"calls": 171432, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14", "self_ns": 260920365},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1", "self_ns": 293374},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData", "self_ns": 23249},
+            {"calls": 87801, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14", "self_ns": 172054718},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1", "self_ns": 156333},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData", "self_ns": 13791},
+            {"calls": 87935, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19", "self_ns": 184508528},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1", "self_ns": 252208},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData", "self_ns": 19166},
+            {"calls": 87913, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14", "self_ns": 173998726},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1", "self_ns": 228583},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData", "self_ns": 19959},
+            {"calls": 87807, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19", "self_ns": 174383131},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1", "self_ns": 181166},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId", "self_ns": 1959},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx", "self_ns": 16542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId", "self_ns": 17292},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure", "self_ns": 5042},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit", "self_ns": 19542},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction", "self_ns": 17292},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr", "self_ns": 18875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote", "self_ns": 1500},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain", "self_ns": 1042},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo", "self_ns": 1625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes", "self_ns": 1084},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Voter", "self_ns": 1709},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter", "self_ns": 7792},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter", "self_ns": 9167},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter", "self_ns": 7083},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Withdrawals", "self_ns": 10166},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId", "self_ns": 8583},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers", "self_ns": 4375},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure", "self_ns": 4250},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataVote", "self_ns": 5917},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter", "self_ns": 3667},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1", "self_ns": 115291},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1", "self_ns": 220458},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData", "self_ns": 15874},
+            {"calls": 161, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19", "self_ns": 3620582},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1", "self_ns": 160833},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.TxId", "self_ns": 6625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.TxOutRef", "self_ns": 1500},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId", "self_ns": 20083},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx", "self_ns": 15625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId", "self_ns": 4000},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef", "self_ns": 2750},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential", "self_ns": 10084},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep", "self_ns": 1208},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep", "self_ns": 6750},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain", "self_ns": 1125},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence", "self_ns": 1250},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRepCredential", "self_ns": 5667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.Delegatee", "self_ns": 9417},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake", "self_ns": 6875},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote", "self_ns": 8167},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote", "self_ns": 9916},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential", "self_ns": 6625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.TxCert", "self_ns": 2375},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee", "self_ns": 11500},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking", "self_ns": 9917},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister", "self_ns": 11209},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire", "self_ns": 18250},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep", "self_ns": 13875},
+            {"calls": 5, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg", "self_ns": 11250},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking", "self_ns": 12333},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee", "self_ns": 6125},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep", "self_ns": 8542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking", "self_ns": 9292},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep", "self_ns": 6708},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep", "self_ns": 3208},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee", "self_ns": 2750},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert", "self_ns": 4500},
+            {"calls": 14, "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1", "self_ns": 322209},
+            {"calls": 10, "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1", "self_ns": 284169},
+            {"calls": 16, "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1", "self_ns": 1468039},
+            {"calls": 6737, "head": "Decidable.decide", "self_ns": 8262470},
+            {"calls": 31538, "head": "Eq", "self_ns": 283926346},
+            {"calls": 13, "head": "Function.comp", "self_ns": 84042},
+            {"calls": 1429, "head": "HAdd.hAdd", "self_ns": 9605845},
+            {"calls": 2438, "head": "HMul.hMul", "self_ns": 12279735},
+            {"calls": 2, "head": "HPow.hPow", "self_ns": 56043},
+            {"calls": 2, "head": "Inhabited.default", "self_ns": 29667},
+            {"calls": 1, "head": "Int", "self_ns": 3458},
+            {"calls": 4267, "head": "Int.add", "self_ns": 14852346},
+            {"calls": 1, "head": "Int.instAdd", "self_ns": 4292},
+            {"calls": 1, "head": "Int.instDecidableEq", "self_ns": 5792},
+            {"calls": 1, "head": "Int.instLEInt", "self_ns": 5875},
+            {"calls": 1, "head": "Int.instLTInt", "self_ns": 7208},
+            {"calls": 1, "head": "Int.instMul", "self_ns": 2833},
+            {"calls": 7095, "head": "Int.mul", "self_ns": 18719195},
+            {"calls": 2838, "head": "Int.natAbs", "self_ns": 3295610},
+            {"calls": 1421, "head": "Int.neg", "self_ns": 3485785},
+            {"calls": 1424, "head": "Int.neg.match_1", "self_ns": 49045480},
+            {"calls": 7, "head": "Int.negOfNat.match_1", "self_ns": 119584},
+            {"calls": 5, "head": "Int.negSucc", "self_ns": 17292},
+            {"calls": 15, "head": "Int.ofNat", "self_ns": 41126},
+            {"calls": 3, "head": "Int.pow", "self_ns": 12667},
+            {"calls": 3675, "head": "Int.toNat", "self_ns": 10521160},
+            {"calls": 3392, "head": "LE.le", "self_ns": 16614128},
+            {"calls": 16414, "head": "LT.lt", "self_ns": 75880863},
+            {"calls": 4310, "head": "List", "self_ns": 7697385},
+            {"calls": 6129244, "head": "List.cons", "self_ns": 12609388444},
+            {"calls": 847, "head": "List.drop", "self_ns": 25675001},
+            {"calls": 158227, "head": "List.get?Internal", "self_ns": 717875624},
+            {"calls": 12778, "head": "List.getLast?.match_1", "self_ns": 271794235},
+            {"calls": 8487, "head": "List.isEmpty", "self_ns": 24956278},
+            {"calls": 20231, "head": "List.nil", "self_ns": 33841199},
+            {"calls": 20211, "head": "List.reverse", "self_ns": 60710864},
+            {"calls": 20211, "head": "List.reverseAux", "self_ns": 116902808},
+            {"calls": 20, "head": "List.take.match_1", "self_ns": 470332},
+            {"calls": 1421, "head": "Mul.mul", "self_ns": 9589607},
+            {"calls": 1, "head": "Nat", "self_ns": 39292},
+            {"calls": 1449, "head": "Nat.add", "self_ns": 5950771},
+            {"calls": 12, "head": "Nat.add.match_1", "self_ns": 294333},
+            {"calls": 2, "head": "Nat.beq", "self_ns": 6000},
+            {"calls": 14, "head": "Nat.beq.match_1", "self_ns": 314207},
+            {"calls": 2, "head": "Nat.ble", "self_ns": 7000},
+            {"calls": 4, "head": "Nat.mul", "self_ns": 18751},
+            {"calls": 12, "head": "Nat.mul.match_1", "self_ns": 234873},
+            {"calls": 4, "head": "Nat.pow", "self_ns": 16708},
+            {"calls": 6, "head": "Nat.pow.match_1", "self_ns": 113167},
+            {"calls": 2, "head": "Nat.pred", "self_ns": 7292},
+            {"calls": 1451, "head": "Nat.sub", "self_ns": 9489151},
+            {"calls": 1432, "head": "Nat.succ", "self_ns": 2303913},
+            {"calls": 1, "head": "Nat.zero", "self_ns": 2167},
+            {"calls": 2, "head": "NatPow.pow", "self_ns": 41959},
+            {"calls": 4814, "head": "Not", "self_ns": 13830658},
+            {"calls": 21, "head": "OfNat.ofNat", "self_ns": 274791},
+            {"calls": 13731, "head": "Option", "self_ns": 22375116},
+            {"calls": 39712, "head": "Option.getD.match_1", "self_ns": 881783674},
+            {"calls": 6343, "head": "Option.map", "self_ns": 25904409},
+            {"calls": 11821, "head": "Option.none", "self_ns": 21169228},
+            {"calls": 148453, "head": "Option.some", "self_ns": 675311327},
+            {"calls": 506, "head": "Or", "self_ns": 3452960},
+            {"calls": 9189, "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse", "self_ns": 35962910},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString", "self_ns": 3791},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString", "self_ns": 1167},
+            {"calls": 25749, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data", "self_ns": 23049722},
+            {"calls": 6262, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length", "self_ns": 10625745},
+            {"calls": 3, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk", "self_ns": 5834},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString", "self_ns": 4375},
+            {"calls": 868, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString", "self_ns": 1162623},
+            {"calls": 924, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString", "self_ns": 1294340},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData", "self_ns": 4542},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data", "self_ns": 1417},
+            {"calls": 356758, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B", "self_ns": 390312613},
+            {"calls": 1193823, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr", "self_ns": 1654241685},
+            {"calls": 263892, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I", "self_ns": 289054779},
+            {"calls": 448023, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List", "self_ns": 671140329},
+            {"calls": 304364, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map", "self_ns": 1273883883},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData", "self_ns": 17375},
+            {"calls": 383, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1", "self_ns": 2895441},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr", "self_ns": 103291},
+            {"calls": 19, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1", "self_ns": 178542},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList", "self_ns": 88250},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1", "self_ns": 321167},
+            {"calls": 377, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap", "self_ns": 2257922},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1", "self_ns": 409459},
+            {"calls": 5140, "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData", "self_ns": 6313223},
+            {"calls": 6100, "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData", "self_ns": 6505503},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant", "self_ns": 3792},
+            {"calls": 1, "head": "PlutusCore.Integer.Integer", "self_ns": 6000},
+            {"calls": 220, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger", "self_ns": 531377},
+            {"calls": 3924, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger", "self_ns": 4945669},
+            {"calls": 516, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger", "self_ns": 619667},
+            {"calls": 375, "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons", "self_ns": 1512326},
+            {"calls": 1185, "head": "PlutusCore.List.PlutusCore.ListInternal.nullList", "self_ns": 3824747},
+            {"calls": 3441, "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair", "self_ns": 12571214},
+            {"calls": 8229, "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair", "self_ns": 27840729},
+            {"calls": 18376, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse", "self_ns": 20415295},
+            {"calls": 9193, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1", "self_ns": 43244661},
+            {"calls": 901, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1", "self_ns": 5495621},
+            {"calls": 868, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString", "self_ns": 1126667},
+            {"calls": 924, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString", "self_ns": 1359418},
+            {"calls": 5140, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData", "self_ns": 6497898},
+            {"calls": 2575, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1", "self_ns": 13697084},
+            {"calls": 6100, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData", "self_ns": 6791777},
+            {"calls": 3055, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1", "self_ns": 14346627},
+            {"calls": 4004, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData", "self_ns": 4925630},
+            {"calls": 2007, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1", "self_ns": 1076600875},
+            {"calls": 16272, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData", "self_ns": 18775092},
+            {"calls": 8142, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1", "self_ns": 293880095},
+            {"calls": 19316, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3", "self_ns": 83751799},
+            {"calls": 1908, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData", "self_ns": 2613560},
+            {"calls": 959, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1", "self_ns": 29129334},
+            {"calls": 7056, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData", "self_ns": 8354742},
+            {"calls": 3533, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1", "self_ns": 85007928},
+            {"calls": 9380, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData", "self_ns": 10346805},
+            {"calls": 4695, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1", "self_ns": 42943222},
+            {"calls": 197156, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction", "self_ns": 196442419},
+            {"calls": 98678, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1", "self_ns": 982562242},
+            {"calls": 220, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger", "self_ns": 292796},
+            {"calls": 2335, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1", "self_ns": 12577589},
+            {"calls": 3924, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger", "self_ns": 5382344},
+            {"calls": 516, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger", "self_ns": 633292},
+            {"calls": 14604, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList", "self_ns": 15929983},
+            {"calls": 7309, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1", "self_ns": 44510048},
+            {"calls": 1672, "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList", "self_ns": 2304766},
+            {"calls": 843, "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1", "self_ns": 6535918},
+            {"calls": 41740, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList", "self_ns": 46734008},
+            {"calls": 41596, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3", "self_ns": 676148171},
+            {"calls": 8822, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5", "self_ns": 124513999},
+            {"calls": 32567, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7", "self_ns": 160096675},
+            {"calls": 748, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons", "self_ns": 1072743},
+            {"calls": 381, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1", "self_ns": 3308161},
+            {"calls": 2368, "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList", "self_ns": 3012100},
+            {"calls": 21012, "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList", "self_ns": 21299844},
+            {"calls": 6880, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair", "self_ns": 8303861},
+            {"calls": 11674, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1", "self_ns": 55373603},
+            {"calls": 16456, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair", "self_ns": 17027887},
+            {"calls": 708, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin", "self_ns": 1118702},
+            {"calls": 359, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin.match_1", "self_ns": 3873931},
+            {"calls": 6388, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData", "self_ns": 7177639},
+            {"calls": 3199, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1", "self_ns": 14496896},
+            {"calls": 5004, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue", "self_ns": 6170206},
+            {"calls": 2799, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1", "self_ns": 14818314},
+            {"calls": 584, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains", "self_ns": 816852},
+            {"calls": 4304, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData", "self_ns": 4934006},
+            {"calls": 2157, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1", "self_ns": 9993215},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV", "self_ns": 1458},
+            {"calls": 13, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More", "self_ns": 34210},
+            {"calls": 3, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One", "self_ns": 8125},
+            {"calls": 73066, "head": "PlutusCore.UPLC.Builtins.expectedArgs", "self_ns": 72339231},
+            {"calls": 36633, "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1", "self_ns": 429846536},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame", "self_ns": 1333},
+            {"calls": 48710, "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee", "self_ns": 107254531},
+            {"calls": 92730, "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument", "self_ns": 301241164},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame", "self_ns": 1417},
+            {"calls": 159013, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm", "self_ns": 380614629},
+            {"calls": 62445, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue", "self_ns": 118760626},
+            {"calls": 185712, "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue", "self_ns": 321954085},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State", "self_ns": 1917},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State.Error", "self_ns": 1500},
+            {"calls": 456005, "head": "PlutusCore.UPLC.CekMachine.State.Eval", "self_ns": 1459695573},
+            {"calls": 769, "head": "PlutusCore.UPLC.CekMachine.State.Halt", "self_ns": 1963501},
+            {"calls": 425818, "head": "PlutusCore.UPLC.CekMachine.State.Return", "self_ns": 1139184791},
+            {"calls": 14, "head": "PlutusCore.UPLC.CekMachine.applyParams", "self_ns": 3143831},
+            {"calls": 3, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram", "self_ns": 52583},
+            {"calls": 4, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1", "self_ns": 91917},
+            {"calls": 197156, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin", "self_ns": 211079189},
+            {"calls": 325885, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1", "self_ns": 6012800433},
+            {"calls": 2, "head": "PlutusCore.UPLC.CekMachine.initialState", "self_ns": 13334},
+            {"calls": 931425, "head": "PlutusCore.UPLC.CekMachine.runSteps", "self_ns": 5678339290},
+            {"calls": 889722, "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1", "self_ns": 2962339174},
+            {"calls": 1749864, "head": "PlutusCore.UPLC.CekMachine.step", "self_ns": 1644858360},
+            {"calls": 82517, "head": "PlutusCore.UPLC.CekMachine.step.folding", "self_ns": 341010248},
+            {"calls": 102594, "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1", "self_ns": 227051077},
+            {"calls": 86832, "head": "PlutusCore.UPLC.CekMachine.step.match_1", "self_ns": 230300220},
+            {"calls": 20091, "head": "PlutusCore.UPLC.CekMachine.step.match_11", "self_ns": 63372142},
+            {"calls": 421499, "head": "PlutusCore.UPLC.CekMachine.step.match_13", "self_ns": 1175669950},
+            {"calls": 874939, "head": "PlutusCore.UPLC.CekMachine.step.match_15", "self_ns": 2290179145},
+            {"calls": 452687, "head": "PlutusCore.UPLC.CekMachine.step.match_3", "self_ns": 1411977306},
+            {"calls": 186001, "head": "PlutusCore.UPLC.CekMachine.step.match_5", "self_ns": 532532533},
+            {"calls": 22171, "head": "PlutusCore.UPLC.CekMachine.step.match_7", "self_ns": 58709001},
+            {"calls": 20079, "head": "PlutusCore.UPLC.CekMachine.step.match_9", "self_ns": 76774474},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekValue.CekValue", "self_ns": 1500},
+            {"calls": 88632, "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin", "self_ns": 227531853},
+            {"calls": 1293467, "head": "PlutusCore.UPLC.CekValue.CekValue.VCon", "self_ns": 2065230118},
+            {"calls": 20214, "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr", "self_ns": 47077760},
+            {"calls": 46346, "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay", "self_ns": 111977957},
+            {"calls": 267852, "head": "PlutusCore.UPLC.CekValue.CekValue.VLam", "self_ns": 641436541},
+            {"calls": 1, "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3", "self_ns": 1333},
+            {"calls": 2, "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk", "self_ns": 9916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun", "self_ns": 1583},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.BData", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256", "self_ns": 1459},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add", "self_ns": 4083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress", "self_ns": 4416},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal", "self_ns": 4958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul", "self_ns": 1417},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg", "self_ns": 2291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add", "self_ns": 4458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg", "self_ns": 1583},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul", "self_ns": 4375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData", "self_ns": 1416},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList", "self_ns": 1792},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit", "self_ns": 4584},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString", "self_ns": 1417},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IData", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString", "self_ns": 16334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256", "self_ns": 1459},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString", "self_ns": 1416},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger", "self_ns": 1708},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons", "self_ns": 2000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger", "self_ns": 1459},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList", "self_ns": 1916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue", "self_ns": 916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData", "self_ns": 4375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256", "self_ns": 1417},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair", "self_ns": 1750},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger", "self_ns": 1834},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList", "self_ns": 1750},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData", "self_ns": 1584},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData", "self_ns": 917},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature", "self_ns": 4416},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature", "self_ns": 1583},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const", "self_ns": 1250},
+            {"calls": 9063, "head": "PlutusCore.UPLC.Term.Const.Bool", "self_ns": 40338156},
+            {"calls": 12054, "head": "PlutusCore.UPLC.Term.Const.ByteString", "self_ns": 14552509},
+            {"calls": 833727, "head": "PlutusCore.UPLC.Term.Const.ConstDataList", "self_ns": 1312638315},
+            {"calls": 11, "head": "PlutusCore.UPLC.Term.Const.ConstList", "self_ns": 18001},
+            {"calls": 110941, "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList", "self_ns": 175522754},
+            {"calls": 443430, "head": "PlutusCore.UPLC.Term.Const.Data", "self_ns": 579081635},
+            {"calls": 46273, "head": "PlutusCore.UPLC.Term.Const.Integer", "self_ns": 62779034},
+            {"calls": 84317, "head": "PlutusCore.UPLC.Term.Const.Pair", "self_ns": 143512014},
+            {"calls": 9909, "head": "PlutusCore.UPLC.Term.Const.PairData", "self_ns": 15774708},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const.Unit", "self_ns": 1000},
+            {"calls": 28981, "head": "PlutusCore.UPLC.Term.Const.Value", "self_ns": 35698970},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Program", "self_ns": 1583},
+            {"calls": 5, "head": "PlutusCore.UPLC.Term.Program.Program", "self_ns": 14417},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term", "self_ns": 1000},
+            {"calls": 532, "head": "PlutusCore.UPLC.Term.Term.Apply", "self_ns": 899487},
+            {"calls": 29, "head": "PlutusCore.UPLC.Term.Term.Builtin", "self_ns": 43668},
+            {"calls": 78, "head": "PlutusCore.UPLC.Term.Term.Case", "self_ns": 137992},
+            {"calls": 17, "head": "PlutusCore.UPLC.Term.Term.Const", "self_ns": 62584},
+            {"calls": 78, "head": "PlutusCore.UPLC.Term.Term.Constr", "self_ns": 133673},
+            {"calls": 83, "head": "PlutusCore.UPLC.Term.Term.Delay", "self_ns": 119121},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term.Error", "self_ns": 1042},
+            {"calls": 70, "head": "PlutusCore.UPLC.Term.Term.Force", "self_ns": 98843},
+            {"calls": 199, "head": "PlutusCore.UPLC.Term.Term.Lam", "self_ns": 251750},
+            {"calls": 125, "head": "PlutusCore.UPLC.Term.Term.Var", "self_ns": 107041},
+            {"calls": 2, "head": "PlutusCore.UPLC.Term.Version.Version", "self_ns": 8584},
+            {"calls": 1, "head": "PlutusCore.Value.ValueRep", "self_ns": 10958},
+            {"calls": 6262, "head": "PlutusCore.Value.ascendingFrom", "self_ns": 11352253},
+            {"calls": 3138, "head": "PlutusCore.Value.ascendingFrom.match_1", "self_ns": 10235515},
+            {"calls": 322, "head": "PlutusCore.Value.containedInner", "self_ns": 3679546},
+            {"calls": 651, "head": "PlutusCore.Value.containedOuter", "self_ns": 4159705},
+            {"calls": 2186, "head": "PlutusCore.Value.deleteCoin", "self_ns": 12036476},
+            {"calls": 6, "head": "PlutusCore.Value.deleteCoin.match_1", "self_ns": 184167},
+            {"calls": 1024, "head": "PlutusCore.Value.hasNegativeAmount", "self_ns": 5515526},
+            {"calls": 15, "head": "PlutusCore.Value.innerDelete", "self_ns": 2742499},
+            {"calls": 958, "head": "PlutusCore.Value.innerHasNegative", "self_ns": 5278647},
+            {"calls": 5374, "head": "PlutusCore.Value.innerHasNegative.match_1", "self_ns": 15730120},
+            {"calls": 24004, "head": "PlutusCore.Value.innerToData", "self_ns": 62015762},
+            {"calls": 708, "head": "PlutusCore.Value.insertCoin", "self_ns": 1199601},
+            {"calls": 12, "head": "PlutusCore.Value.lookupCoin", "self_ns": 3075792},
+            {"calls": 9, "head": "PlutusCore.Value.lookupInner", "self_ns": 2976541},
+            {"calls": 1, "head": "PlutusCore.Value.maxKeyLen", "self_ns": 8917},
+            {"calls": 7752, "head": "PlutusCore.Value.outerToData", "self_ns": 31006415},
+            {"calls": 7976, "head": "PlutusCore.Value.totalSize.match_1", "self_ns": 27959459},
+            {"calls": 6388, "head": "PlutusCore.Value.unValueData", "self_ns": 7355674},
+            {"calls": 3199, "head": "PlutusCore.Value.unValueData.match_1", "self_ns": 36399394},
+            {"calls": 8135, "head": "PlutusCore.Value.unValueDataCurrencies", "self_ns": 70109801},
+            {"calls": 2616, "head": "PlutusCore.Value.unValueDataCurrencies.match_1", "self_ns": 62670240},
+            {"calls": 2616, "head": "PlutusCore.Value.unValueDataCurrencies.match_3", "self_ns": 73610921},
+            {"calls": 3736, "head": "PlutusCore.Value.unValueDataTokens", "self_ns": 27864978},
+            {"calls": 3458, "head": "PlutusCore.Value.unValueDataTokens.match_1", "self_ns": 79525330},
+            {"calls": 5965, "head": "PlutusCore.Value.unValueDataTokens.match_3", "self_ns": 124869935},
+            {"calls": 13, "head": "PlutusCore.Value.unionInner", "self_ns": 223709},
+            {"calls": 17368, "head": "PlutusCore.Value.unionInner.match_1", "self_ns": 392628431},
+            {"calls": 11, "head": "PlutusCore.Value.unionInner.match_3", "self_ns": 478334},
+            {"calls": 2512, "head": "PlutusCore.Value.unionOuter", "self_ns": 12158673},
+            {"calls": 37959, "head": "PlutusCore.Value.unionOuter.match_1", "self_ns": 1078203513},
+            {"calls": 8, "head": "PlutusCore.Value.unionOuter.match_3", "self_ns": 164626},
+            {"calls": 2037, "head": "PlutusCore.Value.unionOuter.match_5", "self_ns": 7651659},
+            {"calls": 5004, "head": "PlutusCore.Value.unionValue", "self_ns": 5711306},
+            {"calls": 6262, "head": "PlutusCore.Value.validKey", "self_ns": 7508911},
+            {"calls": 2838, "head": "PlutusCore.Value.validQuantity", "self_ns": 3545997},
+            {"calls": 584, "head": "PlutusCore.Value.valueContains", "self_ns": 776994},
+            {"calls": 4304, "head": "PlutusCore.Value.valueData", "self_ns": 4591439},
+            {"calls": 2, "head": "Pow.pow", "self_ns": 42124},
+            {"calls": 10, "head": "Prod", "self_ns": 33125},
+            {"calls": 5865, "head": "Prod.fst", "self_ns": 32355456},
+            {"calls": 188154, "head": "Prod.mk", "self_ns": 432642225},
+            {"calls": 8360, "head": "Prod.snd", "self_ns": 78303799},
+            {"calls": 1, "head": "String", "self_ns": 1333},
+            {"calls": 1, "head": "String.instLT", "self_ns": 3083},
+            {"calls": 3132, "head": "String.length", "self_ns": 10975478},
+            {"calls": 2, "head": "WSC.globalInputs1600", "self_ns": 15959},
+            {"calls": 14, "head": "_normalizer", "self_ns": 50201750},
+            {"calls": 2, "head": "instBEqOfDecidableEq", "self_ns": 22041},
+            {"calls": 2, "head": "instHAdd", "self_ns": 24999},
+            {"calls": 3, "head": "instHMul", "self_ns": 17876},
+            {"calls": 2, "head": "instHPow", "self_ns": 22791},
+            {"calls": 1, "head": "instLENat", "self_ns": 3250},
+            {"calls": 1, "head": "instLTNat", "self_ns": 3875},
+            {"calls": 1, "head": "instNatPowNat", "self_ns": 3333},
+            {"calls": 12, "head": "instOfNat", "self_ns": 32042},
+            {"calls": 9, "head": "instOfNatNat", "self_ns": 22333},
+            {"calls": 2, "head": "instPowNat", "self_ns": 19209},
+            {"calls": 26537, "head": "ite", "self_ns": 38160298},
+            {"calls": 1, "head": "programmableLogicGlobal1600", "self_ns": 829708}
           ],
           "imbalances": 0,
           "schema": 1,
@@ -5975,2271 +1359,459 @@
           },
           "hashcons": 8106674,
           "heads": [
-            {
-              "calls": 7,
-              "head": "And",
-              "self_ns": 68500
-            },
-            {
-              "calls": 2,
-              "head": "Applicative.toPure",
-              "self_ns": 15292
-            },
-            {
-              "calls": 6876,
-              "head": "BEq.beq",
-              "self_ns": 113864392
-            },
-            {
-              "calls": 1251,
-              "head": "Blaster.decide'",
-              "self_ns": 4661582
-            },
-            {
-              "calls": 2524270,
-              "head": "Blaster.dite'",
-              "self_ns": 3035707745
-            },
-            {
-              "calls": 1,
-              "head": "Bool",
-              "self_ns": 2333
-            },
-            {
-              "calls": 7,
-              "head": "Bool.and",
-              "self_ns": 60709
-            },
-            {
-              "calls": 1,
-              "head": "Bool.false",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "Bool.true",
-              "self_ns": 1667
-            },
-            {
-              "calls": 97,
-              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
-              "self_ns": 774619
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
-              "self_ns": 3458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
-              "self_ns": 2625
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
-              "self_ns": 16375
-            },
-            {
-              "calls": 74,
-              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
-              "self_ns": 109419
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.IsData.Class.optionToData",
-              "self_ns": 195167
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.IsData.Class.optionToData.match_1",
-              "self_ns": 179877
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.IsData.Class.toTerm",
-              "self_ns": 37583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.Address",
-              "self_ns": 1791
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
-              "self_ns": 15084
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
-              "self_ns": 14625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
-              "self_ns": 2542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose",
-              "self_ns": 1208
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Certifying",
-              "self_ns": 6875
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Minting",
-              "self_ns": 10375
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Rewarding",
-              "self_ns": 7250
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Spending",
-              "self_ns": 11043
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListDCert",
-              "self_ns": 3250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
-              "self_ns": 3000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.instIsDataScriptPurpose",
-              "self_ns": 3833
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V1.Contexts.instReprScriptPurpose.repr.match_1",
-              "self_ns": 262624
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V1.Contexts.scriptPurposeToData",
-              "self_ns": 113166
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData",
-              "self_ns": 13501
-            },
-            {
-              "calls": 38109,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData.go._@.CardanoLedgerApi.V1.Contexts.2955701632._hygCtx._hyg.14",
-              "self_ns": 77082129
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData.match_1",
-              "self_ns": 155707
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
-              "self_ns": 12208
-            },
-            {
-              "calls": 38095,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 75102550
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 153542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.Credential",
-              "self_ns": 1708
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
-              "self_ns": 7500
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
-              "self_ns": 6834
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
-              "self_ns": 6625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
-              "self_ns": 1375
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
-              "self_ns": 6041
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
-              "self_ns": 10417
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V1.Credential.credentialToData",
-              "self_ns": 78958
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
-              "self_ns": 2833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataPubKeyHash",
-              "self_ns": 2541
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
-              "self_ns": 2500
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
-              "self_ns": 169415
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
-              "self_ns": 136043
-            },
-            {
-              "calls": 11,
-              "head": "CardanoLedgerApi.V1.Credential.stakingCredentialToData",
-              "self_ns": 117083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.DCert.DCert",
-              "self_ns": 2250
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegDeRegKey",
-              "self_ns": 6459
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegDelegate",
-              "self_ns": 9250
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegRegKey",
-              "self_ns": 7417
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertGenesis",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertMir",
-              "self_ns": 958
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertPoolRegister",
-              "self_ns": 8333
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertPoolRetire",
-              "self_ns": 8083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.DCert.instIsDataDCert",
-              "self_ns": 3458
-            },
-            {
-              "calls": 12,
-              "head": "CardanoLedgerApi.V1.DCert.instReprDCert.repr.match_1",
-              "self_ns": 584502
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Datum",
-              "self_ns": 6709
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
-              "self_ns": 4709
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
-              "self_ns": 6250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
-              "self_ns": 5375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.TxId",
-              "self_ns": 6708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.TxOutRef",
-              "self_ns": 1417
-            },
-            {
-              "calls": 12,
-              "head": "CardanoLedgerApi.V1.Tx.TxOutRef.txOutRefId",
-              "self_ns": 20626
-            },
-            {
-              "calls": 12,
-              "head": "CardanoLedgerApi.V1.Tx.TxOutRef.txOutRefIdx",
-              "self_ns": 21458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
-              "self_ns": 2500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxOutRef",
-              "self_ns": 3125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
-              "self_ns": 6708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.Value",
-              "self_ns": 13125
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
-              "self_ns": 3042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
-              "self_ns": 17666
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.RedeemerMap",
-              "self_ns": 9083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.ScriptContext",
-              "self_ns": 1167
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Contexts.ScriptContext.scriptContextPurpose",
-              "self_ns": 17917
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.ScriptContext.scriptContextTxInfo",
-              "self_ns": 19458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.ScriptPurpose",
-              "self_ns": 9501
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput",
-              "self_ns": 1416
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.ctx",
-              "self_ns": 20917
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.datum",
-              "self_ns": 13625
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.redeemer",
-              "self_ns": 12750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInInfo",
-              "self_ns": 1250
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInInfo.txInInfoOutRef",
-              "self_ns": 19375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInInfo.txInInfoResolved",
-              "self_ns": 10667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo",
-              "self_ns": 1583
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoDCert",
-              "self_ns": 15334
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoData",
-              "self_ns": 15625
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoFee",
-              "self_ns": 14375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoId",
-              "self_ns": 14375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoInputs",
-              "self_ns": 11916
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoMint",
-              "self_ns": 11000
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoOutputs",
-              "self_ns": 11917
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoRedeemers",
-              "self_ns": 13125
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoReferenceInputs",
-              "self_ns": 11583
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoSignatories",
-              "self_ns": 11334
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoValidRange",
-              "self_ns": 12750
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoWdrl",
-              "self_ns": 24750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.Withdrawals",
-              "self_ns": 12376
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.findOwnInput.match_1",
-              "self_ns": 194665
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
-              "self_ns": 2709
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxInInfo",
-              "self_ns": 2833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
-              "self_ns": 2958
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataRedeemerMap",
-              "self_ns": 3000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataScriptContext",
-              "self_ns": 3458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataTxInInfo",
-              "self_ns": 7459
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataTxInfo",
-              "self_ns": 2542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataWithdrawals",
-              "self_ns": 2625
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.spendingInputs",
-              "self_ns": 37582
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
-              "self_ns": 13083
-            },
-            {
-              "calls": 38095,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
-              "self_ns": 72313494
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
-              "self_ns": 180791
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData",
-              "self_ns": 18000
-            },
-            {
-              "calls": 114276,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V2.Contexts.2536880513._hygCtx._hyg.14",
-              "self_ns": 188116528
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData.match_1",
-              "self_ns": 190166
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
-              "self_ns": 12791
-            },
-            {
-              "calls": 249,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
-              "self_ns": 3405377
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
-              "self_ns": 158834
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData",
-              "self_ns": 12833
-            },
-            {
-              "calls": 38095,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V2.Contexts.2123419846._hygCtx._hyg.19",
-              "self_ns": 73705743
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData.match_1",
-              "self_ns": 174543
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData",
-              "self_ns": 11999
-            },
-            {
-              "calls": 38095,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData.go._@.CardanoLedgerApi.V2.Contexts.2635151150._hygCtx._hyg.19",
-              "self_ns": 76127107
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData.match_1",
-              "self_ns": 161249
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
-              "self_ns": 1417
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
-              "self_ns": 1125
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
-              "self_ns": 7292
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
-              "self_ns": 9833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.TxId",
-              "self_ns": 9042
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut",
-              "self_ns": 1208
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
-              "self_ns": 16376
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
-              "self_ns": 12167
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
-              "self_ns": 17750
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
-              "self_ns": 13458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.TxOutRef",
-              "self_ns": 11166
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
-              "self_ns": 2250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
-              "self_ns": 2916
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
-              "self_ns": 139874
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V2.Tx.outputDatumToData",
-              "self_ns": 64249
-            },
-            {
-              "calls": 1251,
-              "head": "Decidable.decide",
-              "self_ns": 1797259
-            },
-            {
-              "calls": 845568,
-              "head": "Eq",
-              "self_ns": 2190667098
-            },
-            {
-              "calls": 1807,
-              "head": "Except",
-              "self_ns": 4006637
-            },
-            {
-              "calls": 1806,
-              "head": "Except.error",
-              "self_ns": 5338930
-            },
-            {
-              "calls": 2,
-              "head": "Except.instMonad",
-              "self_ns": 11833
-            },
-            {
-              "calls": 26657,
-              "head": "Except.ok",
-              "self_ns": 76641332
-            },
-            {
-              "calls": 26655,
-              "head": "Except.pure",
-              "self_ns": 86506106
-            },
-            {
-              "calls": 37,
-              "head": "Function.comp",
-              "self_ns": 131667
-            },
-            {
-              "calls": 3,
-              "head": "HMul.hMul",
-              "self_ns": 61958
-            },
-            {
-              "calls": 2,
-              "head": "Inhabited.default",
-              "self_ns": 30459
-            },
-            {
-              "calls": 1,
-              "head": "Int",
-              "self_ns": 3500
-            },
-            {
-              "calls": 1,
-              "head": "Int.instDecidableEq",
-              "self_ns": 10000
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLEInt",
-              "self_ns": 4625
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLTInt",
-              "self_ns": 4083
-            },
-            {
-              "calls": 1,
-              "head": "Int.instMul",
-              "self_ns": 3458
-            },
-            {
-              "calls": 2,
-              "head": "Int.mul",
-              "self_ns": 18833
-            },
-            {
-              "calls": 7,
-              "head": "Int.negOfNat.match_1",
-              "self_ns": 134709
-            },
-            {
-              "calls": 8,
-              "head": "Int.ofNat",
-              "self_ns": 34124
-            },
-            {
-              "calls": 3,
-              "head": "Int.pow",
-              "self_ns": 7750
-            },
-            {
-              "calls": 1251,
-              "head": "LE.le",
-              "self_ns": 8075052
-            },
-            {
-              "calls": 1259,
-              "head": "LT.lt",
-              "self_ns": 11143843
-            },
-            {
-              "calls": 9831,
-              "head": "List",
-              "self_ns": 16070832
-            },
-            {
-              "calls": 1440138,
-              "head": "List.cons",
-              "self_ns": 3146221226
-            },
-            {
-              "calls": 15504,
-              "head": "List.getLast?.match_1",
-              "self_ns": 240998653
-            },
-            {
-              "calls": 3513,
-              "head": "List.isEmpty",
-              "self_ns": 11071230
-            },
-            {
-              "calls": 16,
-              "head": "List.nil",
-              "self_ns": 53164
-            },
-            {
-              "calls": 2,
-              "head": "Monad.toApplicative",
-              "self_ns": 14542
-            },
-            {
-              "calls": 1809,
-              "head": "MonadExcept.throw",
-              "self_ns": 13003705
-            },
-            {
-              "calls": 1804,
-              "head": "MonadExceptOf.throw",
-              "self_ns": 11383642
-            },
-            {
-              "calls": 2,
-              "head": "Mul.mul",
-              "self_ns": 29167
-            },
-            {
-              "calls": 1,
-              "head": "Nat",
-              "self_ns": 52166
-            },
-            {
-              "calls": 25,
-              "head": "Nat.add",
-              "self_ns": 101584
-            },
-            {
-              "calls": 12,
-              "head": "Nat.add.match_1",
-              "self_ns": 311791
-            },
-            {
-              "calls": 2,
-              "head": "Nat.beq",
-              "self_ns": 5916
-            },
-            {
-              "calls": 14,
-              "head": "Nat.beq.match_1",
-              "self_ns": 319293
-            },
-            {
-              "calls": 2,
-              "head": "Nat.ble",
-              "self_ns": 7333
-            },
-            {
-              "calls": 4,
-              "head": "Nat.mul",
-              "self_ns": 28958
-            },
-            {
-              "calls": 12,
-              "head": "Nat.mul.match_1",
-              "self_ns": 226376
-            },
-            {
-              "calls": 3,
-              "head": "Nat.pow",
-              "self_ns": 8542
-            },
-            {
-              "calls": 6,
-              "head": "Nat.pow.match_1",
-              "self_ns": 135960
-            },
-            {
-              "calls": 2,
-              "head": "Nat.pred",
-              "self_ns": 6959
-            },
-            {
-              "calls": 32,
-              "head": "Nat.sub",
-              "self_ns": 4078876
-            },
-            {
-              "calls": 11,
-              "head": "Nat.succ",
-              "self_ns": 48706
-            },
-            {
-              "calls": 1,
-              "head": "Nat.zero",
-              "self_ns": 2459
-            },
-            {
-              "calls": 1255,
-              "head": "Not",
-              "self_ns": 4246989
-            },
-            {
-              "calls": 13,
-              "head": "OfNat.ofNat",
-              "self_ns": 187584
-            },
-            {
-              "calls": 6309,
-              "head": "Option",
-              "self_ns": 11646877
-            },
-            {
-              "calls": 6306,
-              "head": "Option.none",
-              "self_ns": 12680875
-            },
-            {
-              "calls": 103911,
-              "head": "Option.some",
-              "self_ns": 584884122
-            },
-            {
-              "calls": 9222,
-              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
-              "self_ns": 33100919
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
-              "self_ns": 4500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
-              "self_ns": 5958
-            },
-            {
-              "calls": 2250,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
-              "self_ns": 3076555
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
-              "self_ns": 8166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
-              "self_ns": 1209
-            },
-            {
-              "calls": 144397,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
-              "self_ns": 160828009
-            },
-            {
-              "calls": 303016,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
-              "self_ns": 519319213
-            },
-            {
-              "calls": 98044,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
-              "self_ns": 101180365
-            },
-            {
-              "calls": 95237,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
-              "self_ns": 147346544
-            },
-            {
-              "calls": 159376,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
-              "self_ns": 209983829
-            },
-            {
-              "calls": 3368,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.constrData",
-              "self_ns": 3953725
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
-              "self_ns": 18542
-            },
-            {
-              "calls": 15,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
-              "self_ns": 777000
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
-              "self_ns": 108333
-            },
-            {
-              "calls": 19,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
-              "self_ns": 171875
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
-              "self_ns": 95334
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
-              "self_ns": 310374
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
-              "self_ns": 968210
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
-              "self_ns": 469082
-            },
-            {
-              "calls": 1990,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
-              "self_ns": 2502836
-            },
-            {
-              "calls": 790,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.iData",
-              "self_ns": 1163531
-            },
-            {
-              "calls": 1156,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
-              "self_ns": 1505002
-            },
-            {
-              "calls": 2762,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unBData",
-              "self_ns": 3266754
-            },
-            {
-              "calls": 1387,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unBData.match_1",
-              "self_ns": 46512573
-            },
-            {
-              "calls": 20160,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unConstrData",
-              "self_ns": 20385707
-            },
-            {
-              "calls": 10086,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unConstrData.match_1",
-              "self_ns": 89735616
-            },
-            {
-              "calls": 3012,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unIData",
-              "self_ns": 3388058
-            },
-            {
-              "calls": 1512,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unIData.match_1",
-              "self_ns": 19099251
-            },
-            {
-              "calls": 16,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unListData",
-              "self_ns": 59332
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unListData.match_1",
-              "self_ns": 151377
-            },
-            {
-              "calls": 3400,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unMapData",
-              "self_ns": 4077673
-            },
-            {
-              "calls": 1706,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.unMapData.match_1",
-              "self_ns": 51478037
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
-              "self_ns": 3250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Integer.Integer",
-              "self_ns": 5292
-            },
-            {
-              "calls": 9492,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
-              "self_ns": 9858606
-            },
-            {
-              "calls": 2500,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
-              "self_ns": 3136636
-            },
-            {
-              "calls": 7476,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.headList",
-              "self_ns": 21196233
-            },
-            {
-              "calls": 22868,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.headList.match_1",
-              "self_ns": 219801264
-            },
-            {
-              "calls": 1690,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
-              "self_ns": 6156896
-            },
-            {
-              "calls": 4505,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.tailList",
-              "self_ns": 12535662
-            },
-            {
-              "calls": 6440,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
-              "self_ns": 21315060
-            },
-            {
-              "calls": 6223,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
-              "self_ns": 20858241
-            },
-            {
-              "calls": 18442,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
-              "self_ns": 20195443
-            },
-            {
-              "calls": 9226,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
-              "self_ns": 45897118
-            },
-            {
-              "calls": 1130,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
-              "self_ns": 6897908
-            },
-            {
-              "calls": 2250,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
-              "self_ns": 2853784
-            },
-            {
-              "calls": 3368,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.constrData",
-              "self_ns": 4026174
-            },
-            {
-              "calls": 1689,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.constrData.match_1",
-              "self_ns": 9027552
-            },
-            {
-              "calls": 1990,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
-              "self_ns": 2755631
-            },
-            {
-              "calls": 1000,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
-              "self_ns": 5816003
-            },
-            {
-              "calls": 790,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.iData",
-              "self_ns": 1231811
-            },
-            {
-              "calls": 400,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.iData.match_1",
-              "self_ns": 2750281
-            },
-            {
-              "calls": 1156,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
-              "self_ns": 1701964
-            },
-            {
-              "calls": 583,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
-              "self_ns": 3324678
-            },
-            {
-              "calls": 2762,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
-              "self_ns": 3102919
-            },
-            {
-              "calls": 20160,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
-              "self_ns": 21944373
-            },
-            {
-              "calls": 20166,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
-              "self_ns": 45388061
-            },
-            {
-              "calls": 14681,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
-              "self_ns": 66266295
-            },
-            {
-              "calls": 3012,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
-              "self_ns": 3375233
-            },
-            {
-              "calls": 16,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
-              "self_ns": 59540
-            },
-            {
-              "calls": 3400,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
-              "self_ns": 4178351
-            },
-            {
-              "calls": 129020,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
-              "self_ns": 130548952
-            },
-            {
-              "calls": 64603,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
-              "self_ns": 1535561329
-            },
-            {
-              "calls": 6001,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
-              "self_ns": 28603816
-            },
-            {
-              "calls": 9492,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
-              "self_ns": 10304357
-            },
-            {
-              "calls": 2500,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
-              "self_ns": 3094015
-            },
-            {
-              "calls": 7024,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
-              "self_ns": 8233132
-            },
-            {
-              "calls": 3519,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
-              "self_ns": 23116543
-            },
-            {
-              "calls": 14950,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
-              "self_ns": 15853910
-            },
-            {
-              "calls": 11986,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_1",
-              "self_ns": 62210716
-            },
-            {
-              "calls": 3378,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
-              "self_ns": 4072348
-            },
-            {
-              "calls": 1696,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
-              "self_ns": 11706180
-            },
-            {
-              "calls": 9008,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
-              "self_ns": 10079733
-            },
-            {
-              "calls": 12878,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
-              "self_ns": 13230291
-            },
-            {
-              "calls": 12667,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
-              "self_ns": 60356151
-            },
-            {
-              "calls": 12444,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
-              "self_ns": 12877493
-            },
-            {
-              "calls": 26656,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Utils.tryCatchSome",
-              "self_ns": 93379171
-            },
-            {
-              "calls": 45567,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Utils.tryCatchSome.match_1",
-              "self_ns": 328464967
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
-              "self_ns": 1875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
-              "self_ns": 1250
-            },
-            {
-              "calls": 17,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
-              "self_ns": 29543
-            },
-            {
-              "calls": 8,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
-              "self_ns": 13708
-            },
-            {
-              "calls": 53626,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
-              "self_ns": 50710000
-            },
-            {
-              "calls": 26906,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
-              "self_ns": 279535297
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame",
-              "self_ns": 1375
-            },
-            {
-              "calls": 40,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
-              "self_ns": 37461
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
-              "self_ns": 14541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
-              "self_ns": 1167
-            },
-            {
-              "calls": 226557,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
-              "self_ns": 503566186
-            },
-            {
-              "calls": 7,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
-              "self_ns": 9876
-            },
-            {
-              "calls": 189807,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
-              "self_ns": 327855980
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State",
-              "self_ns": 2833
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State.Error",
-              "self_ns": 1250
-            },
-            {
-              "calls": 376465,
-              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
-              "self_ns": 1191719463
-            },
-            {
-              "calls": 520,
-              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
-              "self_ns": 1202412
-            },
-            {
-              "calls": 316974,
-              "head": "PlutusCore.UPLC.CekMachine.State.Return",
-              "self_ns": 822480378
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.UPLC.CekMachine.applyParams",
-              "self_ns": 3145834
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.UPLC.CekMachine.applyParams.match_1",
-              "self_ns": 133247
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
-              "self_ns": 895459
-            },
-            {
-              "calls": 4,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
-              "self_ns": 81416
-            },
-            {
-              "calls": 129020,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
-              "self_ns": 126241495
-            },
-            {
-              "calls": 89863,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
-              "self_ns": 1445646222
-            },
-            {
-              "calls": 40,
-              "head": "PlutusCore.UPLC.CekMachine.ifArgQOtherwiseError",
-              "self_ns": 66081
-            },
-            {
-              "calls": 44,
-              "head": "PlutusCore.UPLC.CekMachine.ifArgQOtherwiseError.match_1",
-              "self_ns": 135130
-            },
-            {
-              "calls": 204464,
-              "head": "PlutusCore.UPLC.CekMachine.ifArgVOtherwiseError",
-              "self_ns": 210130567
-            },
-            {
-              "calls": 204468,
-              "head": "PlutusCore.UPLC.CekMachine.ifArgVOtherwiseError.match_1",
-              "self_ns": 291714673
-            },
-            {
-              "calls": 830754,
-              "head": "PlutusCore.UPLC.CekMachine.ifBoundOtherwiseError",
-              "self_ns": 3613749652
-            },
-            {
-              "calls": 830757,
-              "head": "PlutusCore.UPLC.CekMachine.ifBoundOtherwiseError.match_1",
-              "self_ns": 2153678537
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.CekMachine.initialState",
-              "self_ns": 12000
-            },
-            {
-              "calls": 710456,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps",
-              "self_ns": 3521115526
-            },
-            {
-              "calls": 698614,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
-              "self_ns": 2307349832
-            },
-            {
-              "calls": 1377878,
-              "head": "PlutusCore.UPLC.CekMachine.step",
-              "self_ns": 1265124235
-            },
-            {
-              "calls": 688980,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
-              "self_ns": 3531131250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekValue.CekValue",
-              "self_ns": 1209
-            },
-            {
-              "calls": 73958,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
-              "self_ns": 384024287
-            },
-            {
-              "calls": 275737,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
-              "self_ns": 457925693
-            },
-            {
-              "calls": 4,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
-              "self_ns": 7875
-            },
-            {
-              "calls": 38570,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
-              "self_ns": 88719048
-            },
-            {
-              "calls": 139689,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
-              "self_ns": 329118001
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekValue.Environment",
-              "self_ns": 2167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekValue.Environment.EmptyEnvironment",
-              "self_ns": 1208
-            },
-            {
-              "calls": 368802,
-              "head": "PlutusCore.UPLC.CekValue.Environment.NonEmptyEnvironment",
-              "self_ns": 921546795
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV2",
-              "self_ns": 1208
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
-              "self_ns": 11792
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun",
-              "self_ns": 2250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
-              "self_ns": 1916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
-              "self_ns": 917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
-              "self_ns": 750
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
-              "self_ns": 833
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
-              "self_ns": 4458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
-              "self_ns": 792
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
-              "self_ns": 833
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
-              "self_ns": 1667
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
-              "self_ns": 917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
-              "self_ns": 916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
-              "self_ns": 2167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
-              "self_ns": 916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
-              "self_ns": 917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
-              "self_ns": 916
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
-              "self_ns": 4250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
-              "self_ns": 1875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
-              "self_ns": 791
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
-              "self_ns": 2292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
-              "self_ns": 958
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
-              "self_ns": 917
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const",
-              "self_ns": 4667
-            },
-            {
-              "calls": 8121,
-              "head": "PlutusCore.UPLC.Term.Const.Bool",
-              "self_ns": 17773782
-            },
-            {
-              "calls": 9654,
-              "head": "PlutusCore.UPLC.Term.Const.ByteString",
-              "self_ns": 12656793
-            },
-            {
-              "calls": 88333,
-              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
-              "self_ns": 152139061
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.UPLC.Term.Const.ConstList",
-              "self_ns": 15583
-            },
-            {
-              "calls": 29780,
-              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
-              "self_ns": 45814117
-            },
-            {
-              "calls": 150182,
-              "head": "PlutusCore.UPLC.Term.Const.Data",
-              "self_ns": 216141045
-            },
-            {
-              "calls": 24359,
-              "head": "PlutusCore.UPLC.Term.Const.Integer",
-              "self_ns": 41766428
-            },
-            {
-              "calls": 10086,
-              "head": "PlutusCore.UPLC.Term.Const.Pair",
-              "self_ns": 18373114
-            },
-            {
-              "calls": 8029,
-              "head": "PlutusCore.UPLC.Term.Const.PairData",
-              "self_ns": 11062182
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const.Unit",
-              "self_ns": 5208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Program",
-              "self_ns": 1250
-            },
-            {
-              "calls": 5,
-              "head": "PlutusCore.UPLC.Term.Program.Program",
-              "self_ns": 20500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term",
-              "self_ns": 875
-            },
-            {
-              "calls": 276,
-              "head": "PlutusCore.UPLC.Term.Term.Apply",
-              "self_ns": 524125
-            },
-            {
-              "calls": 22,
-              "head": "PlutusCore.UPLC.Term.Term.Builtin",
-              "self_ns": 40919
-            },
-            {
-              "calls": 4,
-              "head": "PlutusCore.UPLC.Term.Term.Case",
-              "self_ns": 10583
-            },
-            {
-              "calls": 14,
-              "head": "PlutusCore.UPLC.Term.Term.Const",
-              "self_ns": 27586
-            },
-            {
-              "calls": 5,
-              "head": "PlutusCore.UPLC.Term.Term.Constr",
-              "self_ns": 15167
-            },
-            {
-              "calls": 35,
-              "head": "PlutusCore.UPLC.Term.Term.Delay",
-              "self_ns": 54376
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term.Error",
-              "self_ns": 875
-            },
-            {
-              "calls": 40,
-              "head": "PlutusCore.UPLC.Term.Term.Force",
-              "self_ns": 62004
-            },
-            {
-              "calls": 124,
-              "head": "PlutusCore.UPLC.Term.Term.Lam",
-              "self_ns": 312325
-            },
-            {
-              "calls": 35,
-              "head": "PlutusCore.UPLC.Term.Term.Var",
-              "self_ns": 52333
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.Term.Version.Version",
-              "self_ns": 9958
-            },
-            {
-              "calls": 6,
-              "head": "Prod",
-              "self_ns": 18208
-            },
-            {
-              "calls": 9234,
-              "head": "Prod.fst",
-              "self_ns": 43449072
-            },
-            {
-              "calls": 22710,
-              "head": "Prod.mk",
-              "self_ns": 61466150
-            },
-            {
-              "calls": 8764,
-              "head": "Prod.snd",
-              "self_ns": 51836103
-            },
-            {
-              "calls": 38093,
-              "head": "Pure.pure",
-              "self_ns": 175820515
-            },
-            {
-              "calls": 1,
-              "head": "String",
-              "self_ns": 1708
-            },
-            {
-              "calls": 13,
-              "head": "_normalizer",
-              "self_ns": 56724376
-            },
-            {
-              "calls": 2,
-              "head": "instBEqOfDecidableEq",
-              "self_ns": 23500
-            },
-            {
-              "calls": 2,
-              "head": "instHMul",
-              "self_ns": 21667
-            },
-            {
-              "calls": 1,
-              "head": "instLTNat",
-              "self_ns": 4292
-            },
-            {
-              "calls": 2,
-              "head": "instMonadExceptOfExcept",
-              "self_ns": 13125
-            },
-            {
-              "calls": 2,
-              "head": "instMonadExceptOfMonadExceptOf",
-              "self_ns": 19250
-            },
-            {
-              "calls": 13,
-              "head": "instOfNat",
-              "self_ns": 23958
-            },
-            {
-              "calls": 5,
-              "head": "instOfNatNat",
-              "self_ns": 17916
-            },
-            {
-              "calls": 843487,
-              "head": "ite",
-              "self_ns": 971987370
-            },
-            {
-              "calls": 1,
-              "head": "sellNFT",
-              "self_ns": 306375
-            },
-            {
-              "calls": 1804,
-              "head": "throwThe",
-              "self_ns": 7627288
-            }
+            {"calls": 7, "head": "And", "self_ns": 68500},
+            {"calls": 2, "head": "Applicative.toPure", "self_ns": 15292},
+            {"calls": 6876, "head": "BEq.beq", "self_ns": 113864392},
+            {"calls": 1251, "head": "Blaster.decide'", "self_ns": 4661582},
+            {"calls": 2524270, "head": "Blaster.dite'", "self_ns": 3035707745},
+            {"calls": 1, "head": "Bool", "self_ns": 2333},
+            {"calls": 7, "head": "Bool.and", "self_ns": 60709},
+            {"calls": 1, "head": "Bool.false", "self_ns": 1167},
+            {"calls": 1, "head": "Bool.true", "self_ns": 1667},
+            {"calls": 97, "head": "CardanoLedgerApi.IsData.Class.IsData.toData", "self_ns": 774619},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataData", "self_ns": 3458},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger", "self_ns": 2625},
+            {"calls": 3, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption", "self_ns": 16375},
+            {"calls": 74, "head": "CardanoLedgerApi.IsData.Class.mkDataConstr", "self_ns": 109419},
+            {"calls": 7, "head": "CardanoLedgerApi.IsData.Class.optionToData", "self_ns": 195167},
+            {"calls": 10, "head": "CardanoLedgerApi.IsData.Class.optionToData.match_1", "self_ns": 179877},
+            {"calls": 4, "head": "CardanoLedgerApi.IsData.Class.toTerm", "self_ns": 37583},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.Address", "self_ns": 1791},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressCredential", "self_ns": 15084},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential", "self_ns": 14625},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.instIsDataAddress", "self_ns": 2542},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose", "self_ns": 1208},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Certifying", "self_ns": 6875},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Minting", "self_ns": 10375},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Rewarding", "self_ns": 7250},
+            {"calls": 5, "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Spending", "self_ns": 11043},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.instIsDataListDCert", "self_ns": 3250},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash", "self_ns": 3000},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.instIsDataScriptPurpose", "self_ns": 3833},
+            {"calls": 10, "head": "CardanoLedgerApi.V1.Contexts.instReprScriptPurpose.repr.match_1", "self_ns": 262624},
+            {"calls": 4, "head": "CardanoLedgerApi.V1.Contexts.scriptPurposeToData", "self_ns": 113166},
+            {"calls": 2, "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData", "self_ns": 13501},
+            {"calls": 38109, "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData.go._@.CardanoLedgerApi.V1.Contexts.2955701632._hygCtx._hyg.14", "self_ns": 77082129},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData.match_1", "self_ns": 155707},
+            {"calls": 2, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData", "self_ns": 12208},
+            {"calls": 38095, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 75102550},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 153542},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.Credential", "self_ns": 1708},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential", "self_ns": 7500},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential", "self_ns": 6834},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.PubKeyHash", "self_ns": 6625},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.StakingCredential", "self_ns": 1375},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash", "self_ns": 6041},
+            {"calls": 5, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr", "self_ns": 10417},
+            {"calls": 5, "head": "CardanoLedgerApi.V1.Credential.credentialToData", "self_ns": 78958},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential", "self_ns": 2833},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataPubKeyHash", "self_ns": 2541},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential", "self_ns": 2500},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1", "self_ns": 169415},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1", "self_ns": 136043},
+            {"calls": 11, "head": "CardanoLedgerApi.V1.Credential.stakingCredentialToData", "self_ns": 117083},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.DCert.DCert", "self_ns": 2250},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegDeRegKey", "self_ns": 6459},
+            {"calls": 4, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegDelegate", "self_ns": 9250},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegRegKey", "self_ns": 7417},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertGenesis", "self_ns": 1250},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertMir", "self_ns": 958},
+            {"calls": 4, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertPoolRegister", "self_ns": 8333},
+            {"calls": 4, "head": "CardanoLedgerApi.V1.DCert.DCert.DCertPoolRetire", "self_ns": 8083},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.DCert.instIsDataDCert", "self_ns": 3458},
+            {"calls": 12, "head": "CardanoLedgerApi.V1.DCert.instReprDCert.repr.match_1", "self_ns": 584502},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Datum", "self_ns": 6709},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.DatumHash", "self_ns": 4709},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Redeemer", "self_ns": 6250},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.ScriptHash", "self_ns": 5375},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.TxId", "self_ns": 6708},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.TxOutRef", "self_ns": 1417},
+            {"calls": 12, "head": "CardanoLedgerApi.V1.Tx.TxOutRef.txOutRefId", "self_ns": 20626},
+            {"calls": 12, "head": "CardanoLedgerApi.V1.Tx.TxOutRef.txOutRefIdx", "self_ns": 21458},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId", "self_ns": 2500},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.instIsDataTxOutRef", "self_ns": 3125},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.CurrencySymbol", "self_ns": 6708},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.Value", "self_ns": 13125},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.instIsDataValue", "self_ns": 3042},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.DatumMap", "self_ns": 17666},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.RedeemerMap", "self_ns": 9083},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.ScriptContext", "self_ns": 1167},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Contexts.ScriptContext.scriptContextPurpose", "self_ns": 17917},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.ScriptContext.scriptContextTxInfo", "self_ns": 19458},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.ScriptPurpose", "self_ns": 9501},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.SpendingInput", "self_ns": 1416},
+            {"calls": 9, "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.ctx", "self_ns": 20917},
+            {"calls": 5, "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.datum", "self_ns": 13625},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.redeemer", "self_ns": 12750},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.TxInInfo", "self_ns": 1250},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInInfo.txInInfoOutRef", "self_ns": 19375},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInInfo.txInInfoResolved", "self_ns": 10667},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.TxInfo", "self_ns": 1583},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoDCert", "self_ns": 15334},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoData", "self_ns": 15625},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoFee", "self_ns": 14375},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoId", "self_ns": 14375},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoInputs", "self_ns": 11916},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoMint", "self_ns": 11000},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoOutputs", "self_ns": 11917},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoRedeemers", "self_ns": 13125},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoReferenceInputs", "self_ns": 11583},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoSignatories", "self_ns": 11334},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoValidRange", "self_ns": 12750},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoWdrl", "self_ns": 24750},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.Withdrawals", "self_ns": 12376},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.findOwnInput.match_1", "self_ns": 194665},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap", "self_ns": 2709},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxInInfo", "self_ns": 2833},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut", "self_ns": 2958},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataRedeemerMap", "self_ns": 3000},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataScriptContext", "self_ns": 3458},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataTxInInfo", "self_ns": 7459},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataTxInfo", "self_ns": 2542},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataWithdrawals", "self_ns": 2625},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.spendingInputs", "self_ns": 37582},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData", "self_ns": 13083},
+            {"calls": 38095, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19", "self_ns": 72313494},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1", "self_ns": 180791},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData", "self_ns": 18000},
+            {"calls": 114276, "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V2.Contexts.2536880513._hygCtx._hyg.14", "self_ns": 188116528},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData.match_1", "self_ns": 190166},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData", "self_ns": 12791},
+            {"calls": 249, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14", "self_ns": 3405377},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1", "self_ns": 158834},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData", "self_ns": 12833},
+            {"calls": 38095, "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V2.Contexts.2123419846._hygCtx._hyg.19", "self_ns": 73705743},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData.match_1", "self_ns": 174543},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData", "self_ns": 11999},
+            {"calls": 38095, "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData.go._@.CardanoLedgerApi.V2.Contexts.2635151150._hygCtx._hyg.19", "self_ns": 76127107},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData.match_1", "self_ns": 161249},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum", "self_ns": 1417},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum", "self_ns": 1125},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum", "self_ns": 7292},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash", "self_ns": 9833},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.TxId", "self_ns": 9042},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.TxOut", "self_ns": 1208},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress", "self_ns": 16376},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum", "self_ns": 12167},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript", "self_ns": 17750},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue", "self_ns": 13458},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.TxOutRef", "self_ns": 11166},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum", "self_ns": 2250},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut", "self_ns": 2916},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1", "self_ns": 139874},
+            {"calls": 4, "head": "CardanoLedgerApi.V2.Tx.outputDatumToData", "self_ns": 64249},
+            {"calls": 1251, "head": "Decidable.decide", "self_ns": 1797259},
+            {"calls": 845568, "head": "Eq", "self_ns": 2190667098},
+            {"calls": 1807, "head": "Except", "self_ns": 4006637},
+            {"calls": 1806, "head": "Except.error", "self_ns": 5338930},
+            {"calls": 2, "head": "Except.instMonad", "self_ns": 11833},
+            {"calls": 26657, "head": "Except.ok", "self_ns": 76641332},
+            {"calls": 26655, "head": "Except.pure", "self_ns": 86506106},
+            {"calls": 37, "head": "Function.comp", "self_ns": 131667},
+            {"calls": 3, "head": "HMul.hMul", "self_ns": 61958},
+            {"calls": 2, "head": "Inhabited.default", "self_ns": 30459},
+            {"calls": 1, "head": "Int", "self_ns": 3500},
+            {"calls": 1, "head": "Int.instDecidableEq", "self_ns": 10000},
+            {"calls": 1, "head": "Int.instLEInt", "self_ns": 4625},
+            {"calls": 1, "head": "Int.instLTInt", "self_ns": 4083},
+            {"calls": 1, "head": "Int.instMul", "self_ns": 3458},
+            {"calls": 2, "head": "Int.mul", "self_ns": 18833},
+            {"calls": 7, "head": "Int.negOfNat.match_1", "self_ns": 134709},
+            {"calls": 8, "head": "Int.ofNat", "self_ns": 34124},
+            {"calls": 3, "head": "Int.pow", "self_ns": 7750},
+            {"calls": 1251, "head": "LE.le", "self_ns": 8075052},
+            {"calls": 1259, "head": "LT.lt", "self_ns": 11143843},
+            {"calls": 9831, "head": "List", "self_ns": 16070832},
+            {"calls": 1440138, "head": "List.cons", "self_ns": 3146221226},
+            {"calls": 15504, "head": "List.getLast?.match_1", "self_ns": 240998653},
+            {"calls": 3513, "head": "List.isEmpty", "self_ns": 11071230},
+            {"calls": 16, "head": "List.nil", "self_ns": 53164},
+            {"calls": 2, "head": "Monad.toApplicative", "self_ns": 14542},
+            {"calls": 1809, "head": "MonadExcept.throw", "self_ns": 13003705},
+            {"calls": 1804, "head": "MonadExceptOf.throw", "self_ns": 11383642},
+            {"calls": 2, "head": "Mul.mul", "self_ns": 29167},
+            {"calls": 1, "head": "Nat", "self_ns": 52166},
+            {"calls": 25, "head": "Nat.add", "self_ns": 101584},
+            {"calls": 12, "head": "Nat.add.match_1", "self_ns": 311791},
+            {"calls": 2, "head": "Nat.beq", "self_ns": 5916},
+            {"calls": 14, "head": "Nat.beq.match_1", "self_ns": 319293},
+            {"calls": 2, "head": "Nat.ble", "self_ns": 7333},
+            {"calls": 4, "head": "Nat.mul", "self_ns": 28958},
+            {"calls": 12, "head": "Nat.mul.match_1", "self_ns": 226376},
+            {"calls": 3, "head": "Nat.pow", "self_ns": 8542},
+            {"calls": 6, "head": "Nat.pow.match_1", "self_ns": 135960},
+            {"calls": 2, "head": "Nat.pred", "self_ns": 6959},
+            {"calls": 32, "head": "Nat.sub", "self_ns": 4078876},
+            {"calls": 11, "head": "Nat.succ", "self_ns": 48706},
+            {"calls": 1, "head": "Nat.zero", "self_ns": 2459},
+            {"calls": 1255, "head": "Not", "self_ns": 4246989},
+            {"calls": 13, "head": "OfNat.ofNat", "self_ns": 187584},
+            {"calls": 6309, "head": "Option", "self_ns": 11646877},
+            {"calls": 6306, "head": "Option.none", "self_ns": 12680875},
+            {"calls": 103911, "head": "Option.some", "self_ns": 584884122},
+            {"calls": 9222, "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse", "self_ns": 33100919},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString", "self_ns": 4500},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString", "self_ns": 1292},
+            {"calls": 3, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk", "self_ns": 5958},
+            {"calls": 2250, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString", "self_ns": 3076555},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData", "self_ns": 8166},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data", "self_ns": 1209},
+            {"calls": 144397, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B", "self_ns": 160828009},
+            {"calls": 303016, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr", "self_ns": 519319213},
+            {"calls": 98044, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I", "self_ns": 101180365},
+            {"calls": 95237, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List", "self_ns": 147346544},
+            {"calls": 159376, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map", "self_ns": 209983829},
+            {"calls": 3368, "head": "PlutusCore.Data.PlutusCore.DataInternal.constrData", "self_ns": 3953725},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData", "self_ns": 18542},
+            {"calls": 15, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1", "self_ns": 777000},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr", "self_ns": 108333},
+            {"calls": 19, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1", "self_ns": 171875},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList", "self_ns": 95334},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1", "self_ns": 310374},
+            {"calls": 9, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap", "self_ns": 968210},
+            {"calls": 12, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1", "self_ns": 469082},
+            {"calls": 1990, "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData", "self_ns": 2502836},
+            {"calls": 790, "head": "PlutusCore.Data.PlutusCore.DataInternal.iData", "self_ns": 1163531},
+            {"calls": 1156, "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData", "self_ns": 1505002},
+            {"calls": 2762, "head": "PlutusCore.Data.PlutusCore.DataInternal.unBData", "self_ns": 3266754},
+            {"calls": 1387, "head": "PlutusCore.Data.PlutusCore.DataInternal.unBData.match_1", "self_ns": 46512573},
+            {"calls": 20160, "head": "PlutusCore.Data.PlutusCore.DataInternal.unConstrData", "self_ns": 20385707},
+            {"calls": 10086, "head": "PlutusCore.Data.PlutusCore.DataInternal.unConstrData.match_1", "self_ns": 89735616},
+            {"calls": 3012, "head": "PlutusCore.Data.PlutusCore.DataInternal.unIData", "self_ns": 3388058},
+            {"calls": 1512, "head": "PlutusCore.Data.PlutusCore.DataInternal.unIData.match_1", "self_ns": 19099251},
+            {"calls": 16, "head": "PlutusCore.Data.PlutusCore.DataInternal.unListData", "self_ns": 59332},
+            {"calls": 13, "head": "PlutusCore.Data.PlutusCore.DataInternal.unListData.match_1", "self_ns": 151377},
+            {"calls": 3400, "head": "PlutusCore.Data.PlutusCore.DataInternal.unMapData", "self_ns": 4077673},
+            {"calls": 1706, "head": "PlutusCore.Data.PlutusCore.DataInternal.unMapData.match_1", "self_ns": 51478037},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant", "self_ns": 3250},
+            {"calls": 1, "head": "PlutusCore.Integer.Integer", "self_ns": 5292},
+            {"calls": 9492, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger", "self_ns": 9858606},
+            {"calls": 2500, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger", "self_ns": 3136636},
+            {"calls": 7476, "head": "PlutusCore.List.PlutusCore.ListInternal.headList", "self_ns": 21196233},
+            {"calls": 22868, "head": "PlutusCore.List.PlutusCore.ListInternal.headList.match_1", "self_ns": 219801264},
+            {"calls": 1690, "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons", "self_ns": 6156896},
+            {"calls": 4505, "head": "PlutusCore.List.PlutusCore.ListInternal.tailList", "self_ns": 12535662},
+            {"calls": 6440, "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair", "self_ns": 21315060},
+            {"calls": 6223, "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair", "self_ns": 20858241},
+            {"calls": 18442, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse", "self_ns": 20195443},
+            {"calls": 9226, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1", "self_ns": 45897118},
+            {"calls": 1130, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1", "self_ns": 6897908},
+            {"calls": 2250, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString", "self_ns": 2853784},
+            {"calls": 3368, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.constrData", "self_ns": 4026174},
+            {"calls": 1689, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.constrData.match_1", "self_ns": 9027552},
+            {"calls": 1990, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData", "self_ns": 2755631},
+            {"calls": 1000, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1", "self_ns": 5816003},
+            {"calls": 790, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.iData", "self_ns": 1231811},
+            {"calls": 400, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.iData.match_1", "self_ns": 2750281},
+            {"calls": 1156, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData", "self_ns": 1701964},
+            {"calls": 583, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1", "self_ns": 3324678},
+            {"calls": 2762, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData", "self_ns": 3102919},
+            {"calls": 20160, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData", "self_ns": 21944373},
+            {"calls": 20166, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1", "self_ns": 45388061},
+            {"calls": 14681, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3", "self_ns": 66266295},
+            {"calls": 3012, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData", "self_ns": 3375233},
+            {"calls": 16, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData", "self_ns": 59540},
+            {"calls": 3400, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData", "self_ns": 4178351},
+            {"calls": 129020, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction", "self_ns": 130548952},
+            {"calls": 64603, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1", "self_ns": 1535561329},
+            {"calls": 6001, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1", "self_ns": 28603816},
+            {"calls": 9492, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger", "self_ns": 10304357},
+            {"calls": 2500, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger", "self_ns": 3094015},
+            {"calls": 7024, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList", "self_ns": 8233132},
+            {"calls": 3519, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1", "self_ns": 23116543},
+            {"calls": 14950, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList", "self_ns": 15853910},
+            {"calls": 11986, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_1", "self_ns": 62210716},
+            {"calls": 3378, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons", "self_ns": 4072348},
+            {"calls": 1696, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1", "self_ns": 11706180},
+            {"calls": 9008, "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList", "self_ns": 10079733},
+            {"calls": 12878, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair", "self_ns": 13230291},
+            {"calls": 12667, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1", "self_ns": 60356151},
+            {"calls": 12444, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair", "self_ns": 12877493},
+            {"calls": 26656, "head": "PlutusCore.UPLC.BuiltinFunctions.Utils.tryCatchSome", "self_ns": 93379171},
+            {"calls": 45567, "head": "PlutusCore.UPLC.BuiltinFunctions.Utils.tryCatchSome.match_1", "self_ns": 328464967},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ", "self_ns": 1875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV", "self_ns": 1250},
+            {"calls": 17, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More", "self_ns": 29543},
+            {"calls": 8, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One", "self_ns": 13708},
+            {"calls": 53626, "head": "PlutusCore.UPLC.Builtins.expectedArgs", "self_ns": 50710000},
+            {"calls": 26906, "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1", "self_ns": 279535297},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame", "self_ns": 1375},
+            {"calls": 40, "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee", "self_ns": 37461},
+            {"calls": 9, "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument", "self_ns": 14541},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame", "self_ns": 1167},
+            {"calls": 226557, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm", "self_ns": 503566186},
+            {"calls": 7, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue", "self_ns": 9876},
+            {"calls": 189807, "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue", "self_ns": 327855980},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State", "self_ns": 2833},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State.Error", "self_ns": 1250},
+            {"calls": 376465, "head": "PlutusCore.UPLC.CekMachine.State.Eval", "self_ns": 1191719463},
+            {"calls": 520, "head": "PlutusCore.UPLC.CekMachine.State.Halt", "self_ns": 1202412},
+            {"calls": 316974, "head": "PlutusCore.UPLC.CekMachine.State.Return", "self_ns": 822480378},
+            {"calls": 9, "head": "PlutusCore.UPLC.CekMachine.applyParams", "self_ns": 3145834},
+            {"calls": 12, "head": "PlutusCore.UPLC.CekMachine.applyParams.match_1", "self_ns": 133247},
+            {"calls": 3, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram", "self_ns": 895459},
+            {"calls": 4, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1", "self_ns": 81416},
+            {"calls": 129020, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin", "self_ns": 126241495},
+            {"calls": 89863, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1", "self_ns": 1445646222},
+            {"calls": 40, "head": "PlutusCore.UPLC.CekMachine.ifArgQOtherwiseError", "self_ns": 66081},
+            {"calls": 44, "head": "PlutusCore.UPLC.CekMachine.ifArgQOtherwiseError.match_1", "self_ns": 135130},
+            {"calls": 204464, "head": "PlutusCore.UPLC.CekMachine.ifArgVOtherwiseError", "self_ns": 210130567},
+            {"calls": 204468, "head": "PlutusCore.UPLC.CekMachine.ifArgVOtherwiseError.match_1", "self_ns": 291714673},
+            {"calls": 830754, "head": "PlutusCore.UPLC.CekMachine.ifBoundOtherwiseError", "self_ns": 3613749652},
+            {"calls": 830757, "head": "PlutusCore.UPLC.CekMachine.ifBoundOtherwiseError.match_1", "self_ns": 2153678537},
+            {"calls": 2, "head": "PlutusCore.UPLC.CekMachine.initialState", "self_ns": 12000},
+            {"calls": 710456, "head": "PlutusCore.UPLC.CekMachine.runSteps", "self_ns": 3521115526},
+            {"calls": 698614, "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1", "self_ns": 2307349832},
+            {"calls": 1377878, "head": "PlutusCore.UPLC.CekMachine.step", "self_ns": 1265124235},
+            {"calls": 688980, "head": "PlutusCore.UPLC.CekMachine.step.match_3", "self_ns": 3531131250},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekValue.CekValue", "self_ns": 1209},
+            {"calls": 73958, "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin", "self_ns": 384024287},
+            {"calls": 275737, "head": "PlutusCore.UPLC.CekValue.CekValue.VCon", "self_ns": 457925693},
+            {"calls": 4, "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr", "self_ns": 7875},
+            {"calls": 38570, "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay", "self_ns": 88719048},
+            {"calls": 139689, "head": "PlutusCore.UPLC.CekValue.CekValue.VLam", "self_ns": 329118001},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekValue.Environment", "self_ns": 2167},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekValue.Environment.EmptyEnvironment", "self_ns": 1208},
+            {"calls": 368802, "head": "PlutusCore.UPLC.CekValue.Environment.NonEmptyEnvironment", "self_ns": 921546795},
+            {"calls": 1, "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV2", "self_ns": 1208},
+            {"calls": 2, "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk", "self_ns": 11792},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun", "self_ns": 2250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger", "self_ns": 1916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString", "self_ns": 917},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.BData", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup", "self_ns": 750},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul", "self_ns": 833},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress", "self_ns": 4458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList", "self_ns": 792},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString", "self_ns": 833},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString", "self_ns": 1667},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData", "self_ns": 917},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData", "self_ns": 916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger", "self_ns": 2167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList", "self_ns": 916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IData", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString", "self_ns": 917},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger", "self_ns": 916},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData", "self_ns": 4250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger", "self_ns": 1875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData", "self_ns": 791},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData", "self_ns": 2292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData", "self_ns": 958},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData", "self_ns": 917},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const", "self_ns": 4667},
+            {"calls": 8121, "head": "PlutusCore.UPLC.Term.Const.Bool", "self_ns": 17773782},
+            {"calls": 9654, "head": "PlutusCore.UPLC.Term.Const.ByteString", "self_ns": 12656793},
+            {"calls": 88333, "head": "PlutusCore.UPLC.Term.Const.ConstDataList", "self_ns": 152139061},
+            {"calls": 9, "head": "PlutusCore.UPLC.Term.Const.ConstList", "self_ns": 15583},
+            {"calls": 29780, "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList", "self_ns": 45814117},
+            {"calls": 150182, "head": "PlutusCore.UPLC.Term.Const.Data", "self_ns": 216141045},
+            {"calls": 24359, "head": "PlutusCore.UPLC.Term.Const.Integer", "self_ns": 41766428},
+            {"calls": 10086, "head": "PlutusCore.UPLC.Term.Const.Pair", "self_ns": 18373114},
+            {"calls": 8029, "head": "PlutusCore.UPLC.Term.Const.PairData", "self_ns": 11062182},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const.Unit", "self_ns": 5208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Program", "self_ns": 1250},
+            {"calls": 5, "head": "PlutusCore.UPLC.Term.Program.Program", "self_ns": 20500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term", "self_ns": 875},
+            {"calls": 276, "head": "PlutusCore.UPLC.Term.Term.Apply", "self_ns": 524125},
+            {"calls": 22, "head": "PlutusCore.UPLC.Term.Term.Builtin", "self_ns": 40919},
+            {"calls": 4, "head": "PlutusCore.UPLC.Term.Term.Case", "self_ns": 10583},
+            {"calls": 14, "head": "PlutusCore.UPLC.Term.Term.Const", "self_ns": 27586},
+            {"calls": 5, "head": "PlutusCore.UPLC.Term.Term.Constr", "self_ns": 15167},
+            {"calls": 35, "head": "PlutusCore.UPLC.Term.Term.Delay", "self_ns": 54376},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term.Error", "self_ns": 875},
+            {"calls": 40, "head": "PlutusCore.UPLC.Term.Term.Force", "self_ns": 62004},
+            {"calls": 124, "head": "PlutusCore.UPLC.Term.Term.Lam", "self_ns": 312325},
+            {"calls": 35, "head": "PlutusCore.UPLC.Term.Term.Var", "self_ns": 52333},
+            {"calls": 2, "head": "PlutusCore.UPLC.Term.Version.Version", "self_ns": 9958},
+            {"calls": 6, "head": "Prod", "self_ns": 18208},
+            {"calls": 9234, "head": "Prod.fst", "self_ns": 43449072},
+            {"calls": 22710, "head": "Prod.mk", "self_ns": 61466150},
+            {"calls": 8764, "head": "Prod.snd", "self_ns": 51836103},
+            {"calls": 38093, "head": "Pure.pure", "self_ns": 175820515},
+            {"calls": 1, "head": "String", "self_ns": 1708},
+            {"calls": 13, "head": "_normalizer", "self_ns": 56724376},
+            {"calls": 2, "head": "instBEqOfDecidableEq", "self_ns": 23500},
+            {"calls": 2, "head": "instHMul", "self_ns": 21667},
+            {"calls": 1, "head": "instLTNat", "self_ns": 4292},
+            {"calls": 2, "head": "instMonadExceptOfExcept", "self_ns": 13125},
+            {"calls": 2, "head": "instMonadExceptOfMonadExceptOf", "self_ns": 19250},
+            {"calls": 13, "head": "instOfNat", "self_ns": 23958},
+            {"calls": 5, "head": "instOfNatNat", "self_ns": 17916},
+            {"calls": 843487, "head": "ite", "self_ns": 971987370},
+            {"calls": 1, "head": "sellNFT", "self_ns": 306375},
+            {"calls": 1804, "head": "throwThe", "self_ns": 7627288}
           ],
           "imbalances": 0,
           "schema": 1,

--- a/Benchmarks/cardano/results/attribution/normalization-attribution.json
+++ b/Benchmarks/cardano/results/attribution/normalization-attribution.json
@@ -1,0 +1,8264 @@
+{
+  "label": "normalization-attribution",
+  "repeat": 1,
+  "timeout_seconds": 300.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "6575b13cb65a060c03b31103f300d26acda80374",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "bc8ecf6013b195227b9f08b138b44650c2b2c4b19d820c01f8db36a1416cd7bb",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": true,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1400,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1400-1.log",
+      "sampled_peak_rss_bytes": 1826635776,
+      "prep": {
+        "optimize_ms": 12392,
+        "hashcons": 3131631,
+        "contexts": 22056,
+        "beta_cache": 560
+      },
+      "source_sha256": "bcd29ed31f80b0132e49b6976a0f9925ffc907fe451ca3dacccda30771955fb7",
+      "elapsed_seconds": 13.876142624998465,
+      "exit_code": 0,
+      "profiles": [
+        {
+          "active_frames": 0,
+          "cache_bypasses": 1884362,
+          "cache_hits": 7106208,
+          "cache_misses": 2893268,
+          "contexts": 22056,
+          "elapsed_ns": 12387123875,
+          "events": {
+            "Eq.choice_match": 796,
+            "List.cons.choice_ite": 2,
+            "List.cons.choice_match": 582,
+            "Option.some.choice_ite": 1,
+            "Option.some.choice_match": 925,
+            "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr.choice_match": 280,
+            "PlutusCore.UPLC.CekMachine.State.Eval.choice_match": 2,
+            "PlutusCore.UPLC.CekMachine.applyParams.choice_match": 2,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_ite": 1540,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_match": 7782,
+            "PlutusCore.UPLC.CekValue.CekValue.VCon.choice_match": 130,
+            "PlutusCore.UPLC.Term.Const.Bool.choice_match": 130,
+            "PlutusCore.UPLC.Term.Const.Data.choice_match": 1,
+            "PlutusCore.UPLC.Term.Term.Const.choice_match": 1,
+            "Prod.mk.choice_ite": 2,
+            "Prod.mk.choice_match": 46
+          },
+          "hashcons": 3131631,
+          "heads": [
+            {
+              "calls": 199,
+              "head": "Add.add",
+              "self_ns": 1433627
+            },
+            {
+              "calls": 8,
+              "head": "And",
+              "self_ns": 75541
+            },
+            {
+              "calls": 1919,
+              "head": "BEq.beq",
+              "self_ns": 42259883
+            },
+            {
+              "calls": 1219,
+              "head": "Blaster.decide'",
+              "self_ns": 3685124
+            },
+            {
+              "calls": 14202,
+              "head": "Blaster.dite'",
+              "self_ns": 124567098
+            },
+            {
+              "calls": 1,
+              "head": "Bool",
+              "self_ns": 2333
+            },
+            {
+              "calls": 63,
+              "head": "Bool.and",
+              "self_ns": 332923
+            },
+            {
+              "calls": 1,
+              "head": "Bool.false",
+              "self_ns": 1084
+            },
+            {
+              "calls": 143,
+              "head": "Bool.or",
+              "self_ns": 767002
+            },
+            {
+              "calls": 1,
+              "head": "Bool.true",
+              "self_ns": 1625
+            },
+            {
+              "calls": 239,
+              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
+              "self_ns": 1578385
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
+              "self_ns": 3208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
+              "self_ns": 2666
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
+              "self_ns": 17876
+            },
+            {
+              "calls": 15,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1",
+              "self_ns": 313711
+            },
+            {
+              "calls": 328,
+              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
+              "self_ns": 378045
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.IsData.Class.toTerm",
+              "self_ns": 34000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.Address",
+              "self_ns": 1541
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
+              "self_ns": 14459
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
+              "self_ns": 15499
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
+              "self_ns": 2459
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
+              "self_ns": 3542
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
+              "self_ns": 12708
+            },
+            {
+              "calls": 10665,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 33328196
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 170292
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.Credential",
+              "self_ns": 1166
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
+              "self_ns": 7250
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
+              "self_ns": 7000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
+              "self_ns": 6583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
+              "self_ns": 1208
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
+              "self_ns": 6583
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
+              "self_ns": 9459
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
+              "self_ns": 2791
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
+              "self_ns": 2500
+            },
+            {
+              "calls": 46,
+              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
+              "self_ns": 1031957
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
+              "self_ns": 158081
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Datum",
+              "self_ns": 4125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
+              "self_ns": 5541
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
+              "self_ns": 5583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
+              "self_ns": 4959
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
+              "self_ns": 3041
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
+              "self_ns": 9792
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.Value",
+              "self_ns": 8209
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
+              "self_ns": 2917
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
+              "self_ns": 10001
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
+              "self_ns": 3167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
+              "self_ns": 3833
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
+              "self_ns": 13583
+            },
+            {
+              "calls": 19989,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
+              "self_ns": 42584525
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
+              "self_ns": 157792
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
+              "self_ns": 14375
+            },
+            {
+              "calls": 17673,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
+              "self_ns": 110671315
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
+              "self_ns": 231833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
+              "self_ns": 1584
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
+              "self_ns": 1167
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
+              "self_ns": 6333
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
+              "self_ns": 6583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut",
+              "self_ns": 1208
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
+              "self_ns": 14791
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
+              "self_ns": 14751
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
+              "self_ns": 16333
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
+              "self_ns": 14875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
+              "self_ns": 2375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
+              "self_ns": 2834
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
+              "self_ns": 155708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap",
+              "self_ns": 5958
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.MintValue",
+              "self_ns": 7000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap",
+              "self_ns": 10750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext",
+              "self_ns": 1083
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer",
+              "self_ns": 12792
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo",
+              "self_ns": 19500
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo",
+              "self_ns": 11458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo",
+              "self_ns": 1333
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript",
+              "self_ns": 9209
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript",
+              "self_ns": 7250
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript",
+              "self_ns": 8083
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript",
+              "self_ns": 9542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript",
+              "self_ns": 10000
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript",
+              "self_ns": 5958
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose",
+              "self_ns": 1833
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying",
+              "self_ns": 8833
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting",
+              "self_ns": 7125
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing",
+              "self_ns": 8542
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding",
+              "self_ns": 6208
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending",
+              "self_ns": 6625
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting",
+              "self_ns": 6625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo",
+              "self_ns": 1417
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef",
+              "self_ns": 13167
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved",
+              "self_ns": 10416
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo",
+              "self_ns": 1458
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount",
+              "self_ns": 15625
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData",
+              "self_ns": 12625
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee",
+              "self_ns": 13959
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId",
+              "self_ns": 14000
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs",
+              "self_ns": 12042
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint",
+              "self_ns": 10958
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs",
+              "self_ns": 12250
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures",
+              "self_ns": 13959
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers",
+              "self_ns": 15417
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs",
+              "self_ns": 14084
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories",
+              "self_ns": 12292
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation",
+              "self_ns": 15708
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts",
+              "self_ns": 11041
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange",
+              "self_ns": 13834
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes",
+              "self_ns": 10959
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl",
+              "self_ns": 18250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.VoterMap",
+              "self_ns": 7708
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData",
+              "self_ns": 14750
+            },
+            {
+              "calls": 26,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19",
+              "self_ns": 3024500
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1",
+              "self_ns": 166585
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap",
+              "self_ns": 3208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure",
+              "self_ns": 3209
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert",
+              "self_ns": 3042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo",
+              "self_ns": 2667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap",
+              "self_ns": 3083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext",
+              "self_ns": 3417
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo",
+              "self_ns": 3125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose",
+              "self_ns": 3083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo",
+              "self_ns": 3042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo",
+              "self_ns": 2667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap",
+              "self_ns": 2708
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1",
+              "self_ns": 231625
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1",
+              "self_ns": 408918
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs",
+              "self_ns": 28333
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1",
+              "self_ns": 200041
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData",
+              "self_ns": 13707
+            },
+            {
+              "calls": 39304,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14",
+              "self_ns": 60824106
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1",
+              "self_ns": 281792
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData",
+              "self_ns": 19501
+            },
+            {
+              "calls": 19993,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14",
+              "self_ns": 40534431
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1",
+              "self_ns": 167668
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData",
+              "self_ns": 18750
+            },
+            {
+              "calls": 20127,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19",
+              "self_ns": 43625531
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1",
+              "self_ns": 251542
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData",
+              "self_ns": 12167
+            },
+            {
+              "calls": 20105,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14",
+              "self_ns": 40708348
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1",
+              "self_ns": 223125
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData",
+              "self_ns": 12084
+            },
+            {
+              "calls": 19999,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19",
+              "self_ns": 41461317
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1",
+              "self_ns": 173291
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId",
+              "self_ns": 1833
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx",
+              "self_ns": 14000
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId",
+              "self_ns": 14417
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure",
+              "self_ns": 1167
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit",
+              "self_ns": 16875
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction",
+              "self_ns": 14750
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr",
+              "self_ns": 14916
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Voter",
+              "self_ns": 1500
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter",
+              "self_ns": 6708
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter",
+              "self_ns": 5958
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter",
+              "self_ns": 5791
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Withdrawals",
+              "self_ns": 9501
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId",
+              "self_ns": 3208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers",
+              "self_ns": 3500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure",
+              "self_ns": 3166
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataVote",
+              "self_ns": 2833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter",
+              "self_ns": 3500
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1",
+              "self_ns": 106999
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1",
+              "self_ns": 189127
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData",
+              "self_ns": 14124
+            },
+            {
+              "calls": 161,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19",
+              "self_ns": 3493084
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1",
+              "self_ns": 148708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.TxId",
+              "self_ns": 6500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef",
+              "self_ns": 1333
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId",
+              "self_ns": 15125
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx",
+              "self_ns": 14333
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId",
+              "self_ns": 4209
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef",
+              "self_ns": 2583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential",
+              "self_ns": 6000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep",
+              "self_ns": 1333
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep",
+              "self_ns": 6292
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRepCredential",
+              "self_ns": 5291
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee",
+              "self_ns": 7792
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake",
+              "self_ns": 8833
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote",
+              "self_ns": 8333
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote",
+              "self_ns": 10042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential",
+              "self_ns": 4875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert",
+              "self_ns": 2083
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee",
+              "self_ns": 9292
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking",
+              "self_ns": 9458
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister",
+              "self_ns": 7875
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire",
+              "self_ns": 7792
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep",
+              "self_ns": 12000
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg",
+              "self_ns": 13833
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking",
+              "self_ns": 11750
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee",
+              "self_ns": 5875
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep",
+              "self_ns": 7958
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking",
+              "self_ns": 9625
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep",
+              "self_ns": 7833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep",
+              "self_ns": 2791
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee",
+              "self_ns": 2917
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert",
+              "self_ns": 4334
+            },
+            {
+              "calls": 14,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1",
+              "self_ns": 315582
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1",
+              "self_ns": 290750
+            },
+            {
+              "calls": 16,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1",
+              "self_ns": 1390792
+            },
+            {
+              "calls": 943,
+              "head": "Decidable.decide",
+              "self_ns": 1189548
+            },
+            {
+              "calls": 5904,
+              "head": "Eq",
+              "self_ns": 49272815
+            },
+            {
+              "calls": 13,
+              "head": "Function.comp",
+              "self_ns": 86500
+            },
+            {
+              "calls": 205,
+              "head": "HAdd.hAdd",
+              "self_ns": 1462458
+            },
+            {
+              "calls": 340,
+              "head": "HMul.hMul",
+              "self_ns": 1808666
+            },
+            {
+              "calls": 2,
+              "head": "HPow.hPow",
+              "self_ns": 52625
+            },
+            {
+              "calls": 2,
+              "head": "Inhabited.default",
+              "self_ns": 28125
+            },
+            {
+              "calls": 1,
+              "head": "Int",
+              "self_ns": 2375
+            },
+            {
+              "calls": 595,
+              "head": "Int.add",
+              "self_ns": 2038208
+            },
+            {
+              "calls": 1,
+              "head": "Int.instAdd",
+              "self_ns": 3667
+            },
+            {
+              "calls": 1,
+              "head": "Int.instDecidableEq",
+              "self_ns": 5542
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLEInt",
+              "self_ns": 4459
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLTInt",
+              "self_ns": 3833
+            },
+            {
+              "calls": 1,
+              "head": "Int.instMul",
+              "self_ns": 2833
+            },
+            {
+              "calls": 975,
+              "head": "Int.mul",
+              "self_ns": 2849256
+            },
+            {
+              "calls": 390,
+              "head": "Int.natAbs",
+              "self_ns": 502378
+            },
+            {
+              "calls": 197,
+              "head": "Int.neg",
+              "self_ns": 461737
+            },
+            {
+              "calls": 200,
+              "head": "Int.neg.match_1",
+              "self_ns": 7043491
+            },
+            {
+              "calls": 7,
+              "head": "Int.negOfNat.match_1",
+              "self_ns": 113834
+            },
+            {
+              "calls": 5,
+              "head": "Int.negSucc",
+              "self_ns": 16584
+            },
+            {
+              "calls": 15,
+              "head": "Int.ofNat",
+              "self_ns": 37126
+            },
+            {
+              "calls": 3,
+              "head": "Int.pow",
+              "self_ns": 7666
+            },
+            {
+              "calls": 595,
+              "head": "Int.toNat",
+              "self_ns": 1792286
+            },
+            {
+              "calls": 452,
+              "head": "LE.le",
+              "self_ns": 2513742
+            },
+            {
+              "calls": 2712,
+              "head": "LT.lt",
+              "self_ns": 11615843
+            },
+            {
+              "calls": 946,
+              "head": "List",
+              "self_ns": 1547758
+            },
+            {
+              "calls": 1303882,
+              "head": "List.cons",
+              "self_ns": 2572110066
+            },
+            {
+              "calls": 215,
+              "head": "List.drop",
+              "self_ns": 9421542
+            },
+            {
+              "calls": 34205,
+              "head": "List.get?Internal",
+              "self_ns": 150078295
+            },
+            {
+              "calls": 2718,
+              "head": "List.getLast?.match_1",
+              "self_ns": 35704345
+            },
+            {
+              "calls": 1791,
+              "head": "List.isEmpty",
+              "self_ns": 4967319
+            },
+            {
+              "calls": 4309,
+              "head": "List.nil",
+              "self_ns": 7127191
+            },
+            {
+              "calls": 4289,
+              "head": "List.reverse",
+              "self_ns": 12911672
+            },
+            {
+              "calls": 4289,
+              "head": "List.reverseAux",
+              "self_ns": 24380874
+            },
+            {
+              "calls": 20,
+              "head": "List.take.match_1",
+              "self_ns": 597835
+            },
+            {
+              "calls": 197,
+              "head": "Mul.mul",
+              "self_ns": 1384996
+            },
+            {
+              "calls": 1,
+              "head": "Nat",
+              "self_ns": 35625
+            },
+            {
+              "calls": 225,
+              "head": "Nat.add",
+              "self_ns": 915199
+            },
+            {
+              "calls": 12,
+              "head": "Nat.add.match_1",
+              "self_ns": 294168
+            },
+            {
+              "calls": 2,
+              "head": "Nat.beq",
+              "self_ns": 6500
+            },
+            {
+              "calls": 14,
+              "head": "Nat.beq.match_1",
+              "self_ns": 333959
+            },
+            {
+              "calls": 2,
+              "head": "Nat.ble",
+              "self_ns": 7167
+            },
+            {
+              "calls": 4,
+              "head": "Nat.mul",
+              "self_ns": 14708
+            },
+            {
+              "calls": 12,
+              "head": "Nat.mul.match_1",
+              "self_ns": 212126
+            },
+            {
+              "calls": 4,
+              "head": "Nat.pow",
+              "self_ns": 14624
+            },
+            {
+              "calls": 6,
+              "head": "Nat.pow.match_1",
+              "self_ns": 132750
+            },
+            {
+              "calls": 2,
+              "head": "Nat.pred",
+              "self_ns": 7542
+            },
+            {
+              "calls": 227,
+              "head": "Nat.sub",
+              "self_ns": 4226962
+            },
+            {
+              "calls": 208,
+              "head": "Nat.succ",
+              "self_ns": 352383
+            },
+            {
+              "calls": 1,
+              "head": "Nat.zero",
+              "self_ns": 2208
+            },
+            {
+              "calls": 2,
+              "head": "NatPow.pow",
+              "self_ns": 29501
+            },
+            {
+              "calls": 650,
+              "head": "Not",
+              "self_ns": 1893034
+            },
+            {
+              "calls": 21,
+              "head": "OfNat.ofNat",
+              "self_ns": 257666
+            },
+            {
+              "calls": 2043,
+              "head": "Option",
+              "self_ns": 3194044
+            },
+            {
+              "calls": 5596,
+              "head": "Option.getD.match_1",
+              "self_ns": 98020094
+            },
+            {
+              "calls": 1017,
+              "head": "Option.map",
+              "self_ns": 4102272
+            },
+            {
+              "calls": 1681,
+              "head": "Option.none",
+              "self_ns": 2987457
+            },
+            {
+              "calls": 29821,
+              "head": "Option.some",
+              "self_ns": 131919653
+            },
+            {
+              "calls": 74,
+              "head": "Or",
+              "self_ns": 538258
+            },
+            {
+              "calls": 2071,
+              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
+              "self_ns": 7912312
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
+              "self_ns": 3792
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
+              "self_ns": 1166
+            },
+            {
+              "calls": 3731,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data",
+              "self_ns": 3999032
+            },
+            {
+              "calls": 838,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length",
+              "self_ns": 836758
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
+              "self_ns": 6291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString",
+              "self_ns": 4041
+            },
+            {
+              "calls": 188,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
+              "self_ns": 284166
+            },
+            {
+              "calls": 204,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString",
+              "self_ns": 288516
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
+              "self_ns": 12875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
+              "self_ns": 1500
+            },
+            {
+              "calls": 72536,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
+              "self_ns": 78458741
+            },
+            {
+              "calls": 237385,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
+              "self_ns": 330078765
+            },
+            {
+              "calls": 55672,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
+              "self_ns": 62536235
+            },
+            {
+              "calls": 96949,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
+              "self_ns": 137956799
+            },
+            {
+              "calls": 65494,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
+              "self_ns": 154104237
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
+              "self_ns": 21500
+            },
+            {
+              "calls": 91,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
+              "self_ns": 1065920
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
+              "self_ns": 89791
+            },
+            {
+              "calls": 19,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
+              "self_ns": 171584
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
+              "self_ns": 73834
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
+              "self_ns": 308042
+            },
+            {
+              "calls": 85,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
+              "self_ns": 490584
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
+              "self_ns": 374708
+            },
+            {
+              "calls": 1140,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
+              "self_ns": 1422758
+            },
+            {
+              "calls": 1020,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
+              "self_ns": 1117008
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
+              "self_ns": 3542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Integer.Integer",
+              "self_ns": 6250
+            },
+            {
+              "calls": 16,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger",
+              "self_ns": 57541
+            },
+            {
+              "calls": 872,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
+              "self_ns": 1067082
+            },
+            {
+              "calls": 60,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
+              "self_ns": 101624
+            },
+            {
+              "calls": 73,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
+              "self_ns": 319416
+            },
+            {
+              "calls": 339,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.nullList",
+              "self_ns": 1050082
+            },
+            {
+              "calls": 805,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
+              "self_ns": 2757976
+            },
+            {
+              "calls": 1737,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
+              "self_ns": 5578044
+            },
+            {
+              "calls": 4140,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
+              "self_ns": 4542964
+            },
+            {
+              "calls": 2075,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
+              "self_ns": 9843347
+            },
+            {
+              "calls": 201,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
+              "self_ns": 1576669
+            },
+            {
+              "calls": 188,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
+              "self_ns": 275837
+            },
+            {
+              "calls": 204,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString",
+              "self_ns": 312158
+            },
+            {
+              "calls": 1140,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
+              "self_ns": 1299735
+            },
+            {
+              "calls": 575,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
+              "self_ns": 3249476
+            },
+            {
+              "calls": 1020,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
+              "self_ns": 1139009
+            },
+            {
+              "calls": 515,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
+              "self_ns": 2517757
+            },
+            {
+              "calls": 928,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
+              "self_ns": 1033606
+            },
+            {
+              "calls": 469,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1",
+              "self_ns": 12405594
+            },
+            {
+              "calls": 3512,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
+              "self_ns": 3688307
+            },
+            {
+              "calls": 1762,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
+              "self_ns": 60816251
+            },
+            {
+              "calls": 4112,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
+              "self_ns": 17946987
+            },
+            {
+              "calls": 460,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
+              "self_ns": 589168
+            },
+            {
+              "calls": 235,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1",
+              "self_ns": 6512370
+            },
+            {
+              "calls": 1484,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
+              "self_ns": 1670566
+            },
+            {
+              "calls": 747,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1",
+              "self_ns": 16497509
+            },
+            {
+              "calls": 1828,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
+              "self_ns": 1963160
+            },
+            {
+              "calls": 919,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1",
+              "self_ns": 9790134
+            },
+            {
+              "calls": 41940,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
+              "self_ns": 39558252
+            },
+            {
+              "calls": 21070,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
+              "self_ns": 208796268
+            },
+            {
+              "calls": 16,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger",
+              "self_ns": 37082
+            },
+            {
+              "calls": 479,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
+              "self_ns": 2687528
+            },
+            {
+              "calls": 872,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
+              "self_ns": 946357
+            },
+            {
+              "calls": 60,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
+              "self_ns": 108044
+            },
+            {
+              "calls": 2904,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
+              "self_ns": 3146246
+            },
+            {
+              "calls": 1459,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
+              "self_ns": 9103887
+            },
+            {
+              "calls": 408,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList",
+              "self_ns": 537874
+            },
+            {
+              "calls": 211,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1",
+              "self_ns": 2036124
+            },
+            {
+              "calls": 9120,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
+              "self_ns": 8801041
+            },
+            {
+              "calls": 9064,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3",
+              "self_ns": 129084294
+            },
+            {
+              "calls": 2010,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5",
+              "self_ns": 27445895
+            },
+            {
+              "calls": 7437,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7",
+              "self_ns": 36213015
+            },
+            {
+              "calls": 144,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
+              "self_ns": 233793
+            },
+            {
+              "calls": 79,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
+              "self_ns": 1285380
+            },
+            {
+              "calls": 676,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList",
+              "self_ns": 775289
+            },
+            {
+              "calls": 5064,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
+              "self_ns": 4889818
+            },
+            {
+              "calls": 1608,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
+              "self_ns": 1765133
+            },
+            {
+              "calls": 2546,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
+              "self_ns": 11787544
+            },
+            {
+              "calls": 3472,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
+              "self_ns": 3545426
+            },
+            {
+              "calls": 100,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin",
+              "self_ns": 181537
+            },
+            {
+              "calls": 55,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin.match_1",
+              "self_ns": 1364511
+            },
+            {
+              "calls": 1092,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData",
+              "self_ns": 1258251
+            },
+            {
+              "calls": 551,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1",
+              "self_ns": 2607852
+            },
+            {
+              "calls": 752,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue",
+              "self_ns": 954283
+            },
+            {
+              "calls": 425,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1",
+              "self_ns": 2477281
+            },
+            {
+              "calls": 88,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains",
+              "self_ns": 161672
+            },
+            {
+              "calls": 660,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData",
+              "self_ns": 741085
+            },
+            {
+              "calls": 335,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1",
+              "self_ns": 1693091
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
+              "self_ns": 1208
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
+              "self_ns": 37498
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
+              "self_ns": 7709
+            },
+            {
+              "calls": 14798,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
+              "self_ns": 14390713
+            },
+            {
+              "calls": 7499,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
+              "self_ns": 90707748
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame",
+              "self_ns": 1334
+            },
+            {
+              "calls": 9682,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
+              "self_ns": 20770824
+            },
+            {
+              "calls": 19156,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
+              "self_ns": 66183436
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
+              "self_ns": 1250
+            },
+            {
+              "calls": 32913,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
+              "self_ns": 75431948
+            },
+            {
+              "calls": 13357,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
+              "self_ns": 24218961
+            },
+            {
+              "calls": 41742,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
+              "self_ns": 70024539
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State.Error",
+              "self_ns": 1291
+            },
+            {
+              "calls": 97703,
+              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
+              "self_ns": 302551107
+            },
+            {
+              "calls": 141,
+              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
+              "self_ns": 354619
+            },
+            {
+              "calls": 91162,
+              "head": "PlutusCore.UPLC.CekMachine.State.Return",
+              "self_ns": 271222791
+            },
+            {
+              "calls": 14,
+              "head": "PlutusCore.UPLC.CekMachine.applyParams",
+              "self_ns": 3149500
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
+              "self_ns": 50833
+            },
+            {
+              "calls": 4,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
+              "self_ns": 83375
+            },
+            {
+              "calls": 41940,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
+              "self_ns": 44115857
+            },
+            {
+              "calls": 69673,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
+              "self_ns": 1060629176
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.CekMachine.initialState",
+              "self_ns": 12292
+            },
+            {
+              "calls": 200707,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps",
+              "self_ns": 1194681782
+            },
+            {
+              "calls": 191252,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
+              "self_ns": 620226248
+            },
+            {
+              "calls": 374984,
+              "head": "PlutusCore.UPLC.CekMachine.step",
+              "self_ns": 346386157
+            },
+            {
+              "calls": 17627,
+              "head": "PlutusCore.UPLC.CekMachine.step.folding",
+              "self_ns": 75964457
+            },
+            {
+              "calls": 21902,
+              "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1",
+              "self_ns": 48496495
+            },
+            {
+              "calls": 18452,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_1",
+              "self_ns": 47603803
+            },
+            {
+              "calls": 4289,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_11",
+              "self_ns": 13363743
+            },
+            {
+              "calls": 90445,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_13",
+              "self_ns": 247461507
+            },
+            {
+              "calls": 187499,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_15",
+              "self_ns": 491042694
+            },
+            {
+              "calls": 96929,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
+              "self_ns": 294011483
+            },
+            {
+              "calls": 39771,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_5",
+              "self_ns": 113615833
+            },
+            {
+              "calls": 4843,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_7",
+              "self_ns": 12736573
+            },
+            {
+              "calls": 4277,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_9",
+              "self_ns": 15843828
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekValue.CekValue",
+              "self_ns": 1375
+            },
+            {
+              "calls": 18492,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
+              "self_ns": 45379718
+            },
+            {
+              "calls": 290575,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
+              "self_ns": 449640797
+            },
+            {
+              "calls": 4292,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
+              "self_ns": 9729336
+            },
+            {
+              "calls": 9994,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
+              "self_ns": 23047045
+            },
+            {
+              "calls": 60642,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
+              "self_ns": 139647836
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3",
+              "self_ns": 1333
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
+              "self_ns": 10209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun",
+              "self_ns": 1416
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
+              "self_ns": 917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
+              "self_ns": 12875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
+              "self_ns": 916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
+              "self_ns": 1541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const",
+              "self_ns": 1125
+            },
+            {
+              "calls": 2013,
+              "head": "PlutusCore.UPLC.Term.Const.Bool",
+              "self_ns": 7426977
+            },
+            {
+              "calls": 2236,
+              "head": "PlutusCore.UPLC.Term.Const.ByteString",
+              "self_ns": 2913366
+            },
+            {
+              "calls": 191173,
+              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
+              "self_ns": 289106527
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.UPLC.Term.Const.ConstList",
+              "self_ns": 22540
+            },
+            {
+              "calls": 22701,
+              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
+              "self_ns": 34462409
+            },
+            {
+              "calls": 101896,
+              "head": "PlutusCore.UPLC.Term.Const.Data",
+              "self_ns": 127972334
+            },
+            {
+              "calls": 10787,
+              "head": "PlutusCore.UPLC.Term.Const.Integer",
+              "self_ns": 13133253
+            },
+            {
+              "calls": 19367,
+              "head": "PlutusCore.UPLC.Term.Const.Pair",
+              "self_ns": 32726519
+            },
+            {
+              "calls": 2115,
+              "head": "PlutusCore.UPLC.Term.Const.PairData",
+              "self_ns": 3236361
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const.Unit",
+              "self_ns": 1167
+            },
+            {
+              "calls": 4109,
+              "head": "PlutusCore.UPLC.Term.Const.Value",
+              "self_ns": 5069804
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Program",
+              "self_ns": 1750
+            },
+            {
+              "calls": 5,
+              "head": "PlutusCore.UPLC.Term.Program.Program",
+              "self_ns": 14500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term",
+              "self_ns": 1000
+            },
+            {
+              "calls": 532,
+              "head": "PlutusCore.UPLC.Term.Term.Apply",
+              "self_ns": 958420
+            },
+            {
+              "calls": 29,
+              "head": "PlutusCore.UPLC.Term.Term.Builtin",
+              "self_ns": 42915
+            },
+            {
+              "calls": 78,
+              "head": "PlutusCore.UPLC.Term.Term.Case",
+              "self_ns": 138249
+            },
+            {
+              "calls": 17,
+              "head": "PlutusCore.UPLC.Term.Term.Const",
+              "self_ns": 71374
+            },
+            {
+              "calls": 78,
+              "head": "PlutusCore.UPLC.Term.Term.Constr",
+              "self_ns": 135078
+            },
+            {
+              "calls": 83,
+              "head": "PlutusCore.UPLC.Term.Term.Delay",
+              "self_ns": 116953
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term.Error",
+              "self_ns": 917
+            },
+            {
+              "calls": 70,
+              "head": "PlutusCore.UPLC.Term.Term.Force",
+              "self_ns": 100050
+            },
+            {
+              "calls": 199,
+              "head": "PlutusCore.UPLC.Term.Term.Lam",
+              "self_ns": 268321
+            },
+            {
+              "calls": 125,
+              "head": "PlutusCore.UPLC.Term.Term.Var",
+              "self_ns": 110129
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.Term.Version.Version",
+              "self_ns": 9000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Value.ValueRep",
+              "self_ns": 15500
+            },
+            {
+              "calls": 838,
+              "head": "PlutusCore.Value.ascendingFrom",
+              "self_ns": 1099281
+            },
+            {
+              "calls": 426,
+              "head": "PlutusCore.Value.ascendingFrom.match_1",
+              "self_ns": 1512001
+            },
+            {
+              "calls": 60,
+              "head": "PlutusCore.Value.containedInner",
+              "self_ns": 2309415
+            },
+            {
+              "calls": 99,
+              "head": "PlutusCore.Value.containedOuter",
+              "self_ns": 1859574
+            },
+            {
+              "calls": 282,
+              "head": "PlutusCore.Value.deleteCoin",
+              "self_ns": 4546960
+            },
+            {
+              "calls": 6,
+              "head": "PlutusCore.Value.deleteCoin.match_1",
+              "self_ns": 144167
+            },
+            {
+              "calls": 154,
+              "head": "PlutusCore.Value.hasNegativeAmount",
+              "self_ns": 2289535
+            },
+            {
+              "calls": 15,
+              "head": "PlutusCore.Value.innerDelete",
+              "self_ns": 2785333
+            },
+            {
+              "calls": 144,
+              "head": "PlutusCore.Value.innerHasNegative",
+              "self_ns": 2367632
+            },
+            {
+              "calls": 604,
+              "head": "PlutusCore.Value.innerHasNegative.match_1",
+              "self_ns": 2223870
+            },
+            {
+              "calls": 2450,
+              "head": "PlutusCore.Value.innerToData",
+              "self_ns": 8620832
+            },
+            {
+              "calls": 100,
+              "head": "PlutusCore.Value.insertCoin",
+              "self_ns": 212461
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.Value.lookupCoin",
+              "self_ns": 3206583
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.Value.lookupInner",
+              "self_ns": 3020751
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Value.maxKeyLen",
+              "self_ns": 8833
+            },
+            {
+              "calls": 934,
+              "head": "PlutusCore.Value.outerToData",
+              "self_ns": 5933856
+            },
+            {
+              "calls": 1024,
+              "head": "PlutusCore.Value.totalSize.match_1",
+              "self_ns": 3439409
+            },
+            {
+              "calls": 1092,
+              "head": "PlutusCore.Value.unValueData",
+              "self_ns": 1285297
+            },
+            {
+              "calls": 551,
+              "head": "PlutusCore.Value.unValueData.match_1",
+              "self_ns": 6994922
+            },
+            {
+              "calls": 1291,
+              "head": "PlutusCore.Value.unValueDataCurrencies",
+              "self_ns": 45858115
+            },
+            {
+              "calls": 352,
+              "head": "PlutusCore.Value.unValueDataCurrencies.match_1",
+              "self_ns": 7785333
+            },
+            {
+              "calls": 352,
+              "head": "PlutusCore.Value.unValueDataCurrencies.match_3",
+              "self_ns": 8762971
+            },
+            {
+              "calls": 512,
+              "head": "PlutusCore.Value.unValueDataTokens",
+              "self_ns": 14632621
+            },
+            {
+              "calls": 486,
+              "head": "PlutusCore.Value.unValueDataTokens.match_1",
+              "self_ns": 10750956
+            },
+            {
+              "calls": 873,
+              "head": "PlutusCore.Value.unValueDataTokens.match_3",
+              "self_ns": 15956947
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.Value.unionInner",
+              "self_ns": 366168
+            },
+            {
+              "calls": 2458,
+              "head": "PlutusCore.Value.unionInner.match_1",
+              "self_ns": 50598922
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Value.unionInner.match_3",
+              "self_ns": 609833
+            },
+            {
+              "calls": 386,
+              "head": "PlutusCore.Value.unionOuter",
+              "self_ns": 1997376
+            },
+            {
+              "calls": 3295,
+              "head": "PlutusCore.Value.unionOuter.match_1",
+              "self_ns": 77071999
+            },
+            {
+              "calls": 8,
+              "head": "PlutusCore.Value.unionOuter.match_3",
+              "self_ns": 179917
+            },
+            {
+              "calls": 303,
+              "head": "PlutusCore.Value.unionOuter.match_5",
+              "self_ns": 1547634
+            },
+            {
+              "calls": 752,
+              "head": "PlutusCore.Value.unionValue",
+              "self_ns": 885743
+            },
+            {
+              "calls": 838,
+              "head": "PlutusCore.Value.validKey",
+              "self_ns": 981318
+            },
+            {
+              "calls": 390,
+              "head": "PlutusCore.Value.validQuantity",
+              "self_ns": 519330
+            },
+            {
+              "calls": 88,
+              "head": "PlutusCore.Value.valueContains",
+              "self_ns": 127288
+            },
+            {
+              "calls": 660,
+              "head": "PlutusCore.Value.valueData",
+              "self_ns": 726212
+            },
+            {
+              "calls": 2,
+              "head": "Pow.pow",
+              "self_ns": 49541
+            },
+            {
+              "calls": 10,
+              "head": "Prod",
+              "self_ns": 32086
+            },
+            {
+              "calls": 1389,
+              "head": "Prod.fst",
+              "self_ns": 7045746
+            },
+            {
+              "calls": 31056,
+              "head": "Prod.mk",
+              "self_ns": 73418028
+            },
+            {
+              "calls": 1756,
+              "head": "Prod.snd",
+              "self_ns": 15522234
+            },
+            {
+              "calls": 1,
+              "head": "String",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "String.instLT",
+              "self_ns": 2833
+            },
+            {
+              "calls": 420,
+              "head": "String.length",
+              "self_ns": 1511919
+            },
+            {
+              "calls": 2,
+              "head": "WSC.globalInputs1600",
+              "self_ns": 17249
+            },
+            {
+              "calls": 14,
+              "head": "_normalizer",
+              "self_ns": 26795082
+            },
+            {
+              "calls": 2,
+              "head": "instBEqOfDecidableEq",
+              "self_ns": 19708
+            },
+            {
+              "calls": 2,
+              "head": "instHAdd",
+              "self_ns": 17708
+            },
+            {
+              "calls": 3,
+              "head": "instHMul",
+              "self_ns": 17876
+            },
+            {
+              "calls": 2,
+              "head": "instHPow",
+              "self_ns": 19291
+            },
+            {
+              "calls": 1,
+              "head": "instLENat",
+              "self_ns": 3458
+            },
+            {
+              "calls": 1,
+              "head": "instLTNat",
+              "self_ns": 4334
+            },
+            {
+              "calls": 1,
+              "head": "instNatPowNat",
+              "self_ns": 3625
+            },
+            {
+              "calls": 12,
+              "head": "instOfNat",
+              "self_ns": 25667
+            },
+            {
+              "calls": 9,
+              "head": "instOfNatNat",
+              "self_ns": 23708
+            },
+            {
+              "calls": 2,
+              "head": "instPowNat",
+              "self_ns": 14750
+            },
+            {
+              "calls": 4897,
+              "head": "ite",
+              "self_ns": 7022870
+            },
+            {
+              "calls": 1,
+              "head": "programmableLogicGlobal1600",
+              "self_ns": 841542
+            }
+          ],
+          "imbalances": 0,
+          "schema": 1,
+          "status": "complete"
+        }
+      ],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 7,
+          "command_ms": 12683
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 173856,
+      "profile_snapshot_count": 5
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 3428564992,
+      "prep": {
+        "optimize_ms": 64757,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "c72f5457ab5df7526b42fa873f2d5bf0da18eb3ad903107505e5ab605286dc62",
+      "elapsed_seconds": 68.22704891697504,
+      "exit_code": 0,
+      "profiles": [
+        {
+          "active_frames": 0,
+          "cache_bypasses": 8949762,
+          "cache_hits": 33262159,
+          "cache_misses": 13474894,
+          "contexts": 103138,
+          "elapsed_ns": 64751719417,
+          "events": {
+            "Eq.choice_match": 3808,
+            "List.cons.choice_ite": 2,
+            "List.cons.choice_match": 582,
+            "Option.some.choice_ite": 1,
+            "Option.some.choice_match": 4289,
+            "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr.choice_match": 280,
+            "PlutusCore.UPLC.CekMachine.State.Eval.choice_match": 2,
+            "PlutusCore.UPLC.CekMachine.applyParams.choice_match": 2,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_ite": 8994,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_match": 35132,
+            "PlutusCore.UPLC.CekValue.CekValue.VCon.choice_match": 482,
+            "PlutusCore.UPLC.Term.Const.Bool.choice_match": 482,
+            "PlutusCore.UPLC.Term.Const.Data.choice_match": 1,
+            "PlutusCore.UPLC.Term.Term.Const.choice_match": 1,
+            "Prod.mk.choice_ite": 2,
+            "Prod.mk.choice_match": 46
+          },
+          "hashcons": 15595053,
+          "heads": [
+            {
+              "calls": 1423,
+              "head": "Add.add",
+              "self_ns": 9452403
+            },
+            {
+              "calls": 8,
+              "head": "And",
+              "self_ns": 75789
+            },
+            {
+              "calls": 9841,
+              "head": "BEq.beq",
+              "self_ns": 205471933
+            },
+            {
+              "calls": 8093,
+              "head": "Blaster.decide'",
+              "self_ns": 24609419
+            },
+            {
+              "calls": 79680,
+              "head": "Blaster.dite'",
+              "self_ns": 676621788
+            },
+            {
+              "calls": 1,
+              "head": "Bool",
+              "self_ns": 2250
+            },
+            {
+              "calls": 323,
+              "head": "Bool.and",
+              "self_ns": 1671115
+            },
+            {
+              "calls": 1,
+              "head": "Bool.false",
+              "self_ns": 1125
+            },
+            {
+              "calls": 957,
+              "head": "Bool.or",
+              "self_ns": 5106386
+            },
+            {
+              "calls": 1,
+              "head": "Bool.true",
+              "self_ns": 1375
+            },
+            {
+              "calls": 239,
+              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
+              "self_ns": 1685207
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
+              "self_ns": 3709
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
+              "self_ns": 2833
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
+              "self_ns": 18460
+            },
+            {
+              "calls": 15,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1",
+              "self_ns": 325960
+            },
+            {
+              "calls": 328,
+              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
+              "self_ns": 386270
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.IsData.Class.toTerm",
+              "self_ns": 32375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.Address",
+              "self_ns": 1708
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
+              "self_ns": 16000
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
+              "self_ns": 16958
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
+              "self_ns": 2625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
+              "self_ns": 4000
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
+              "self_ns": 17750
+            },
+            {
+              "calls": 43805,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 161033090
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 159625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.Credential",
+              "self_ns": 1292
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
+              "self_ns": 7291
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
+              "self_ns": 11042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
+              "self_ns": 10916
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
+              "self_ns": 1292
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
+              "self_ns": 6541
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
+              "self_ns": 9584
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
+              "self_ns": 2709
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
+              "self_ns": 2375
+            },
+            {
+              "calls": 46,
+              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
+              "self_ns": 1114616
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
+              "self_ns": 162292
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Datum",
+              "self_ns": 8333
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
+              "self_ns": 5500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
+              "self_ns": 6000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
+              "self_ns": 5458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
+              "self_ns": 3583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
+              "self_ns": 9375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.Value",
+              "self_ns": 9084
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
+              "self_ns": 3041
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
+              "self_ns": 12875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
+              "self_ns": 3459
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
+              "self_ns": 6917
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
+              "self_ns": 16624
+            },
+            {
+              "calls": 87797,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
+              "self_ns": 182130939
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
+              "self_ns": 167417
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
+              "self_ns": 18374
+            },
+            {
+              "calls": 70225,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
+              "self_ns": 2247854218
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
+              "self_ns": 271082
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
+              "self_ns": 1334
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
+              "self_ns": 7208
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
+              "self_ns": 7500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut",
+              "self_ns": 1291
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
+              "self_ns": 16250
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
+              "self_ns": 16292
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
+              "self_ns": 17583
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
+              "self_ns": 16209
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
+              "self_ns": 2584
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
+              "self_ns": 2958
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
+              "self_ns": 170499
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap",
+              "self_ns": 7125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.MintValue",
+              "self_ns": 13458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap",
+              "self_ns": 9083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext",
+              "self_ns": 1125
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer",
+              "self_ns": 14375
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo",
+              "self_ns": 20709
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo",
+              "self_ns": 11042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo",
+              "self_ns": 1250
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript",
+              "self_ns": 9625
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript",
+              "self_ns": 9459
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript",
+              "self_ns": 8541
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript",
+              "self_ns": 10375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript",
+              "self_ns": 12167
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript",
+              "self_ns": 6833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose",
+              "self_ns": 1750
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying",
+              "self_ns": 9292
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting",
+              "self_ns": 20417
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing",
+              "self_ns": 8584
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding",
+              "self_ns": 6375
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending",
+              "self_ns": 6792
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting",
+              "self_ns": 7167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo",
+              "self_ns": 1375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef",
+              "self_ns": 14500
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved",
+              "self_ns": 10667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo",
+              "self_ns": 1500
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount",
+              "self_ns": 15666
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData",
+              "self_ns": 13208
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee",
+              "self_ns": 20500
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId",
+              "self_ns": 16875
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs",
+              "self_ns": 12584
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint",
+              "self_ns": 17417
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs",
+              "self_ns": 14791
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures",
+              "self_ns": 17541
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers",
+              "self_ns": 13083
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs",
+              "self_ns": 29375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories",
+              "self_ns": 17625
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation",
+              "self_ns": 13667
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts",
+              "self_ns": 13208
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange",
+              "self_ns": 16542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes",
+              "self_ns": 12542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl",
+              "self_ns": 21125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.VoterMap",
+              "self_ns": 8791
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData",
+              "self_ns": 16208
+            },
+            {
+              "calls": 26,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19",
+              "self_ns": 2965958
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1",
+              "self_ns": 179167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap",
+              "self_ns": 6292
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure",
+              "self_ns": 6542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert",
+              "self_ns": 4208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo",
+              "self_ns": 2375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap",
+              "self_ns": 3667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext",
+              "self_ns": 3500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo",
+              "self_ns": 3416
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose",
+              "self_ns": 3375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo",
+              "self_ns": 3209
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo",
+              "self_ns": 2666
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap",
+              "self_ns": 2958
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1",
+              "self_ns": 246875
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1",
+              "self_ns": 451539
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs",
+              "self_ns": 23541
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1",
+              "self_ns": 183666
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData",
+              "self_ns": 14793
+            },
+            {
+              "calls": 171432,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14",
+              "self_ns": 260920365
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1",
+              "self_ns": 293374
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData",
+              "self_ns": 23249
+            },
+            {
+              "calls": 87801,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14",
+              "self_ns": 172054718
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1",
+              "self_ns": 156333
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData",
+              "self_ns": 13791
+            },
+            {
+              "calls": 87935,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19",
+              "self_ns": 184508528
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1",
+              "self_ns": 252208
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData",
+              "self_ns": 19166
+            },
+            {
+              "calls": 87913,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14",
+              "self_ns": 173998726
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1",
+              "self_ns": 228583
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData",
+              "self_ns": 19959
+            },
+            {
+              "calls": 87807,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19",
+              "self_ns": 174383131
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1",
+              "self_ns": 181166
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId",
+              "self_ns": 1959
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx",
+              "self_ns": 16542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId",
+              "self_ns": 17292
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure",
+              "self_ns": 5042
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit",
+              "self_ns": 19542
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction",
+              "self_ns": 17292
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr",
+              "self_ns": 18875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Voter",
+              "self_ns": 1709
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter",
+              "self_ns": 7792
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter",
+              "self_ns": 9167
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter",
+              "self_ns": 7083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Withdrawals",
+              "self_ns": 10166
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId",
+              "self_ns": 8583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers",
+              "self_ns": 4375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure",
+              "self_ns": 4250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataVote",
+              "self_ns": 5917
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter",
+              "self_ns": 3667
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1",
+              "self_ns": 115291
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1",
+              "self_ns": 220458
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData",
+              "self_ns": 15874
+            },
+            {
+              "calls": 161,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19",
+              "self_ns": 3620582
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1",
+              "self_ns": 160833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.TxId",
+              "self_ns": 6625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef",
+              "self_ns": 1500
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId",
+              "self_ns": 20083
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx",
+              "self_ns": 15625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId",
+              "self_ns": 4000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef",
+              "self_ns": 2750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential",
+              "self_ns": 10084
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep",
+              "self_ns": 1208
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep",
+              "self_ns": 6750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRepCredential",
+              "self_ns": 5667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee",
+              "self_ns": 9417
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake",
+              "self_ns": 6875
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote",
+              "self_ns": 8167
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote",
+              "self_ns": 9916
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential",
+              "self_ns": 6625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert",
+              "self_ns": 2375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee",
+              "self_ns": 11500
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking",
+              "self_ns": 9917
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister",
+              "self_ns": 11209
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire",
+              "self_ns": 18250
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep",
+              "self_ns": 13875
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg",
+              "self_ns": 11250
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking",
+              "self_ns": 12333
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee",
+              "self_ns": 6125
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep",
+              "self_ns": 8542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking",
+              "self_ns": 9292
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep",
+              "self_ns": 6708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep",
+              "self_ns": 3208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee",
+              "self_ns": 2750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert",
+              "self_ns": 4500
+            },
+            {
+              "calls": 14,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1",
+              "self_ns": 322209
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1",
+              "self_ns": 284169
+            },
+            {
+              "calls": 16,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1",
+              "self_ns": 1468039
+            },
+            {
+              "calls": 6737,
+              "head": "Decidable.decide",
+              "self_ns": 8262470
+            },
+            {
+              "calls": 31538,
+              "head": "Eq",
+              "self_ns": 283926346
+            },
+            {
+              "calls": 13,
+              "head": "Function.comp",
+              "self_ns": 84042
+            },
+            {
+              "calls": 1429,
+              "head": "HAdd.hAdd",
+              "self_ns": 9605845
+            },
+            {
+              "calls": 2438,
+              "head": "HMul.hMul",
+              "self_ns": 12279735
+            },
+            {
+              "calls": 2,
+              "head": "HPow.hPow",
+              "self_ns": 56043
+            },
+            {
+              "calls": 2,
+              "head": "Inhabited.default",
+              "self_ns": 29667
+            },
+            {
+              "calls": 1,
+              "head": "Int",
+              "self_ns": 3458
+            },
+            {
+              "calls": 4267,
+              "head": "Int.add",
+              "self_ns": 14852346
+            },
+            {
+              "calls": 1,
+              "head": "Int.instAdd",
+              "self_ns": 4292
+            },
+            {
+              "calls": 1,
+              "head": "Int.instDecidableEq",
+              "self_ns": 5792
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLEInt",
+              "self_ns": 5875
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLTInt",
+              "self_ns": 7208
+            },
+            {
+              "calls": 1,
+              "head": "Int.instMul",
+              "self_ns": 2833
+            },
+            {
+              "calls": 7095,
+              "head": "Int.mul",
+              "self_ns": 18719195
+            },
+            {
+              "calls": 2838,
+              "head": "Int.natAbs",
+              "self_ns": 3295610
+            },
+            {
+              "calls": 1421,
+              "head": "Int.neg",
+              "self_ns": 3485785
+            },
+            {
+              "calls": 1424,
+              "head": "Int.neg.match_1",
+              "self_ns": 49045480
+            },
+            {
+              "calls": 7,
+              "head": "Int.negOfNat.match_1",
+              "self_ns": 119584
+            },
+            {
+              "calls": 5,
+              "head": "Int.negSucc",
+              "self_ns": 17292
+            },
+            {
+              "calls": 15,
+              "head": "Int.ofNat",
+              "self_ns": 41126
+            },
+            {
+              "calls": 3,
+              "head": "Int.pow",
+              "self_ns": 12667
+            },
+            {
+              "calls": 3675,
+              "head": "Int.toNat",
+              "self_ns": 10521160
+            },
+            {
+              "calls": 3392,
+              "head": "LE.le",
+              "self_ns": 16614128
+            },
+            {
+              "calls": 16414,
+              "head": "LT.lt",
+              "self_ns": 75880863
+            },
+            {
+              "calls": 4310,
+              "head": "List",
+              "self_ns": 7697385
+            },
+            {
+              "calls": 6129244,
+              "head": "List.cons",
+              "self_ns": 12609388444
+            },
+            {
+              "calls": 847,
+              "head": "List.drop",
+              "self_ns": 25675001
+            },
+            {
+              "calls": 158227,
+              "head": "List.get?Internal",
+              "self_ns": 717875624
+            },
+            {
+              "calls": 12778,
+              "head": "List.getLast?.match_1",
+              "self_ns": 271794235
+            },
+            {
+              "calls": 8487,
+              "head": "List.isEmpty",
+              "self_ns": 24956278
+            },
+            {
+              "calls": 20231,
+              "head": "List.nil",
+              "self_ns": 33841199
+            },
+            {
+              "calls": 20211,
+              "head": "List.reverse",
+              "self_ns": 60710864
+            },
+            {
+              "calls": 20211,
+              "head": "List.reverseAux",
+              "self_ns": 116902808
+            },
+            {
+              "calls": 20,
+              "head": "List.take.match_1",
+              "self_ns": 470332
+            },
+            {
+              "calls": 1421,
+              "head": "Mul.mul",
+              "self_ns": 9589607
+            },
+            {
+              "calls": 1,
+              "head": "Nat",
+              "self_ns": 39292
+            },
+            {
+              "calls": 1449,
+              "head": "Nat.add",
+              "self_ns": 5950771
+            },
+            {
+              "calls": 12,
+              "head": "Nat.add.match_1",
+              "self_ns": 294333
+            },
+            {
+              "calls": 2,
+              "head": "Nat.beq",
+              "self_ns": 6000
+            },
+            {
+              "calls": 14,
+              "head": "Nat.beq.match_1",
+              "self_ns": 314207
+            },
+            {
+              "calls": 2,
+              "head": "Nat.ble",
+              "self_ns": 7000
+            },
+            {
+              "calls": 4,
+              "head": "Nat.mul",
+              "self_ns": 18751
+            },
+            {
+              "calls": 12,
+              "head": "Nat.mul.match_1",
+              "self_ns": 234873
+            },
+            {
+              "calls": 4,
+              "head": "Nat.pow",
+              "self_ns": 16708
+            },
+            {
+              "calls": 6,
+              "head": "Nat.pow.match_1",
+              "self_ns": 113167
+            },
+            {
+              "calls": 2,
+              "head": "Nat.pred",
+              "self_ns": 7292
+            },
+            {
+              "calls": 1451,
+              "head": "Nat.sub",
+              "self_ns": 9489151
+            },
+            {
+              "calls": 1432,
+              "head": "Nat.succ",
+              "self_ns": 2303913
+            },
+            {
+              "calls": 1,
+              "head": "Nat.zero",
+              "self_ns": 2167
+            },
+            {
+              "calls": 2,
+              "head": "NatPow.pow",
+              "self_ns": 41959
+            },
+            {
+              "calls": 4814,
+              "head": "Not",
+              "self_ns": 13830658
+            },
+            {
+              "calls": 21,
+              "head": "OfNat.ofNat",
+              "self_ns": 274791
+            },
+            {
+              "calls": 13731,
+              "head": "Option",
+              "self_ns": 22375116
+            },
+            {
+              "calls": 39712,
+              "head": "Option.getD.match_1",
+              "self_ns": 881783674
+            },
+            {
+              "calls": 6343,
+              "head": "Option.map",
+              "self_ns": 25904409
+            },
+            {
+              "calls": 11821,
+              "head": "Option.none",
+              "self_ns": 21169228
+            },
+            {
+              "calls": 148453,
+              "head": "Option.some",
+              "self_ns": 675311327
+            },
+            {
+              "calls": 506,
+              "head": "Or",
+              "self_ns": 3452960
+            },
+            {
+              "calls": 9189,
+              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
+              "self_ns": 35962910
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
+              "self_ns": 3791
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
+              "self_ns": 1167
+            },
+            {
+              "calls": 25749,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data",
+              "self_ns": 23049722
+            },
+            {
+              "calls": 6262,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length",
+              "self_ns": 10625745
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
+              "self_ns": 5834
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString",
+              "self_ns": 4375
+            },
+            {
+              "calls": 868,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
+              "self_ns": 1162623
+            },
+            {
+              "calls": 924,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString",
+              "self_ns": 1294340
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
+              "self_ns": 4542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
+              "self_ns": 1417
+            },
+            {
+              "calls": 356758,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
+              "self_ns": 390312613
+            },
+            {
+              "calls": 1193823,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
+              "self_ns": 1654241685
+            },
+            {
+              "calls": 263892,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
+              "self_ns": 289054779
+            },
+            {
+              "calls": 448023,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
+              "self_ns": 671140329
+            },
+            {
+              "calls": 304364,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
+              "self_ns": 1273883883
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
+              "self_ns": 17375
+            },
+            {
+              "calls": 383,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
+              "self_ns": 2895441
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
+              "self_ns": 103291
+            },
+            {
+              "calls": 19,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
+              "self_ns": 178542
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
+              "self_ns": 88250
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
+              "self_ns": 321167
+            },
+            {
+              "calls": 377,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
+              "self_ns": 2257922
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
+              "self_ns": 409459
+            },
+            {
+              "calls": 5140,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
+              "self_ns": 6313223
+            },
+            {
+              "calls": 6100,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
+              "self_ns": 6505503
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
+              "self_ns": 3792
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Integer.Integer",
+              "self_ns": 6000
+            },
+            {
+              "calls": 220,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger",
+              "self_ns": 531377
+            },
+            {
+              "calls": 3924,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
+              "self_ns": 4945669
+            },
+            {
+              "calls": 516,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
+              "self_ns": 619667
+            },
+            {
+              "calls": 375,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
+              "self_ns": 1512326
+            },
+            {
+              "calls": 1185,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.nullList",
+              "self_ns": 3824747
+            },
+            {
+              "calls": 3441,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
+              "self_ns": 12571214
+            },
+            {
+              "calls": 8229,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
+              "self_ns": 27840729
+            },
+            {
+              "calls": 18376,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
+              "self_ns": 20415295
+            },
+            {
+              "calls": 9193,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
+              "self_ns": 43244661
+            },
+            {
+              "calls": 901,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
+              "self_ns": 5495621
+            },
+            {
+              "calls": 868,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
+              "self_ns": 1126667
+            },
+            {
+              "calls": 924,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString",
+              "self_ns": 1359418
+            },
+            {
+              "calls": 5140,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
+              "self_ns": 6497898
+            },
+            {
+              "calls": 2575,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
+              "self_ns": 13697084
+            },
+            {
+              "calls": 6100,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
+              "self_ns": 6791777
+            },
+            {
+              "calls": 3055,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
+              "self_ns": 14346627
+            },
+            {
+              "calls": 4004,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
+              "self_ns": 4925630
+            },
+            {
+              "calls": 2007,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1",
+              "self_ns": 1076600875
+            },
+            {
+              "calls": 16272,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
+              "self_ns": 18775092
+            },
+            {
+              "calls": 8142,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
+              "self_ns": 293880095
+            },
+            {
+              "calls": 19316,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
+              "self_ns": 83751799
+            },
+            {
+              "calls": 1908,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
+              "self_ns": 2613560
+            },
+            {
+              "calls": 959,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1",
+              "self_ns": 29129334
+            },
+            {
+              "calls": 7056,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
+              "self_ns": 8354742
+            },
+            {
+              "calls": 3533,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1",
+              "self_ns": 85007928
+            },
+            {
+              "calls": 9380,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
+              "self_ns": 10346805
+            },
+            {
+              "calls": 4695,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1",
+              "self_ns": 42943222
+            },
+            {
+              "calls": 197156,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
+              "self_ns": 196442419
+            },
+            {
+              "calls": 98678,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
+              "self_ns": 982562242
+            },
+            {
+              "calls": 220,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger",
+              "self_ns": 292796
+            },
+            {
+              "calls": 2335,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
+              "self_ns": 12577589
+            },
+            {
+              "calls": 3924,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
+              "self_ns": 5382344
+            },
+            {
+              "calls": 516,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
+              "self_ns": 633292
+            },
+            {
+              "calls": 14604,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
+              "self_ns": 15929983
+            },
+            {
+              "calls": 7309,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
+              "self_ns": 44510048
+            },
+            {
+              "calls": 1672,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList",
+              "self_ns": 2304766
+            },
+            {
+              "calls": 843,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1",
+              "self_ns": 6535918
+            },
+            {
+              "calls": 41740,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
+              "self_ns": 46734008
+            },
+            {
+              "calls": 41596,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3",
+              "self_ns": 676148171
+            },
+            {
+              "calls": 8822,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5",
+              "self_ns": 124513999
+            },
+            {
+              "calls": 32567,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7",
+              "self_ns": 160096675
+            },
+            {
+              "calls": 748,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
+              "self_ns": 1072743
+            },
+            {
+              "calls": 381,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
+              "self_ns": 3308161
+            },
+            {
+              "calls": 2368,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList",
+              "self_ns": 3012100
+            },
+            {
+              "calls": 21012,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
+              "self_ns": 21299844
+            },
+            {
+              "calls": 6880,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
+              "self_ns": 8303861
+            },
+            {
+              "calls": 11674,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
+              "self_ns": 55373603
+            },
+            {
+              "calls": 16456,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
+              "self_ns": 17027887
+            },
+            {
+              "calls": 708,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin",
+              "self_ns": 1118702
+            },
+            {
+              "calls": 359,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.insertCoin.match_1",
+              "self_ns": 3873931
+            },
+            {
+              "calls": 6388,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData",
+              "self_ns": 7177639
+            },
+            {
+              "calls": 3199,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1",
+              "self_ns": 14496896
+            },
+            {
+              "calls": 5004,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue",
+              "self_ns": 6170206
+            },
+            {
+              "calls": 2799,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1",
+              "self_ns": 14818314
+            },
+            {
+              "calls": 584,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains",
+              "self_ns": 816852
+            },
+            {
+              "calls": 4304,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData",
+              "self_ns": 4934006
+            },
+            {
+              "calls": 2157,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1",
+              "self_ns": 9993215
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
+              "self_ns": 1458
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
+              "self_ns": 34210
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
+              "self_ns": 8125
+            },
+            {
+              "calls": 73066,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
+              "self_ns": 72339231
+            },
+            {
+              "calls": 36633,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
+              "self_ns": 429846536
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame",
+              "self_ns": 1333
+            },
+            {
+              "calls": 48710,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
+              "self_ns": 107254531
+            },
+            {
+              "calls": 92730,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
+              "self_ns": 301241164
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
+              "self_ns": 1417
+            },
+            {
+              "calls": 159013,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
+              "self_ns": 380614629
+            },
+            {
+              "calls": 62445,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
+              "self_ns": 118760626
+            },
+            {
+              "calls": 185712,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
+              "self_ns": 321954085
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State",
+              "self_ns": 1917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State.Error",
+              "self_ns": 1500
+            },
+            {
+              "calls": 456005,
+              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
+              "self_ns": 1459695573
+            },
+            {
+              "calls": 769,
+              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
+              "self_ns": 1963501
+            },
+            {
+              "calls": 425818,
+              "head": "PlutusCore.UPLC.CekMachine.State.Return",
+              "self_ns": 1139184791
+            },
+            {
+              "calls": 14,
+              "head": "PlutusCore.UPLC.CekMachine.applyParams",
+              "self_ns": 3143831
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
+              "self_ns": 52583
+            },
+            {
+              "calls": 4,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
+              "self_ns": 91917
+            },
+            {
+              "calls": 197156,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
+              "self_ns": 211079189
+            },
+            {
+              "calls": 325885,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
+              "self_ns": 6012800433
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.CekMachine.initialState",
+              "self_ns": 13334
+            },
+            {
+              "calls": 931425,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps",
+              "self_ns": 5678339290
+            },
+            {
+              "calls": 889722,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
+              "self_ns": 2962339174
+            },
+            {
+              "calls": 1749864,
+              "head": "PlutusCore.UPLC.CekMachine.step",
+              "self_ns": 1644858360
+            },
+            {
+              "calls": 82517,
+              "head": "PlutusCore.UPLC.CekMachine.step.folding",
+              "self_ns": 341010248
+            },
+            {
+              "calls": 102594,
+              "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1",
+              "self_ns": 227051077
+            },
+            {
+              "calls": 86832,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_1",
+              "self_ns": 230300220
+            },
+            {
+              "calls": 20091,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_11",
+              "self_ns": 63372142
+            },
+            {
+              "calls": 421499,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_13",
+              "self_ns": 1175669950
+            },
+            {
+              "calls": 874939,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_15",
+              "self_ns": 2290179145
+            },
+            {
+              "calls": 452687,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
+              "self_ns": 1411977306
+            },
+            {
+              "calls": 186001,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_5",
+              "self_ns": 532532533
+            },
+            {
+              "calls": 22171,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_7",
+              "self_ns": 58709001
+            },
+            {
+              "calls": 20079,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_9",
+              "self_ns": 76774474
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekValue.CekValue",
+              "self_ns": 1500
+            },
+            {
+              "calls": 88632,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
+              "self_ns": 227531853
+            },
+            {
+              "calls": 1293467,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
+              "self_ns": 2065230118
+            },
+            {
+              "calls": 20214,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
+              "self_ns": 47077760
+            },
+            {
+              "calls": 46346,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
+              "self_ns": 111977957
+            },
+            {
+              "calls": 267852,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
+              "self_ns": 641436541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3",
+              "self_ns": 1333
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
+              "self_ns": 9916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun",
+              "self_ns": 1583
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
+              "self_ns": 1459
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
+              "self_ns": 4083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
+              "self_ns": 4416
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
+              "self_ns": 4958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
+              "self_ns": 1417
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
+              "self_ns": 2291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
+              "self_ns": 4458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
+              "self_ns": 1583
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
+              "self_ns": 4375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
+              "self_ns": 1416
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
+              "self_ns": 1792
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
+              "self_ns": 4584
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
+              "self_ns": 1417
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
+              "self_ns": 16334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
+              "self_ns": 1459
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
+              "self_ns": 1416
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
+              "self_ns": 1708
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
+              "self_ns": 2000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
+              "self_ns": 1459
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
+              "self_ns": 1916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue",
+              "self_ns": 916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
+              "self_ns": 4375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
+              "self_ns": 1417
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
+              "self_ns": 1750
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
+              "self_ns": 1834
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
+              "self_ns": 1750
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
+              "self_ns": 1584
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData",
+              "self_ns": 917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
+              "self_ns": 4416
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
+              "self_ns": 1583
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const",
+              "self_ns": 1250
+            },
+            {
+              "calls": 9063,
+              "head": "PlutusCore.UPLC.Term.Const.Bool",
+              "self_ns": 40338156
+            },
+            {
+              "calls": 12054,
+              "head": "PlutusCore.UPLC.Term.Const.ByteString",
+              "self_ns": 14552509
+            },
+            {
+              "calls": 833727,
+              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
+              "self_ns": 1312638315
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.UPLC.Term.Const.ConstList",
+              "self_ns": 18001
+            },
+            {
+              "calls": 110941,
+              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
+              "self_ns": 175522754
+            },
+            {
+              "calls": 443430,
+              "head": "PlutusCore.UPLC.Term.Const.Data",
+              "self_ns": 579081635
+            },
+            {
+              "calls": 46273,
+              "head": "PlutusCore.UPLC.Term.Const.Integer",
+              "self_ns": 62779034
+            },
+            {
+              "calls": 84317,
+              "head": "PlutusCore.UPLC.Term.Const.Pair",
+              "self_ns": 143512014
+            },
+            {
+              "calls": 9909,
+              "head": "PlutusCore.UPLC.Term.Const.PairData",
+              "self_ns": 15774708
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const.Unit",
+              "self_ns": 1000
+            },
+            {
+              "calls": 28981,
+              "head": "PlutusCore.UPLC.Term.Const.Value",
+              "self_ns": 35698970
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Program",
+              "self_ns": 1583
+            },
+            {
+              "calls": 5,
+              "head": "PlutusCore.UPLC.Term.Program.Program",
+              "self_ns": 14417
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term",
+              "self_ns": 1000
+            },
+            {
+              "calls": 532,
+              "head": "PlutusCore.UPLC.Term.Term.Apply",
+              "self_ns": 899487
+            },
+            {
+              "calls": 29,
+              "head": "PlutusCore.UPLC.Term.Term.Builtin",
+              "self_ns": 43668
+            },
+            {
+              "calls": 78,
+              "head": "PlutusCore.UPLC.Term.Term.Case",
+              "self_ns": 137992
+            },
+            {
+              "calls": 17,
+              "head": "PlutusCore.UPLC.Term.Term.Const",
+              "self_ns": 62584
+            },
+            {
+              "calls": 78,
+              "head": "PlutusCore.UPLC.Term.Term.Constr",
+              "self_ns": 133673
+            },
+            {
+              "calls": 83,
+              "head": "PlutusCore.UPLC.Term.Term.Delay",
+              "self_ns": 119121
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term.Error",
+              "self_ns": 1042
+            },
+            {
+              "calls": 70,
+              "head": "PlutusCore.UPLC.Term.Term.Force",
+              "self_ns": 98843
+            },
+            {
+              "calls": 199,
+              "head": "PlutusCore.UPLC.Term.Term.Lam",
+              "self_ns": 251750
+            },
+            {
+              "calls": 125,
+              "head": "PlutusCore.UPLC.Term.Term.Var",
+              "self_ns": 107041
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.Term.Version.Version",
+              "self_ns": 8584
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Value.ValueRep",
+              "self_ns": 10958
+            },
+            {
+              "calls": 6262,
+              "head": "PlutusCore.Value.ascendingFrom",
+              "self_ns": 11352253
+            },
+            {
+              "calls": 3138,
+              "head": "PlutusCore.Value.ascendingFrom.match_1",
+              "self_ns": 10235515
+            },
+            {
+              "calls": 322,
+              "head": "PlutusCore.Value.containedInner",
+              "self_ns": 3679546
+            },
+            {
+              "calls": 651,
+              "head": "PlutusCore.Value.containedOuter",
+              "self_ns": 4159705
+            },
+            {
+              "calls": 2186,
+              "head": "PlutusCore.Value.deleteCoin",
+              "self_ns": 12036476
+            },
+            {
+              "calls": 6,
+              "head": "PlutusCore.Value.deleteCoin.match_1",
+              "self_ns": 184167
+            },
+            {
+              "calls": 1024,
+              "head": "PlutusCore.Value.hasNegativeAmount",
+              "self_ns": 5515526
+            },
+            {
+              "calls": 15,
+              "head": "PlutusCore.Value.innerDelete",
+              "self_ns": 2742499
+            },
+            {
+              "calls": 958,
+              "head": "PlutusCore.Value.innerHasNegative",
+              "self_ns": 5278647
+            },
+            {
+              "calls": 5374,
+              "head": "PlutusCore.Value.innerHasNegative.match_1",
+              "self_ns": 15730120
+            },
+            {
+              "calls": 24004,
+              "head": "PlutusCore.Value.innerToData",
+              "self_ns": 62015762
+            },
+            {
+              "calls": 708,
+              "head": "PlutusCore.Value.insertCoin",
+              "self_ns": 1199601
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.Value.lookupCoin",
+              "self_ns": 3075792
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.Value.lookupInner",
+              "self_ns": 2976541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Value.maxKeyLen",
+              "self_ns": 8917
+            },
+            {
+              "calls": 7752,
+              "head": "PlutusCore.Value.outerToData",
+              "self_ns": 31006415
+            },
+            {
+              "calls": 7976,
+              "head": "PlutusCore.Value.totalSize.match_1",
+              "self_ns": 27959459
+            },
+            {
+              "calls": 6388,
+              "head": "PlutusCore.Value.unValueData",
+              "self_ns": 7355674
+            },
+            {
+              "calls": 3199,
+              "head": "PlutusCore.Value.unValueData.match_1",
+              "self_ns": 36399394
+            },
+            {
+              "calls": 8135,
+              "head": "PlutusCore.Value.unValueDataCurrencies",
+              "self_ns": 70109801
+            },
+            {
+              "calls": 2616,
+              "head": "PlutusCore.Value.unValueDataCurrencies.match_1",
+              "self_ns": 62670240
+            },
+            {
+              "calls": 2616,
+              "head": "PlutusCore.Value.unValueDataCurrencies.match_3",
+              "self_ns": 73610921
+            },
+            {
+              "calls": 3736,
+              "head": "PlutusCore.Value.unValueDataTokens",
+              "self_ns": 27864978
+            },
+            {
+              "calls": 3458,
+              "head": "PlutusCore.Value.unValueDataTokens.match_1",
+              "self_ns": 79525330
+            },
+            {
+              "calls": 5965,
+              "head": "PlutusCore.Value.unValueDataTokens.match_3",
+              "self_ns": 124869935
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.Value.unionInner",
+              "self_ns": 223709
+            },
+            {
+              "calls": 17368,
+              "head": "PlutusCore.Value.unionInner.match_1",
+              "self_ns": 392628431
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Value.unionInner.match_3",
+              "self_ns": 478334
+            },
+            {
+              "calls": 2512,
+              "head": "PlutusCore.Value.unionOuter",
+              "self_ns": 12158673
+            },
+            {
+              "calls": 37959,
+              "head": "PlutusCore.Value.unionOuter.match_1",
+              "self_ns": 1078203513
+            },
+            {
+              "calls": 8,
+              "head": "PlutusCore.Value.unionOuter.match_3",
+              "self_ns": 164626
+            },
+            {
+              "calls": 2037,
+              "head": "PlutusCore.Value.unionOuter.match_5",
+              "self_ns": 7651659
+            },
+            {
+              "calls": 5004,
+              "head": "PlutusCore.Value.unionValue",
+              "self_ns": 5711306
+            },
+            {
+              "calls": 6262,
+              "head": "PlutusCore.Value.validKey",
+              "self_ns": 7508911
+            },
+            {
+              "calls": 2838,
+              "head": "PlutusCore.Value.validQuantity",
+              "self_ns": 3545997
+            },
+            {
+              "calls": 584,
+              "head": "PlutusCore.Value.valueContains",
+              "self_ns": 776994
+            },
+            {
+              "calls": 4304,
+              "head": "PlutusCore.Value.valueData",
+              "self_ns": 4591439
+            },
+            {
+              "calls": 2,
+              "head": "Pow.pow",
+              "self_ns": 42124
+            },
+            {
+              "calls": 10,
+              "head": "Prod",
+              "self_ns": 33125
+            },
+            {
+              "calls": 5865,
+              "head": "Prod.fst",
+              "self_ns": 32355456
+            },
+            {
+              "calls": 188154,
+              "head": "Prod.mk",
+              "self_ns": 432642225
+            },
+            {
+              "calls": 8360,
+              "head": "Prod.snd",
+              "self_ns": 78303799
+            },
+            {
+              "calls": 1,
+              "head": "String",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "String.instLT",
+              "self_ns": 3083
+            },
+            {
+              "calls": 3132,
+              "head": "String.length",
+              "self_ns": 10975478
+            },
+            {
+              "calls": 2,
+              "head": "WSC.globalInputs1600",
+              "self_ns": 15959
+            },
+            {
+              "calls": 14,
+              "head": "_normalizer",
+              "self_ns": 50201750
+            },
+            {
+              "calls": 2,
+              "head": "instBEqOfDecidableEq",
+              "self_ns": 22041
+            },
+            {
+              "calls": 2,
+              "head": "instHAdd",
+              "self_ns": 24999
+            },
+            {
+              "calls": 3,
+              "head": "instHMul",
+              "self_ns": 17876
+            },
+            {
+              "calls": 2,
+              "head": "instHPow",
+              "self_ns": 22791
+            },
+            {
+              "calls": 1,
+              "head": "instLENat",
+              "self_ns": 3250
+            },
+            {
+              "calls": 1,
+              "head": "instLTNat",
+              "self_ns": 3875
+            },
+            {
+              "calls": 1,
+              "head": "instNatPowNat",
+              "self_ns": 3333
+            },
+            {
+              "calls": 12,
+              "head": "instOfNat",
+              "self_ns": 32042
+            },
+            {
+              "calls": 9,
+              "head": "instOfNatNat",
+              "self_ns": 22333
+            },
+            {
+              "calls": 2,
+              "head": "instPowNat",
+              "self_ns": 19209
+            },
+            {
+              "calls": 26537,
+              "head": "ite",
+              "self_ns": 38160298
+            },
+            {
+              "calls": 1,
+              "head": "programmableLogicGlobal1600",
+              "self_ns": 829708
+            }
+          ],
+          "imbalances": 0,
+          "schema": 1,
+          "status": "complete"
+        }
+      ],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 31,
+          "command_ms": 66697
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 633904,
+      "profile_snapshot_count": 23
+    },
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2340651008,
+      "prep": {
+        "optimize_ms": 40230,
+        "hashcons": 8106674,
+        "contexts": 29063,
+        "beta_cache": 221
+      },
+      "source_sha256": "4e243d97b09ce1311f3d059b793afdbe48f6bd692eec0d05648153a2fa5895ad",
+      "elapsed_seconds": 42.77454283297993,
+      "exit_code": 0,
+      "profiles": [
+        {
+          "active_frames": 0,
+          "cache_bypasses": 11585607,
+          "cache_hits": 25383164,
+          "cache_misses": 4259525,
+          "contexts": 29063,
+          "elapsed_ns": 40225599333,
+          "events": {
+            "Eq.choice_match": 3512,
+            "List.cons.choice_match": 2,
+            "Option.some.choice_ite": 2859,
+            "Option.some.choice_match": 3512,
+            "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr.choice_match": 1,
+            "PlutusCore.UPLC.CekMachine.State.Eval.choice_match": 1,
+            "PlutusCore.UPLC.CekMachine.applyParams.choice_match": 1,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_ite": 2859,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_match": 9816
+          },
+          "hashcons": 8106674,
+          "heads": [
+            {
+              "calls": 7,
+              "head": "And",
+              "self_ns": 68500
+            },
+            {
+              "calls": 2,
+              "head": "Applicative.toPure",
+              "self_ns": 15292
+            },
+            {
+              "calls": 6876,
+              "head": "BEq.beq",
+              "self_ns": 113864392
+            },
+            {
+              "calls": 1251,
+              "head": "Blaster.decide'",
+              "self_ns": 4661582
+            },
+            {
+              "calls": 2524270,
+              "head": "Blaster.dite'",
+              "self_ns": 3035707745
+            },
+            {
+              "calls": 1,
+              "head": "Bool",
+              "self_ns": 2333
+            },
+            {
+              "calls": 7,
+              "head": "Bool.and",
+              "self_ns": 60709
+            },
+            {
+              "calls": 1,
+              "head": "Bool.false",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "Bool.true",
+              "self_ns": 1667
+            },
+            {
+              "calls": 97,
+              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
+              "self_ns": 774619
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
+              "self_ns": 3458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
+              "self_ns": 2625
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
+              "self_ns": 16375
+            },
+            {
+              "calls": 74,
+              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
+              "self_ns": 109419
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.IsData.Class.optionToData",
+              "self_ns": 195167
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.IsData.Class.optionToData.match_1",
+              "self_ns": 179877
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.IsData.Class.toTerm",
+              "self_ns": 37583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.Address",
+              "self_ns": 1791
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
+              "self_ns": 15084
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
+              "self_ns": 14625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
+              "self_ns": 2542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose",
+              "self_ns": 1208
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Certifying",
+              "self_ns": 6875
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Minting",
+              "self_ns": 10375
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Rewarding",
+              "self_ns": 7250
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V1.Contexts.ScriptPurpose.Spending",
+              "self_ns": 11043
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListDCert",
+              "self_ns": 3250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
+              "self_ns": 3000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.instIsDataScriptPurpose",
+              "self_ns": 3833
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V1.Contexts.instReprScriptPurpose.repr.match_1",
+              "self_ns": 262624
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V1.Contexts.scriptPurposeToData",
+              "self_ns": 113166
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData",
+              "self_ns": 13501
+            },
+            {
+              "calls": 38109,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData.go._@.CardanoLedgerApi.V1.Contexts.2955701632._hygCtx._hyg.14",
+              "self_ns": 77082129
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoDCertsToListData.match_1",
+              "self_ns": 155707
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
+              "self_ns": 12208
+            },
+            {
+              "calls": 38095,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 75102550
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 153542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.Credential",
+              "self_ns": 1708
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
+              "self_ns": 7500
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
+              "self_ns": 6834
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
+              "self_ns": 6625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
+              "self_ns": 1375
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
+              "self_ns": 6041
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
+              "self_ns": 10417
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V1.Credential.credentialToData",
+              "self_ns": 78958
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
+              "self_ns": 2833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataPubKeyHash",
+              "self_ns": 2541
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
+              "self_ns": 2500
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
+              "self_ns": 169415
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
+              "self_ns": 136043
+            },
+            {
+              "calls": 11,
+              "head": "CardanoLedgerApi.V1.Credential.stakingCredentialToData",
+              "self_ns": 117083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.DCert.DCert",
+              "self_ns": 2250
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegDeRegKey",
+              "self_ns": 6459
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegDelegate",
+              "self_ns": 9250
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertDelegRegKey",
+              "self_ns": 7417
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertGenesis",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertMir",
+              "self_ns": 958
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertPoolRegister",
+              "self_ns": 8333
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V1.DCert.DCert.DCertPoolRetire",
+              "self_ns": 8083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.DCert.instIsDataDCert",
+              "self_ns": 3458
+            },
+            {
+              "calls": 12,
+              "head": "CardanoLedgerApi.V1.DCert.instReprDCert.repr.match_1",
+              "self_ns": 584502
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Datum",
+              "self_ns": 6709
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
+              "self_ns": 4709
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
+              "self_ns": 6250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
+              "self_ns": 5375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.TxId",
+              "self_ns": 6708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.TxOutRef",
+              "self_ns": 1417
+            },
+            {
+              "calls": 12,
+              "head": "CardanoLedgerApi.V1.Tx.TxOutRef.txOutRefId",
+              "self_ns": 20626
+            },
+            {
+              "calls": 12,
+              "head": "CardanoLedgerApi.V1.Tx.TxOutRef.txOutRefIdx",
+              "self_ns": 21458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
+              "self_ns": 2500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxOutRef",
+              "self_ns": 3125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
+              "self_ns": 6708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.Value",
+              "self_ns": 13125
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
+              "self_ns": 3042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
+              "self_ns": 17666
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.RedeemerMap",
+              "self_ns": 9083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.ScriptContext",
+              "self_ns": 1167
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Contexts.ScriptContext.scriptContextPurpose",
+              "self_ns": 17917
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.ScriptContext.scriptContextTxInfo",
+              "self_ns": 19458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.ScriptPurpose",
+              "self_ns": 9501
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput",
+              "self_ns": 1416
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.ctx",
+              "self_ns": 20917
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.datum",
+              "self_ns": 13625
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.SpendingInput.redeemer",
+              "self_ns": 12750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInInfo",
+              "self_ns": 1250
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInInfo.txInInfoOutRef",
+              "self_ns": 19375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInInfo.txInInfoResolved",
+              "self_ns": 10667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo",
+              "self_ns": 1583
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoDCert",
+              "self_ns": 15334
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoData",
+              "self_ns": 15625
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoFee",
+              "self_ns": 14375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoId",
+              "self_ns": 14375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoInputs",
+              "self_ns": 11916
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoMint",
+              "self_ns": 11000
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoOutputs",
+              "self_ns": 11917
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoRedeemers",
+              "self_ns": 13125
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoReferenceInputs",
+              "self_ns": 11583
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoSignatories",
+              "self_ns": 11334
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoValidRange",
+              "self_ns": 12750
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.TxInfo.txInfoWdrl",
+              "self_ns": 24750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.Withdrawals",
+              "self_ns": 12376
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.findOwnInput.match_1",
+              "self_ns": 194665
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
+              "self_ns": 2709
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxInInfo",
+              "self_ns": 2833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
+              "self_ns": 2958
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataRedeemerMap",
+              "self_ns": 3000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataScriptContext",
+              "self_ns": 3458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataTxInInfo",
+              "self_ns": 7459
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataTxInfo",
+              "self_ns": 2542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataWithdrawals",
+              "self_ns": 2625
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.spendingInputs",
+              "self_ns": 37582
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
+              "self_ns": 13083
+            },
+            {
+              "calls": 38095,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
+              "self_ns": 72313494
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
+              "self_ns": 180791
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData",
+              "self_ns": 18000
+            },
+            {
+              "calls": 114276,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V2.Contexts.2536880513._hygCtx._hyg.14",
+              "self_ns": 188116528
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoInputsToListData.match_1",
+              "self_ns": 190166
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
+              "self_ns": 12791
+            },
+            {
+              "calls": 249,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
+              "self_ns": 3405377
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
+              "self_ns": 158834
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData",
+              "self_ns": 12833
+            },
+            {
+              "calls": 38095,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V2.Contexts.2123419846._hygCtx._hyg.19",
+              "self_ns": 73705743
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoRedeemersToListPairData.match_1",
+              "self_ns": 174543
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData",
+              "self_ns": 11999
+            },
+            {
+              "calls": 38095,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData.go._@.CardanoLedgerApi.V2.Contexts.2635151150._hygCtx._hyg.19",
+              "self_ns": 76127107
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoWdrlToListPairData.match_1",
+              "self_ns": 161249
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
+              "self_ns": 1417
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
+              "self_ns": 1125
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
+              "self_ns": 7292
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
+              "self_ns": 9833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.TxId",
+              "self_ns": 9042
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut",
+              "self_ns": 1208
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
+              "self_ns": 16376
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
+              "self_ns": 12167
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
+              "self_ns": 17750
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
+              "self_ns": 13458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.TxOutRef",
+              "self_ns": 11166
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
+              "self_ns": 2250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
+              "self_ns": 2916
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
+              "self_ns": 139874
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V2.Tx.outputDatumToData",
+              "self_ns": 64249
+            },
+            {
+              "calls": 1251,
+              "head": "Decidable.decide",
+              "self_ns": 1797259
+            },
+            {
+              "calls": 845568,
+              "head": "Eq",
+              "self_ns": 2190667098
+            },
+            {
+              "calls": 1807,
+              "head": "Except",
+              "self_ns": 4006637
+            },
+            {
+              "calls": 1806,
+              "head": "Except.error",
+              "self_ns": 5338930
+            },
+            {
+              "calls": 2,
+              "head": "Except.instMonad",
+              "self_ns": 11833
+            },
+            {
+              "calls": 26657,
+              "head": "Except.ok",
+              "self_ns": 76641332
+            },
+            {
+              "calls": 26655,
+              "head": "Except.pure",
+              "self_ns": 86506106
+            },
+            {
+              "calls": 37,
+              "head": "Function.comp",
+              "self_ns": 131667
+            },
+            {
+              "calls": 3,
+              "head": "HMul.hMul",
+              "self_ns": 61958
+            },
+            {
+              "calls": 2,
+              "head": "Inhabited.default",
+              "self_ns": 30459
+            },
+            {
+              "calls": 1,
+              "head": "Int",
+              "self_ns": 3500
+            },
+            {
+              "calls": 1,
+              "head": "Int.instDecidableEq",
+              "self_ns": 10000
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLEInt",
+              "self_ns": 4625
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLTInt",
+              "self_ns": 4083
+            },
+            {
+              "calls": 1,
+              "head": "Int.instMul",
+              "self_ns": 3458
+            },
+            {
+              "calls": 2,
+              "head": "Int.mul",
+              "self_ns": 18833
+            },
+            {
+              "calls": 7,
+              "head": "Int.negOfNat.match_1",
+              "self_ns": 134709
+            },
+            {
+              "calls": 8,
+              "head": "Int.ofNat",
+              "self_ns": 34124
+            },
+            {
+              "calls": 3,
+              "head": "Int.pow",
+              "self_ns": 7750
+            },
+            {
+              "calls": 1251,
+              "head": "LE.le",
+              "self_ns": 8075052
+            },
+            {
+              "calls": 1259,
+              "head": "LT.lt",
+              "self_ns": 11143843
+            },
+            {
+              "calls": 9831,
+              "head": "List",
+              "self_ns": 16070832
+            },
+            {
+              "calls": 1440138,
+              "head": "List.cons",
+              "self_ns": 3146221226
+            },
+            {
+              "calls": 15504,
+              "head": "List.getLast?.match_1",
+              "self_ns": 240998653
+            },
+            {
+              "calls": 3513,
+              "head": "List.isEmpty",
+              "self_ns": 11071230
+            },
+            {
+              "calls": 16,
+              "head": "List.nil",
+              "self_ns": 53164
+            },
+            {
+              "calls": 2,
+              "head": "Monad.toApplicative",
+              "self_ns": 14542
+            },
+            {
+              "calls": 1809,
+              "head": "MonadExcept.throw",
+              "self_ns": 13003705
+            },
+            {
+              "calls": 1804,
+              "head": "MonadExceptOf.throw",
+              "self_ns": 11383642
+            },
+            {
+              "calls": 2,
+              "head": "Mul.mul",
+              "self_ns": 29167
+            },
+            {
+              "calls": 1,
+              "head": "Nat",
+              "self_ns": 52166
+            },
+            {
+              "calls": 25,
+              "head": "Nat.add",
+              "self_ns": 101584
+            },
+            {
+              "calls": 12,
+              "head": "Nat.add.match_1",
+              "self_ns": 311791
+            },
+            {
+              "calls": 2,
+              "head": "Nat.beq",
+              "self_ns": 5916
+            },
+            {
+              "calls": 14,
+              "head": "Nat.beq.match_1",
+              "self_ns": 319293
+            },
+            {
+              "calls": 2,
+              "head": "Nat.ble",
+              "self_ns": 7333
+            },
+            {
+              "calls": 4,
+              "head": "Nat.mul",
+              "self_ns": 28958
+            },
+            {
+              "calls": 12,
+              "head": "Nat.mul.match_1",
+              "self_ns": 226376
+            },
+            {
+              "calls": 3,
+              "head": "Nat.pow",
+              "self_ns": 8542
+            },
+            {
+              "calls": 6,
+              "head": "Nat.pow.match_1",
+              "self_ns": 135960
+            },
+            {
+              "calls": 2,
+              "head": "Nat.pred",
+              "self_ns": 6959
+            },
+            {
+              "calls": 32,
+              "head": "Nat.sub",
+              "self_ns": 4078876
+            },
+            {
+              "calls": 11,
+              "head": "Nat.succ",
+              "self_ns": 48706
+            },
+            {
+              "calls": 1,
+              "head": "Nat.zero",
+              "self_ns": 2459
+            },
+            {
+              "calls": 1255,
+              "head": "Not",
+              "self_ns": 4246989
+            },
+            {
+              "calls": 13,
+              "head": "OfNat.ofNat",
+              "self_ns": 187584
+            },
+            {
+              "calls": 6309,
+              "head": "Option",
+              "self_ns": 11646877
+            },
+            {
+              "calls": 6306,
+              "head": "Option.none",
+              "self_ns": 12680875
+            },
+            {
+              "calls": 103911,
+              "head": "Option.some",
+              "self_ns": 584884122
+            },
+            {
+              "calls": 9222,
+              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
+              "self_ns": 33100919
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
+              "self_ns": 4500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
+              "self_ns": 5958
+            },
+            {
+              "calls": 2250,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
+              "self_ns": 3076555
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
+              "self_ns": 8166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
+              "self_ns": 1209
+            },
+            {
+              "calls": 144397,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
+              "self_ns": 160828009
+            },
+            {
+              "calls": 303016,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
+              "self_ns": 519319213
+            },
+            {
+              "calls": 98044,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
+              "self_ns": 101180365
+            },
+            {
+              "calls": 95237,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
+              "self_ns": 147346544
+            },
+            {
+              "calls": 159376,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
+              "self_ns": 209983829
+            },
+            {
+              "calls": 3368,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.constrData",
+              "self_ns": 3953725
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
+              "self_ns": 18542
+            },
+            {
+              "calls": 15,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
+              "self_ns": 777000
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
+              "self_ns": 108333
+            },
+            {
+              "calls": 19,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
+              "self_ns": 171875
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
+              "self_ns": 95334
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
+              "self_ns": 310374
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
+              "self_ns": 968210
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
+              "self_ns": 469082
+            },
+            {
+              "calls": 1990,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
+              "self_ns": 2502836
+            },
+            {
+              "calls": 790,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.iData",
+              "self_ns": 1163531
+            },
+            {
+              "calls": 1156,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
+              "self_ns": 1505002
+            },
+            {
+              "calls": 2762,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unBData",
+              "self_ns": 3266754
+            },
+            {
+              "calls": 1387,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unBData.match_1",
+              "self_ns": 46512573
+            },
+            {
+              "calls": 20160,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unConstrData",
+              "self_ns": 20385707
+            },
+            {
+              "calls": 10086,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unConstrData.match_1",
+              "self_ns": 89735616
+            },
+            {
+              "calls": 3012,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unIData",
+              "self_ns": 3388058
+            },
+            {
+              "calls": 1512,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unIData.match_1",
+              "self_ns": 19099251
+            },
+            {
+              "calls": 16,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unListData",
+              "self_ns": 59332
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unListData.match_1",
+              "self_ns": 151377
+            },
+            {
+              "calls": 3400,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unMapData",
+              "self_ns": 4077673
+            },
+            {
+              "calls": 1706,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.unMapData.match_1",
+              "self_ns": 51478037
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
+              "self_ns": 3250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Integer.Integer",
+              "self_ns": 5292
+            },
+            {
+              "calls": 9492,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
+              "self_ns": 9858606
+            },
+            {
+              "calls": 2500,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
+              "self_ns": 3136636
+            },
+            {
+              "calls": 7476,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.headList",
+              "self_ns": 21196233
+            },
+            {
+              "calls": 22868,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.headList.match_1",
+              "self_ns": 219801264
+            },
+            {
+              "calls": 1690,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
+              "self_ns": 6156896
+            },
+            {
+              "calls": 4505,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.tailList",
+              "self_ns": 12535662
+            },
+            {
+              "calls": 6440,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
+              "self_ns": 21315060
+            },
+            {
+              "calls": 6223,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
+              "self_ns": 20858241
+            },
+            {
+              "calls": 18442,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
+              "self_ns": 20195443
+            },
+            {
+              "calls": 9226,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
+              "self_ns": 45897118
+            },
+            {
+              "calls": 1130,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
+              "self_ns": 6897908
+            },
+            {
+              "calls": 2250,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
+              "self_ns": 2853784
+            },
+            {
+              "calls": 3368,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.constrData",
+              "self_ns": 4026174
+            },
+            {
+              "calls": 1689,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.constrData.match_1",
+              "self_ns": 9027552
+            },
+            {
+              "calls": 1990,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
+              "self_ns": 2755631
+            },
+            {
+              "calls": 1000,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
+              "self_ns": 5816003
+            },
+            {
+              "calls": 790,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.iData",
+              "self_ns": 1231811
+            },
+            {
+              "calls": 400,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.iData.match_1",
+              "self_ns": 2750281
+            },
+            {
+              "calls": 1156,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
+              "self_ns": 1701964
+            },
+            {
+              "calls": 583,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
+              "self_ns": 3324678
+            },
+            {
+              "calls": 2762,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
+              "self_ns": 3102919
+            },
+            {
+              "calls": 20160,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
+              "self_ns": 21944373
+            },
+            {
+              "calls": 20166,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
+              "self_ns": 45388061
+            },
+            {
+              "calls": 14681,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
+              "self_ns": 66266295
+            },
+            {
+              "calls": 3012,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
+              "self_ns": 3375233
+            },
+            {
+              "calls": 16,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
+              "self_ns": 59540
+            },
+            {
+              "calls": 3400,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
+              "self_ns": 4178351
+            },
+            {
+              "calls": 129020,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
+              "self_ns": 130548952
+            },
+            {
+              "calls": 64603,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
+              "self_ns": 1535561329
+            },
+            {
+              "calls": 6001,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
+              "self_ns": 28603816
+            },
+            {
+              "calls": 9492,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
+              "self_ns": 10304357
+            },
+            {
+              "calls": 2500,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
+              "self_ns": 3094015
+            },
+            {
+              "calls": 7024,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
+              "self_ns": 8233132
+            },
+            {
+              "calls": 3519,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
+              "self_ns": 23116543
+            },
+            {
+              "calls": 14950,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
+              "self_ns": 15853910
+            },
+            {
+              "calls": 11986,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_1",
+              "self_ns": 62210716
+            },
+            {
+              "calls": 3378,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
+              "self_ns": 4072348
+            },
+            {
+              "calls": 1696,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
+              "self_ns": 11706180
+            },
+            {
+              "calls": 9008,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
+              "self_ns": 10079733
+            },
+            {
+              "calls": 12878,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
+              "self_ns": 13230291
+            },
+            {
+              "calls": 12667,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
+              "self_ns": 60356151
+            },
+            {
+              "calls": 12444,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
+              "self_ns": 12877493
+            },
+            {
+              "calls": 26656,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Utils.tryCatchSome",
+              "self_ns": 93379171
+            },
+            {
+              "calls": 45567,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Utils.tryCatchSome.match_1",
+              "self_ns": 328464967
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
+              "self_ns": 1875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
+              "self_ns": 1250
+            },
+            {
+              "calls": 17,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
+              "self_ns": 29543
+            },
+            {
+              "calls": 8,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
+              "self_ns": 13708
+            },
+            {
+              "calls": 53626,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
+              "self_ns": 50710000
+            },
+            {
+              "calls": 26906,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
+              "self_ns": 279535297
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame",
+              "self_ns": 1375
+            },
+            {
+              "calls": 40,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
+              "self_ns": 37461
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
+              "self_ns": 14541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
+              "self_ns": 1167
+            },
+            {
+              "calls": 226557,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
+              "self_ns": 503566186
+            },
+            {
+              "calls": 7,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
+              "self_ns": 9876
+            },
+            {
+              "calls": 189807,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
+              "self_ns": 327855980
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State",
+              "self_ns": 2833
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State.Error",
+              "self_ns": 1250
+            },
+            {
+              "calls": 376465,
+              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
+              "self_ns": 1191719463
+            },
+            {
+              "calls": 520,
+              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
+              "self_ns": 1202412
+            },
+            {
+              "calls": 316974,
+              "head": "PlutusCore.UPLC.CekMachine.State.Return",
+              "self_ns": 822480378
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.UPLC.CekMachine.applyParams",
+              "self_ns": 3145834
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.UPLC.CekMachine.applyParams.match_1",
+              "self_ns": 133247
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
+              "self_ns": 895459
+            },
+            {
+              "calls": 4,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
+              "self_ns": 81416
+            },
+            {
+              "calls": 129020,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
+              "self_ns": 126241495
+            },
+            {
+              "calls": 89863,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
+              "self_ns": 1445646222
+            },
+            {
+              "calls": 40,
+              "head": "PlutusCore.UPLC.CekMachine.ifArgQOtherwiseError",
+              "self_ns": 66081
+            },
+            {
+              "calls": 44,
+              "head": "PlutusCore.UPLC.CekMachine.ifArgQOtherwiseError.match_1",
+              "self_ns": 135130
+            },
+            {
+              "calls": 204464,
+              "head": "PlutusCore.UPLC.CekMachine.ifArgVOtherwiseError",
+              "self_ns": 210130567
+            },
+            {
+              "calls": 204468,
+              "head": "PlutusCore.UPLC.CekMachine.ifArgVOtherwiseError.match_1",
+              "self_ns": 291714673
+            },
+            {
+              "calls": 830754,
+              "head": "PlutusCore.UPLC.CekMachine.ifBoundOtherwiseError",
+              "self_ns": 3613749652
+            },
+            {
+              "calls": 830757,
+              "head": "PlutusCore.UPLC.CekMachine.ifBoundOtherwiseError.match_1",
+              "self_ns": 2153678537
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.CekMachine.initialState",
+              "self_ns": 12000
+            },
+            {
+              "calls": 710456,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps",
+              "self_ns": 3521115526
+            },
+            {
+              "calls": 698614,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
+              "self_ns": 2307349832
+            },
+            {
+              "calls": 1377878,
+              "head": "PlutusCore.UPLC.CekMachine.step",
+              "self_ns": 1265124235
+            },
+            {
+              "calls": 688980,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
+              "self_ns": 3531131250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekValue.CekValue",
+              "self_ns": 1209
+            },
+            {
+              "calls": 73958,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
+              "self_ns": 384024287
+            },
+            {
+              "calls": 275737,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
+              "self_ns": 457925693
+            },
+            {
+              "calls": 4,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
+              "self_ns": 7875
+            },
+            {
+              "calls": 38570,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
+              "self_ns": 88719048
+            },
+            {
+              "calls": 139689,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
+              "self_ns": 329118001
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekValue.Environment",
+              "self_ns": 2167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekValue.Environment.EmptyEnvironment",
+              "self_ns": 1208
+            },
+            {
+              "calls": 368802,
+              "head": "PlutusCore.UPLC.CekValue.Environment.NonEmptyEnvironment",
+              "self_ns": 921546795
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV2",
+              "self_ns": 1208
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
+              "self_ns": 11792
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun",
+              "self_ns": 2250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
+              "self_ns": 1916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
+              "self_ns": 917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
+              "self_ns": 750
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
+              "self_ns": 833
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
+              "self_ns": 4458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
+              "self_ns": 792
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
+              "self_ns": 833
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
+              "self_ns": 1667
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
+              "self_ns": 917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
+              "self_ns": 916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
+              "self_ns": 2167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
+              "self_ns": 916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
+              "self_ns": 917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
+              "self_ns": 916
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
+              "self_ns": 4250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
+              "self_ns": 1875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
+              "self_ns": 791
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
+              "self_ns": 2292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
+              "self_ns": 958
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
+              "self_ns": 917
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const",
+              "self_ns": 4667
+            },
+            {
+              "calls": 8121,
+              "head": "PlutusCore.UPLC.Term.Const.Bool",
+              "self_ns": 17773782
+            },
+            {
+              "calls": 9654,
+              "head": "PlutusCore.UPLC.Term.Const.ByteString",
+              "self_ns": 12656793
+            },
+            {
+              "calls": 88333,
+              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
+              "self_ns": 152139061
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.UPLC.Term.Const.ConstList",
+              "self_ns": 15583
+            },
+            {
+              "calls": 29780,
+              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
+              "self_ns": 45814117
+            },
+            {
+              "calls": 150182,
+              "head": "PlutusCore.UPLC.Term.Const.Data",
+              "self_ns": 216141045
+            },
+            {
+              "calls": 24359,
+              "head": "PlutusCore.UPLC.Term.Const.Integer",
+              "self_ns": 41766428
+            },
+            {
+              "calls": 10086,
+              "head": "PlutusCore.UPLC.Term.Const.Pair",
+              "self_ns": 18373114
+            },
+            {
+              "calls": 8029,
+              "head": "PlutusCore.UPLC.Term.Const.PairData",
+              "self_ns": 11062182
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const.Unit",
+              "self_ns": 5208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Program",
+              "self_ns": 1250
+            },
+            {
+              "calls": 5,
+              "head": "PlutusCore.UPLC.Term.Program.Program",
+              "self_ns": 20500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term",
+              "self_ns": 875
+            },
+            {
+              "calls": 276,
+              "head": "PlutusCore.UPLC.Term.Term.Apply",
+              "self_ns": 524125
+            },
+            {
+              "calls": 22,
+              "head": "PlutusCore.UPLC.Term.Term.Builtin",
+              "self_ns": 40919
+            },
+            {
+              "calls": 4,
+              "head": "PlutusCore.UPLC.Term.Term.Case",
+              "self_ns": 10583
+            },
+            {
+              "calls": 14,
+              "head": "PlutusCore.UPLC.Term.Term.Const",
+              "self_ns": 27586
+            },
+            {
+              "calls": 5,
+              "head": "PlutusCore.UPLC.Term.Term.Constr",
+              "self_ns": 15167
+            },
+            {
+              "calls": 35,
+              "head": "PlutusCore.UPLC.Term.Term.Delay",
+              "self_ns": 54376
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term.Error",
+              "self_ns": 875
+            },
+            {
+              "calls": 40,
+              "head": "PlutusCore.UPLC.Term.Term.Force",
+              "self_ns": 62004
+            },
+            {
+              "calls": 124,
+              "head": "PlutusCore.UPLC.Term.Term.Lam",
+              "self_ns": 312325
+            },
+            {
+              "calls": 35,
+              "head": "PlutusCore.UPLC.Term.Term.Var",
+              "self_ns": 52333
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.Term.Version.Version",
+              "self_ns": 9958
+            },
+            {
+              "calls": 6,
+              "head": "Prod",
+              "self_ns": 18208
+            },
+            {
+              "calls": 9234,
+              "head": "Prod.fst",
+              "self_ns": 43449072
+            },
+            {
+              "calls": 22710,
+              "head": "Prod.mk",
+              "self_ns": 61466150
+            },
+            {
+              "calls": 8764,
+              "head": "Prod.snd",
+              "self_ns": 51836103
+            },
+            {
+              "calls": 38093,
+              "head": "Pure.pure",
+              "self_ns": 175820515
+            },
+            {
+              "calls": 1,
+              "head": "String",
+              "self_ns": 1708
+            },
+            {
+              "calls": 13,
+              "head": "_normalizer",
+              "self_ns": 56724376
+            },
+            {
+              "calls": 2,
+              "head": "instBEqOfDecidableEq",
+              "self_ns": 23500
+            },
+            {
+              "calls": 2,
+              "head": "instHMul",
+              "self_ns": 21667
+            },
+            {
+              "calls": 1,
+              "head": "instLTNat",
+              "self_ns": 4292
+            },
+            {
+              "calls": 2,
+              "head": "instMonadExceptOfExcept",
+              "self_ns": 13125
+            },
+            {
+              "calls": 2,
+              "head": "instMonadExceptOfMonadExceptOf",
+              "self_ns": 19250
+            },
+            {
+              "calls": 13,
+              "head": "instOfNat",
+              "self_ns": 23958
+            },
+            {
+              "calls": 5,
+              "head": "instOfNatNat",
+              "self_ns": 17916
+            },
+            {
+              "calls": 843487,
+              "head": "ite",
+              "self_ns": 971987370
+            },
+            {
+              "calls": 1,
+              "head": "sellNFT",
+              "self_ns": 306375
+            },
+            {
+              "calls": 1804,
+              "head": "throwThe",
+              "self_ns": 7627288
+            }
+          ],
+          "imbalances": 0,
+          "schema": 1,
+          "status": "complete"
+        }
+      ],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 41253
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 831120,
+      "profile_snapshot_count": 16
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/results/attribution/profile-timeout-check.json
+++ b/Benchmarks/cardano/results/attribution/profile-timeout-check.json
@@ -81,2861 +81,577 @@
           },
           "hashcons": 755671,
           "heads": [
-            {
-              "calls": 126,
-              "head": "Add.add",
-              "self_ns": 839702
-            },
-            {
-              "calls": 8,
-              "head": "And",
-              "self_ns": 83919
-            },
-            {
-              "calls": 545,
-              "head": "BEq.beq",
-              "self_ns": 14578642
-            },
-            {
-              "calls": 810,
-              "head": "Blaster.decide'",
-              "self_ns": 2269085
-            },
-            {
-              "calls": 5591,
-              "head": "Blaster.dite'",
-              "self_ns": 38148984
-            },
-            {
-              "calls": 1,
-              "head": "Bool",
-              "self_ns": 2584
-            },
-            {
-              "calls": 73,
-              "head": "Bool.and",
-              "self_ns": 368114
-            },
-            {
-              "calls": 1,
-              "head": "Bool.false",
-              "self_ns": 1291
-            },
-            {
-              "calls": 251,
-              "head": "Bool.or",
-              "self_ns": 1282588
-            },
-            {
-              "calls": 1,
-              "head": "Bool.true",
-              "self_ns": 1958
-            },
-            {
-              "calls": 239,
-              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
-              "self_ns": 1868144
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
-              "self_ns": 5708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
-              "self_ns": 3083
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
-              "self_ns": 29000
-            },
-            {
-              "calls": 15,
-              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1",
-              "self_ns": 387125
-            },
-            {
-              "calls": 328,
-              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
-              "self_ns": 428865
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.IsData.Class.toTerm",
-              "self_ns": 42333
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.Address",
-              "self_ns": 2000
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
-              "self_ns": 19625
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
-              "self_ns": 28251
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
-              "self_ns": 3083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
-              "self_ns": 5125
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
-              "self_ns": 29833
-            },
-            {
-              "calls": 3731,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 11035506
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
-              "self_ns": 193500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.Credential",
-              "self_ns": 1167
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
-              "self_ns": 8125
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
-              "self_ns": 7500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
-              "self_ns": 8000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
-              "self_ns": 2042
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
-              "self_ns": 8958
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
-              "self_ns": 11542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
-              "self_ns": 3875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
-              "self_ns": 3916
-            },
-            {
-              "calls": 46,
-              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
-              "self_ns": 1274875
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
-              "self_ns": 207000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Datum",
-              "self_ns": 4291
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
-              "self_ns": 5666
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
-              "self_ns": 12375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
-              "self_ns": 7250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
-              "self_ns": 4083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
-              "self_ns": 10875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.Value",
-              "self_ns": 11667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
-              "self_ns": 3792
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
-              "self_ns": 11083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
-              "self_ns": 3167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
-              "self_ns": 8750
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
-              "self_ns": 13292
-            },
-            {
-              "calls": 3731,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
-              "self_ns": 10181078
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
-              "self_ns": 172667
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
-              "self_ns": 23625
-            },
-            {
-              "calls": 399,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
-              "self_ns": 6312452
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
-              "self_ns": 287957
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
-              "self_ns": 1750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
-              "self_ns": 1458
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
-              "self_ns": 7958
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
-              "self_ns": 8333
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut",
-              "self_ns": 1583
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
-              "self_ns": 18250
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
-              "self_ns": 17333
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
-              "self_ns": 21083
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
-              "self_ns": 19000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
-              "self_ns": 3417
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
-              "self_ns": 4041
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
-              "self_ns": 196375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap",
-              "self_ns": 6625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.MintValue",
-              "self_ns": 9875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap",
-              "self_ns": 12542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext",
-              "self_ns": 1417
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer",
-              "self_ns": 13500
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo",
-              "self_ns": 25792
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo",
-              "self_ns": 14667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo",
-              "self_ns": 1625
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript",
-              "self_ns": 9667
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript",
-              "self_ns": 9583
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript",
-              "self_ns": 8458
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript",
-              "self_ns": 11958
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript",
-              "self_ns": 10959
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript",
-              "self_ns": 6542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose",
-              "self_ns": 1958
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying",
-              "self_ns": 14334
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting",
-              "self_ns": 8750
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing",
-              "self_ns": 9666
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding",
-              "self_ns": 7250
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending",
-              "self_ns": 7709
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting",
-              "self_ns": 8167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo",
-              "self_ns": 1416
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef",
-              "self_ns": 16417
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved",
-              "self_ns": 11583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo",
-              "self_ns": 1791
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount",
-              "self_ns": 15708
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData",
-              "self_ns": 13291
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee",
-              "self_ns": 23209
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId",
-              "self_ns": 20083
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs",
-              "self_ns": 12791
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint",
-              "self_ns": 15375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs",
-              "self_ns": 16541
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures",
-              "self_ns": 21542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers",
-              "self_ns": 16125
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs",
-              "self_ns": 32708
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories",
-              "self_ns": 18542
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation",
-              "self_ns": 15333
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts",
-              "self_ns": 14000
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange",
-              "self_ns": 22666
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes",
-              "self_ns": 12875
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl",
-              "self_ns": 18167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.VoterMap",
-              "self_ns": 8125
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData",
-              "self_ns": 18041
-            },
-            {
-              "calls": 26,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19",
-              "self_ns": 3237083
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1",
-              "self_ns": 204832
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap",
-              "self_ns": 4667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure",
-              "self_ns": 4084
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert",
-              "self_ns": 4458
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo",
-              "self_ns": 2708
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap",
-              "self_ns": 3667
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext",
-              "self_ns": 3875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo",
-              "self_ns": 4000
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose",
-              "self_ns": 4875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo",
-              "self_ns": 3917
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo",
-              "self_ns": 3958
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap",
-              "self_ns": 3083
-            },
-            {
-              "calls": 9,
-              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1",
-              "self_ns": 235750
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1",
-              "self_ns": 461917
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs",
-              "self_ns": 33709
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1",
-              "self_ns": 224582
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData",
-              "self_ns": 15667
-            },
-            {
-              "calls": 7556,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14",
-              "self_ns": 14738976
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1",
-              "self_ns": 333999
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData",
-              "self_ns": 20625
-            },
-            {
-              "calls": 3735,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14",
-              "self_ns": 10123911
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1",
-              "self_ns": 177041
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData",
-              "self_ns": 15584
-            },
-            {
-              "calls": 3869,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19",
-              "self_ns": 10937996
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1",
-              "self_ns": 279626
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData",
-              "self_ns": 15541
-            },
-            {
-              "calls": 3847,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14",
-              "self_ns": 11839841
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1",
-              "self_ns": 229750
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData",
-              "self_ns": 13375
-            },
-            {
-              "calls": 3741,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19",
-              "self_ns": 9890843
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1",
-              "self_ns": 179916
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId",
-              "self_ns": 2041
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx",
-              "self_ns": 14833
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId",
-              "self_ns": 22542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure",
-              "self_ns": 1166
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit",
-              "self_ns": 18957
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction",
-              "self_ns": 15041
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr",
-              "self_ns": 16208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo",
-              "self_ns": 6083
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Voter",
-              "self_ns": 1625
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter",
-              "self_ns": 7042
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter",
-              "self_ns": 10500
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter",
-              "self_ns": 5875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.Withdrawals",
-              "self_ns": 13542
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId",
-              "self_ns": 5041
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers",
-              "self_ns": 4500
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure",
-              "self_ns": 3375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataVote",
-              "self_ns": 3291
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter",
-              "self_ns": 3875
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1",
-              "self_ns": 129792
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1",
-              "self_ns": 220001
-            },
-            {
-              "calls": 2,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData",
-              "self_ns": 17583
-            },
-            {
-              "calls": 87,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19",
-              "self_ns": 5664334
-            },
-            {
-              "calls": 7,
-              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1",
-              "self_ns": 278625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.TxId",
-              "self_ns": 8417
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef",
-              "self_ns": 1584
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId",
-              "self_ns": 19709
-            },
-            {
-              "calls": 8,
-              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx",
-              "self_ns": 16833
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId",
-              "self_ns": 5583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef",
-              "self_ns": 2875
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential",
-              "self_ns": 6750
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep",
-              "self_ns": 1500
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep",
-              "self_ns": 7250
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.DRepCredential",
-              "self_ns": 6625
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee",
-              "self_ns": 12417
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake",
-              "self_ns": 7667
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote",
-              "self_ns": 9208
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote",
-              "self_ns": 8791
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential",
-              "self_ns": 5583
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert",
-              "self_ns": 4083
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee",
-              "self_ns": 10459
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking",
-              "self_ns": 11750
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister",
-              "self_ns": 9459
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire",
-              "self_ns": 9375
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep",
-              "self_ns": 9875
-            },
-            {
-              "calls": 5,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg",
-              "self_ns": 12000
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking",
-              "self_ns": 13458
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee",
-              "self_ns": 6917
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep",
-              "self_ns": 9583
-            },
-            {
-              "calls": 4,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking",
-              "self_ns": 11000
-            },
-            {
-              "calls": 3,
-              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep",
-              "self_ns": 7084
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep",
-              "self_ns": 3709
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee",
-              "self_ns": 3041
-            },
-            {
-              "calls": 1,
-              "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert",
-              "self_ns": 5209
-            },
-            {
-              "calls": 14,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1",
-              "self_ns": 353708
-            },
-            {
-              "calls": 10,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1",
-              "self_ns": 327462
-            },
-            {
-              "calls": 16,
-              "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1",
-              "self_ns": 1485249
-            },
-            {
-              "calls": 681,
-              "head": "Decidable.decide",
-              "self_ns": 850719
-            },
-            {
-              "calls": 2212,
-              "head": "Eq",
-              "self_ns": 16524774
-            },
-            {
-              "calls": 13,
-              "head": "Function.comp",
-              "self_ns": 77833
-            },
-            {
-              "calls": 132,
-              "head": "HAdd.hAdd",
-              "self_ns": 907438
-            },
-            {
-              "calls": 181,
-              "head": "HMul.hMul",
-              "self_ns": 1102403
-            },
-            {
-              "calls": 2,
-              "head": "HPow.hPow",
-              "self_ns": 52333
-            },
-            {
-              "calls": 2,
-              "head": "Inhabited.default",
-              "self_ns": 30708
-            },
-            {
-              "calls": 1,
-              "head": "Int",
-              "self_ns": 3292
-            },
-            {
-              "calls": 376,
-              "head": "Int.add",
-              "self_ns": 1230431
-            },
-            {
-              "calls": 1,
-              "head": "Int.instAdd",
-              "self_ns": 3792
-            },
-            {
-              "calls": 1,
-              "head": "Int.instDecidableEq",
-              "self_ns": 6167
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLEInt",
-              "self_ns": 5917
-            },
-            {
-              "calls": 1,
-              "head": "Int.instLTInt",
-              "self_ns": 3917
-            },
-            {
-              "calls": 1,
-              "head": "Int.instMul",
-              "self_ns": 3333
-            },
-            {
-              "calls": 610,
-              "head": "Int.mul",
-              "self_ns": 2072920
-            },
-            {
-              "calls": 244,
-              "head": "Int.natAbs",
-              "self_ns": 288080
-            },
-            {
-              "calls": 124,
-              "head": "Int.neg",
-              "self_ns": 304073
-            },
-            {
-              "calls": 127,
-              "head": "Int.neg.match_1",
-              "self_ns": 3977311
-            },
-            {
-              "calls": 7,
-              "head": "Int.negOfNat.match_1",
-              "self_ns": 135292
-            },
-            {
-              "calls": 5,
-              "head": "Int.negSucc",
-              "self_ns": 17416
-            },
-            {
-              "calls": 15,
-              "head": "Int.ofNat",
-              "self_ns": 42085
-            },
-            {
-              "calls": 3,
-              "head": "Int.pow",
-              "self_ns": 8333
-            },
-            {
-              "calls": 246,
-              "head": "Int.toNat",
-              "self_ns": 622964
-            },
-            {
-              "calls": 350,
-              "head": "LE.le",
-              "self_ns": 1894489
-            },
-            {
-              "calls": 1121,
-              "head": "LT.lt",
-              "self_ns": 5902608
-            },
-            {
-              "calls": 234,
-              "head": "List",
-              "self_ns": 412490
-            },
-            {
-              "calls": 229961,
-              "head": "List.cons",
-              "self_ns": 481276433
-            },
-            {
-              "calls": 7,
-              "head": "List.drop",
-              "self_ns": 4424416
-            },
-            {
-              "calls": 8419,
-              "head": "List.get?Internal",
-              "self_ns": 39619300
-            },
-            {
-              "calls": 556,
-              "head": "List.getLast?.match_1",
-              "self_ns": 7304600
-            },
-            {
-              "calls": 341,
-              "head": "List.isEmpty",
-              "self_ns": 1016240
-            },
-            {
-              "calls": 1025,
-              "head": "List.nil",
-              "self_ns": 1714124
-            },
-            {
-              "calls": 1005,
-              "head": "List.reverse",
-              "self_ns": 3116005
-            },
-            {
-              "calls": 1005,
-              "head": "List.reverseAux",
-              "self_ns": 5487822
-            },
-            {
-              "calls": 13,
-              "head": "List.take.match_1",
-              "self_ns": 314708
-            },
-            {
-              "calls": 124,
-              "head": "Mul.mul",
-              "self_ns": 845083
-            },
-            {
-              "calls": 1,
-              "head": "Nat",
-              "self_ns": 43125
-            },
-            {
-              "calls": 152,
-              "head": "Nat.add",
-              "self_ns": 635176
-            },
-            {
-              "calls": 12,
-              "head": "Nat.add.match_1",
-              "self_ns": 333459
-            },
-            {
-              "calls": 2,
-              "head": "Nat.beq",
-              "self_ns": 10750
-            },
-            {
-              "calls": 14,
-              "head": "Nat.beq.match_1",
-              "self_ns": 362374
-            },
-            {
-              "calls": 2,
-              "head": "Nat.ble",
-              "self_ns": 8417
-            },
-            {
-              "calls": 4,
-              "head": "Nat.mul",
-              "self_ns": 21584
-            },
-            {
-              "calls": 12,
-              "head": "Nat.mul.match_1",
-              "self_ns": 237208
-            },
-            {
-              "calls": 4,
-              "head": "Nat.pow",
-              "self_ns": 15707
-            },
-            {
-              "calls": 6,
-              "head": "Nat.pow.match_1",
-              "self_ns": 121126
-            },
-            {
-              "calls": 2,
-              "head": "Nat.pred",
-              "self_ns": 8375
-            },
-            {
-              "calls": 154,
-              "head": "Nat.sub",
-              "self_ns": 4085414
-            },
-            {
-              "calls": 135,
-              "head": "Nat.succ",
-              "self_ns": 238032
-            },
-            {
-              "calls": 1,
-              "head": "Nat.zero",
-              "self_ns": 2416
-            },
-            {
-              "calls": 2,
-              "head": "NatPow.pow",
-              "self_ns": 29001
-            },
-            {
-              "calls": 475,
-              "head": "Not",
-              "self_ns": 1351920
-            },
-            {
-              "calls": 21,
-              "head": "OfNat.ofNat",
-              "self_ns": 320207
-            },
-            {
-              "calls": 777,
-              "head": "Option",
-              "self_ns": 1254621
-            },
-            {
-              "calls": 2140,
-              "head": "Option.getD.match_1",
-              "self_ns": 28071129
-            },
-            {
-              "calls": 401,
-              "head": "Option.map",
-              "self_ns": 1682548
-            },
-            {
-              "calls": 717,
-              "head": "Option.none",
-              "self_ns": 1283213
-            },
-            {
-              "calls": 7553,
-              "head": "Option.some",
-              "self_ns": 33278406
-            },
-            {
-              "calls": 127,
-              "head": "Or",
-              "self_ns": 909165
-            },
-            {
-              "calls": 512,
-              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
-              "self_ns": 2069244
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
-              "self_ns": 7208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1843,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data",
-              "self_ns": 1684935
-            },
-            {
-              "calls": 558,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length",
-              "self_ns": 553946
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
-              "self_ns": 6292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString",
-              "self_ns": 7000
-            },
-            {
-              "calls": 38,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
-              "self_ns": 66002
-            },
-            {
-              "calls": 26,
-              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString",
-              "self_ns": 57085
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
-              "self_ns": 4375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
-              "self_ns": 1792
-            },
-            {
-              "calls": 19822,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
-              "self_ns": 20990829
-            },
-            {
-              "calls": 31236,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
-              "self_ns": 52749807
-            },
-            {
-              "calls": 10713,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
-              "self_ns": 11365024
-            },
-            {
-              "calls": 22123,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
-              "self_ns": 26947877
-            },
-            {
-              "calls": 15442,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
-              "self_ns": 22492559
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
-              "self_ns": 16251
-            },
-            {
-              "calls": 51,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
-              "self_ns": 909165
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
-              "self_ns": 84292
-            },
-            {
-              "calls": 19,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
-              "self_ns": 149208
-            },
-            {
-              "calls": 10,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
-              "self_ns": 74918
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
-              "self_ns": 288541
-            },
-            {
-              "calls": 45,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
-              "self_ns": 306416
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
-              "self_ns": 370000
-            },
-            {
-              "calls": 420,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
-              "self_ns": 594322
-            },
-            {
-              "calls": 538,
-              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
-              "self_ns": 601303
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
-              "self_ns": 3834
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Integer.Integer",
-              "self_ns": 7584
-            },
-            {
-              "calls": 82,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger",
-              "self_ns": 198626
-            },
-            {
-              "calls": 244,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
-              "self_ns": 337632
-            },
-            {
-              "calls": 136,
-              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
-              "self_ns": 201627
-            },
-            {
-              "calls": 7,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
-              "self_ns": 49916
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.List.PlutusCore.ListInternal.nullList",
-              "self_ns": 61877
-            },
-            {
-              "calls": 163,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
-              "self_ns": 617636
-            },
-            {
-              "calls": 456,
-              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
-              "self_ns": 1601926
-            },
-            {
-              "calls": 1022,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
-              "self_ns": 1224239
-            },
-            {
-              "calls": 516,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
-              "self_ns": 2827748
-            },
-            {
-              "calls": 37,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
-              "self_ns": 572543
-            },
-            {
-              "calls": 38,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
-              "self_ns": 71375
-            },
-            {
-              "calls": 26,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString",
-              "self_ns": 66541
-            },
-            {
-              "calls": 420,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
-              "self_ns": 539460
-            },
-            {
-              "calls": 215,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
-              "self_ns": 1546968
-            },
-            {
-              "calls": 538,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
-              "self_ns": 628295
-            },
-            {
-              "calls": 274,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
-              "self_ns": 1513406
-            },
-            {
-              "calls": 80,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
-              "self_ns": 101123
-            },
-            {
-              "calls": 45,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1",
-              "self_ns": 863828
-            },
-            {
-              "calls": 1106,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
-              "self_ns": 1251760
-            },
-            {
-              "calls": 559,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
-              "self_ns": 13098821
-            },
-            {
-              "calls": 785,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
-              "self_ns": 3657055
-            },
-            {
-              "calls": 16,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
-              "self_ns": 39874
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1",
-              "self_ns": 296457
-            },
-            {
-              "calls": 192,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
-              "self_ns": 273954
-            },
-            {
-              "calls": 101,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1",
-              "self_ns": 603207
-            },
-            {
-              "calls": 164,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
-              "self_ns": 231831
-            },
-            {
-              "calls": 87,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1",
-              "self_ns": 1940127
-            },
-            {
-              "calls": 9882,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
-              "self_ns": 9706134
-            },
-            {
-              "calls": 5041,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
-              "self_ns": 59033445
-            },
-            {
-              "calls": 82,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger",
-              "self_ns": 119336
-            },
-            {
-              "calls": 236,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
-              "self_ns": 1437899
-            },
-            {
-              "calls": 244,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
-              "self_ns": 304202
-            },
-            {
-              "calls": 136,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
-              "self_ns": 166950
-            },
-            {
-              "calls": 656,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
-              "self_ns": 761638
-            },
-            {
-              "calls": 335,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
-              "self_ns": 2514166
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList",
-              "self_ns": 25541
-            },
-            {
-              "calls": 8,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1",
-              "self_ns": 744459
-            },
-            {
-              "calls": 2004,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
-              "self_ns": 2035130
-            },
-            {
-              "calls": 2314,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3",
-              "self_ns": 26847744
-            },
-            {
-              "calls": 276,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5",
-              "self_ns": 3946580
-            },
-            {
-              "calls": 1552,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7",
-              "self_ns": 8042136
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
-              "self_ns": 51835
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
-              "self_ns": 768707
-            },
-            {
-              "calls": 24,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList",
-              "self_ns": 57624
-            },
-            {
-              "calls": 1062,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
-              "self_ns": 1138138
-            },
-            {
-              "calls": 324,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
-              "self_ns": 379040
-            },
-            {
-              "calls": 623,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
-              "self_ns": 3135153
-            },
-            {
-              "calls": 910,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
-              "self_ns": 1023677
-            },
-            {
-              "calls": 488,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData",
-              "self_ns": 613993
-            },
-            {
-              "calls": 249,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1",
-              "self_ns": 1256708
-            },
-            {
-              "calls": 162,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue",
-              "self_ns": 268049
-            },
-            {
-              "calls": 161,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1",
-              "self_ns": 1189623
-            },
-            {
-              "calls": 150,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains",
-              "self_ns": 242619
-            },
-            {
-              "calls": 24,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData",
-              "self_ns": 47500
-            },
-            {
-              "calls": 17,
-              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1",
-              "self_ns": 254045
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
-              "self_ns": 1667
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
-              "self_ns": 6458
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
-              "self_ns": 63999
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
-              "self_ns": 13166
-            },
-            {
-              "calls": 4016,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
-              "self_ns": 4074893
-            },
-            {
-              "calls": 2108,
-              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
-              "self_ns": 34671147
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame",
-              "self_ns": 1459
-            },
-            {
-              "calls": 3386,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
-              "self_ns": 6829597
-            },
-            {
-              "calls": 5549,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
-              "self_ns": 16144931
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
-              "self_ns": 1292
-            },
-            {
-              "calls": 10014,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
-              "self_ns": 22377123
-            },
-            {
-              "calls": 3129,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
-              "self_ns": 5674355
-            },
-            {
-              "calls": 7630,
-              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
-              "self_ns": 13203334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State",
-              "self_ns": 2375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekMachine.State.Error",
-              "self_ns": 1708
-            },
-            {
-              "calls": 23083,
-              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
-              "self_ns": 67554133
-            },
-            {
-              "calls": 77,
-              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
-              "self_ns": 198626
-            },
-            {
-              "calls": 22083,
-              "head": "PlutusCore.UPLC.CekMachine.State.Return",
-              "self_ns": 55020953
-            },
-            {
-              "calls": 14,
-              "head": "PlutusCore.UPLC.CekMachine.applyParams",
-              "self_ns": 3783750
-            },
-            {
-              "calls": 3,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
-              "self_ns": 56794
-            },
-            {
-              "calls": 4,
-              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
-              "self_ns": 89416
-            },
-            {
-              "calls": 9882,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
-              "self_ns": 10561102
-            },
-            {
-              "calls": 16088,
-              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
-              "self_ns": 212234794
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.CekMachine.initialState",
-              "self_ns": 12959
-            },
-            {
-              "calls": 48942,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps",
-              "self_ns": 323361684
-            },
-            {
-              "calls": 46127,
-              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
-              "self_ns": 149961878
-            },
-            {
-              "calls": 89708,
-              "head": "PlutusCore.UPLC.CekMachine.step",
-              "self_ns": 83534104
-            },
-            {
-              "calls": 4131,
-              "head": "PlutusCore.UPLC.CekMachine.step.folding",
-              "self_ns": 20295711
-            },
-            {
-              "calls": 5138,
-              "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1",
-              "self_ns": 11454025
-            },
-            {
-              "calls": 4143,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_1",
-              "self_ns": 11464955
-            },
-            {
-              "calls": 1021,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_11",
-              "self_ns": 3825034
-            },
-            {
-              "calls": 21863,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_13",
-              "self_ns": 60025241
-            },
-            {
-              "calls": 44861,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_15",
-              "self_ns": 119238793
-            },
-            {
-              "calls": 22937,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
-              "self_ns": 71026036
-            },
-            {
-              "calls": 9749,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_5",
-              "self_ns": 28427407
-            },
-            {
-              "calls": 1133,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_7",
-              "self_ns": 3427933
-            },
-            {
-              "calls": 1009,
-              "head": "PlutusCore.UPLC.CekMachine.step.match_9",
-              "self_ns": 3855244
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.CekValue.CekValue",
-              "self_ns": 1584
-            },
-            {
-              "calls": 4506,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
-              "self_ns": 11295643
-            },
-            {
-              "calls": 50105,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
-              "self_ns": 74946292
-            },
-            {
-              "calls": 1008,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
-              "self_ns": 2210078
-            },
-            {
-              "calls": 2328,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
-              "self_ns": 5325750
-            },
-            {
-              "calls": 9569,
-              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
-              "self_ns": 21501048
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3",
-              "self_ns": 1792
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
-              "self_ns": 15041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun",
-              "self_ns": 1541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
-              "self_ns": 959
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
-              "self_ns": 1000
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
-              "self_ns": 1416
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
-              "self_ns": 875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
-              "self_ns": 1459
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
-              "self_ns": 1166
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
-              "self_ns": 13625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
-              "self_ns": 1459
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
-              "self_ns": 1500
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
-              "self_ns": 1042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
-              "self_ns": 1209
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
-              "self_ns": 1084
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
-              "self_ns": 1375
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
-              "self_ns": 1334
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
-              "self_ns": 1459
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue",
-              "self_ns": 1208
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
-              "self_ns": 1584
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
-              "self_ns": 1875
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
-              "self_ns": 1417
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
-              "self_ns": 1041
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
-              "self_ns": 1541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
-              "self_ns": 1625
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData",
-              "self_ns": 1333
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue",
-              "self_ns": 1291
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData",
-              "self_ns": 1125
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
-              "self_ns": 1542
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
-              "self_ns": 1250
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
-              "self_ns": 1167
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
-              "self_ns": 1083
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const",
-              "self_ns": 1416
-            },
-            {
-              "calls": 599,
-              "head": "PlutusCore.UPLC.Term.Const.Bool",
-              "self_ns": 1169240
-            },
-            {
-              "calls": 1539,
-              "head": "PlutusCore.UPLC.Term.Const.ByteString",
-              "self_ns": 1524255
-            },
-            {
-              "calls": 29879,
-              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
-              "self_ns": 46332073
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.UPLC.Term.Const.ConstList",
-              "self_ns": 17083
-            },
-            {
-              "calls": 6964,
-              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
-              "self_ns": 10090036
-            },
-            {
-              "calls": 14672,
-              "head": "PlutusCore.UPLC.Term.Const.Data",
-              "self_ns": 17165281
-            },
-            {
-              "calls": 1691,
-              "head": "PlutusCore.UPLC.Term.Const.Integer",
-              "self_ns": 2161264
-            },
-            {
-              "calls": 2426,
-              "head": "PlutusCore.UPLC.Term.Const.Pair",
-              "self_ns": 3976382
-            },
-            {
-              "calls": 136,
-              "head": "PlutusCore.UPLC.Term.Const.PairData",
-              "self_ns": 216701
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Const.Unit",
-              "self_ns": 1458
-            },
-            {
-              "calls": 1365,
-              "head": "PlutusCore.UPLC.Term.Const.Value",
-              "self_ns": 2354698
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Program",
-              "self_ns": 1875
-            },
-            {
-              "calls": 5,
-              "head": "PlutusCore.UPLC.Term.Program.Program",
-              "self_ns": 18627
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term",
-              "self_ns": 1416
-            },
-            {
-              "calls": 532,
-              "head": "PlutusCore.UPLC.Term.Term.Apply",
-              "self_ns": 1123635
-            },
-            {
-              "calls": 29,
-              "head": "PlutusCore.UPLC.Term.Term.Builtin",
-              "self_ns": 54582
-            },
-            {
-              "calls": 78,
-              "head": "PlutusCore.UPLC.Term.Term.Case",
-              "self_ns": 170539
-            },
-            {
-              "calls": 17,
-              "head": "PlutusCore.UPLC.Term.Term.Const",
-              "self_ns": 65376
-            },
-            {
-              "calls": 78,
-              "head": "PlutusCore.UPLC.Term.Term.Constr",
-              "self_ns": 165885
-            },
-            {
-              "calls": 83,
-              "head": "PlutusCore.UPLC.Term.Term.Delay",
-              "self_ns": 147785
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.UPLC.Term.Term.Error",
-              "self_ns": 1166
-            },
-            {
-              "calls": 70,
-              "head": "PlutusCore.UPLC.Term.Term.Force",
-              "self_ns": 124909
-            },
-            {
-              "calls": 199,
-              "head": "PlutusCore.UPLC.Term.Term.Lam",
-              "self_ns": 309829
-            },
-            {
-              "calls": 125,
-              "head": "PlutusCore.UPLC.Term.Term.Var",
-              "self_ns": 136461
-            },
-            {
-              "calls": 2,
-              "head": "PlutusCore.UPLC.Term.Version.Version",
-              "self_ns": 12541
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Value.ValueRep",
-              "self_ns": 15666
-            },
-            {
-              "calls": 558,
-              "head": "PlutusCore.Value.ascendingFrom",
-              "self_ns": 666212
-            },
-            {
-              "calls": 286,
-              "head": "PlutusCore.Value.ascendingFrom.match_1",
-              "self_ns": 1043047
-            },
-            {
-              "calls": 72,
-              "head": "PlutusCore.Value.containedInner",
-              "self_ns": 2514255
-            },
-            {
-              "calls": 163,
-              "head": "PlutusCore.Value.containedOuter",
-              "self_ns": 2476878
-            },
-            {
-              "calls": 268,
-              "head": "PlutusCore.Value.hasNegativeAmount",
-              "self_ns": 3055174
-            },
-            {
-              "calls": 252,
-              "head": "PlutusCore.Value.innerHasNegative",
-              "self_ns": 2964288
-            },
-            {
-              "calls": 206,
-              "head": "PlutusCore.Value.innerHasNegative.match_1",
-              "self_ns": 1040417
-            },
-            {
-              "calls": 1077,
-              "head": "PlutusCore.Value.innerToData",
-              "self_ns": 4799950
-            },
-            {
-              "calls": 12,
-              "head": "PlutusCore.Value.lookupCoin",
-              "self_ns": 3238042
-            },
-            {
-              "calls": 9,
-              "head": "PlutusCore.Value.lookupInner",
-              "self_ns": 3316042
-            },
-            {
-              "calls": 1,
-              "head": "PlutusCore.Value.maxKeyLen",
-              "self_ns": 9208
-            },
-            {
-              "calls": 26,
-              "head": "PlutusCore.Value.outerToData",
-              "self_ns": 2868167
-            },
-            {
-              "calls": 368,
-              "head": "PlutusCore.Value.totalSize.match_1",
-              "self_ns": 1454533
-            },
-            {
-              "calls": 488,
-              "head": "PlutusCore.Value.unValueData",
-              "self_ns": 585710
-            },
-            {
-              "calls": 249,
-              "head": "PlutusCore.Value.unValueData.match_1",
-              "self_ns": 1824457
-            },
-            {
-              "calls": 472,
-              "head": "PlutusCore.Value.unValueDataCurrencies",
-              "self_ns": 44060949
-            },
-            {
-              "calls": 187,
-              "head": "PlutusCore.Value.unValueDataCurrencies.match_1",
-              "self_ns": 1966504
-            },
-            {
-              "calls": 187,
-              "head": "PlutusCore.Value.unValueDataCurrencies.match_3",
-              "self_ns": 1945499
-            },
-            {
-              "calls": 268,
-              "head": "PlutusCore.Value.unValueDataTokens",
-              "self_ns": 14044214
-            },
-            {
-              "calls": 241,
-              "head": "PlutusCore.Value.unValueDataTokens.match_1",
-              "self_ns": 4318160
-            },
-            {
-              "calls": 463,
-              "head": "PlutusCore.Value.unValueDataTokens.match_3",
-              "self_ns": 5812591
-            },
-            {
-              "calls": 13,
-              "head": "PlutusCore.Value.unionInner",
-              "self_ns": 221502
-            },
-            {
-              "calls": 1462,
-              "head": "PlutusCore.Value.unionInner.match_1",
-              "self_ns": 24416342
-            },
-            {
-              "calls": 11,
-              "head": "PlutusCore.Value.unionInner.match_3",
-              "self_ns": 399752
-            },
-            {
-              "calls": 91,
-              "head": "PlutusCore.Value.unionOuter",
-              "self_ns": 610793
-            },
-            {
-              "calls": 454,
-              "head": "PlutusCore.Value.unionOuter.match_1",
-              "self_ns": 7267292
-            },
-            {
-              "calls": 8,
-              "head": "PlutusCore.Value.unionOuter.match_3",
-              "self_ns": 145416
-            },
-            {
-              "calls": 56,
-              "head": "PlutusCore.Value.unionOuter.match_5",
-              "self_ns": 644411
-            },
-            {
-              "calls": 162,
-              "head": "PlutusCore.Value.unionValue",
-              "self_ns": 226746
-            },
-            {
-              "calls": 558,
-              "head": "PlutusCore.Value.validKey",
-              "self_ns": 615632
-            },
-            {
-              "calls": 244,
-              "head": "PlutusCore.Value.validQuantity",
-              "self_ns": 318128
-            },
-            {
-              "calls": 150,
-              "head": "PlutusCore.Value.valueContains",
-              "self_ns": 246663
-            },
-            {
-              "calls": 24,
-              "head": "PlutusCore.Value.valueData",
-              "self_ns": 39461
-            },
-            {
-              "calls": 2,
-              "head": "Pow.pow",
-              "self_ns": 42500
-            },
-            {
-              "calls": 10,
-              "head": "Prod",
-              "self_ns": 34585
-            },
-            {
-              "calls": 255,
-              "head": "Prod.fst",
-              "self_ns": 1543493
-            },
-            {
-              "calls": 13066,
-              "head": "Prod.mk",
-              "self_ns": 29069902
-            },
-            {
-              "calls": 497,
-              "head": "Prod.snd",
-              "self_ns": 4405112
-            },
-            {
-              "calls": 1,
-              "head": "String",
-              "self_ns": 1292
-            },
-            {
-              "calls": 1,
-              "head": "String.instLT",
-              "self_ns": 2916
-            },
-            {
-              "calls": 280,
-              "head": "String.length",
-              "self_ns": 925748
-            },
-            {
-              "calls": 2,
-              "head": "WSC.globalInputs1600",
-              "self_ns": 22583
-            },
-            {
-              "calls": 14,
-              "head": "_normalizer",
-              "self_ns": 23366582
-            },
-            {
-              "calls": 2,
-              "head": "instBEqOfDecidableEq",
-              "self_ns": 21958
-            },
-            {
-              "calls": 2,
-              "head": "instHAdd",
-              "self_ns": 18124
-            },
-            {
-              "calls": 3,
-              "head": "instHMul",
-              "self_ns": 19751
-            },
-            {
-              "calls": 2,
-              "head": "instHPow",
-              "self_ns": 19375
-            },
-            {
-              "calls": 1,
-              "head": "instLENat",
-              "self_ns": 7792
-            },
-            {
-              "calls": 1,
-              "head": "instLTNat",
-              "self_ns": 5166
-            },
-            {
-              "calls": 1,
-              "head": "instNatPowNat",
-              "self_ns": 3375
-            },
-            {
-              "calls": 12,
-              "head": "instOfNat",
-              "self_ns": 30415
-            },
-            {
-              "calls": 9,
-              "head": "instOfNatNat",
-              "self_ns": 24042
-            },
-            {
-              "calls": 2,
-              "head": "instPowNat",
-              "self_ns": 16625
-            },
-            {
-              "calls": 1798,
-              "head": "ite",
-              "self_ns": 2560443
-            },
-            {
-              "calls": 1,
-              "head": "programmableLogicGlobal1600",
-              "self_ns": 1033833
-            }
+            {"calls": 126, "head": "Add.add", "self_ns": 839702},
+            {"calls": 8, "head": "And", "self_ns": 83919},
+            {"calls": 545, "head": "BEq.beq", "self_ns": 14578642},
+            {"calls": 810, "head": "Blaster.decide'", "self_ns": 2269085},
+            {"calls": 5591, "head": "Blaster.dite'", "self_ns": 38148984},
+            {"calls": 1, "head": "Bool", "self_ns": 2584},
+            {"calls": 73, "head": "Bool.and", "self_ns": 368114},
+            {"calls": 1, "head": "Bool.false", "self_ns": 1291},
+            {"calls": 251, "head": "Bool.or", "self_ns": 1282588},
+            {"calls": 1, "head": "Bool.true", "self_ns": 1958},
+            {"calls": 239, "head": "CardanoLedgerApi.IsData.Class.IsData.toData", "self_ns": 1868144},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataData", "self_ns": 5708},
+            {"calls": 1, "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger", "self_ns": 3083},
+            {"calls": 4, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption", "self_ns": 29000},
+            {"calls": 15, "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1", "self_ns": 387125},
+            {"calls": 328, "head": "CardanoLedgerApi.IsData.Class.mkDataConstr", "self_ns": 428865},
+            {"calls": 5, "head": "CardanoLedgerApi.IsData.Class.toTerm", "self_ns": 42333},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.Address", "self_ns": 2000},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressCredential", "self_ns": 19625},
+            {"calls": 8, "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential", "self_ns": 28251},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Address.instIsDataAddress", "self_ns": 3083},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash", "self_ns": 5125},
+            {"calls": 2, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData", "self_ns": 29833},
+            {"calls": 3731, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 11035506},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14", "self_ns": 193500},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.Credential", "self_ns": 1167},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential", "self_ns": 8125},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential", "self_ns": 7500},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.PubKeyHash", "self_ns": 8000},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.StakingCredential", "self_ns": 2042},
+            {"calls": 3, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash", "self_ns": 8958},
+            {"calls": 5, "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr", "self_ns": 11542},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential", "self_ns": 3875},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential", "self_ns": 3916},
+            {"calls": 46, "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1", "self_ns": 1274875},
+            {"calls": 7, "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1", "self_ns": 207000},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Datum", "self_ns": 4291},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.DatumHash", "self_ns": 5666},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.Redeemer", "self_ns": 12375},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Scripts.ScriptHash", "self_ns": 7250},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId", "self_ns": 4083},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.CurrencySymbol", "self_ns": 10875},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.Value", "self_ns": 11667},
+            {"calls": 1, "head": "CardanoLedgerApi.V1.Value.instIsDataValue", "self_ns": 3792},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.DatumMap", "self_ns": 11083},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap", "self_ns": 3167},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut", "self_ns": 8750},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData", "self_ns": 13292},
+            {"calls": 3731, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19", "self_ns": 10181078},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1", "self_ns": 172667},
+            {"calls": 2, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData", "self_ns": 23625},
+            {"calls": 399, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14", "self_ns": 6312452},
+            {"calls": 7, "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1", "self_ns": 287957},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum", "self_ns": 1750},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum", "self_ns": 1458},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum", "self_ns": 7958},
+            {"calls": 3, "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash", "self_ns": 8333},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.TxOut", "self_ns": 1583},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress", "self_ns": 18250},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum", "self_ns": 17333},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript", "self_ns": 21083},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue", "self_ns": 19000},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum", "self_ns": 3417},
+            {"calls": 1, "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut", "self_ns": 4041},
+            {"calls": 8, "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1", "self_ns": 196375},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap", "self_ns": 6625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.MintValue", "self_ns": 9875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap", "self_ns": 12542},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext", "self_ns": 1417},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer", "self_ns": 13500},
+            {"calls": 9, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo", "self_ns": 25792},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo", "self_ns": 14667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo", "self_ns": 1625},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript", "self_ns": 9667},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript", "self_ns": 9583},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript", "self_ns": 8458},
+            {"calls": 5, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript", "self_ns": 11958},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript", "self_ns": 10959},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript", "self_ns": 6542},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose", "self_ns": 1958},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying", "self_ns": 14334},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting", "self_ns": 8750},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing", "self_ns": 9666},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding", "self_ns": 7250},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending", "self_ns": 7709},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting", "self_ns": 8167},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo", "self_ns": 1416},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef", "self_ns": 16417},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved", "self_ns": 11583},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.TxInfo", "self_ns": 1791},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount", "self_ns": 15708},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData", "self_ns": 13291},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee", "self_ns": 23209},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId", "self_ns": 20083},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs", "self_ns": 12791},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint", "self_ns": 15375},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs", "self_ns": 16541},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures", "self_ns": 21542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers", "self_ns": 16125},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs", "self_ns": 32708},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories", "self_ns": 18542},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation", "self_ns": 15333},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts", "self_ns": 14000},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange", "self_ns": 22666},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes", "self_ns": 12875},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl", "self_ns": 18167},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.VoterMap", "self_ns": 8125},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData", "self_ns": 18041},
+            {"calls": 26, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19", "self_ns": 3237083},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1", "self_ns": 204832},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap", "self_ns": 4667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure", "self_ns": 4084},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert", "self_ns": 4458},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo", "self_ns": 2708},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap", "self_ns": 3667},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext", "self_ns": 3875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo", "self_ns": 4000},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose", "self_ns": 4875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo", "self_ns": 3917},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo", "self_ns": 3958},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap", "self_ns": 3083},
+            {"calls": 9, "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1", "self_ns": 235750},
+            {"calls": 10, "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1", "self_ns": 461917},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs", "self_ns": 33709},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1", "self_ns": 224582},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData", "self_ns": 15667},
+            {"calls": 7556, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14", "self_ns": 14738976},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1", "self_ns": 333999},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData", "self_ns": 20625},
+            {"calls": 3735, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14", "self_ns": 10123911},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1", "self_ns": 177041},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData", "self_ns": 15584},
+            {"calls": 3869, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19", "self_ns": 10937996},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1", "self_ns": 279626},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData", "self_ns": 15541},
+            {"calls": 3847, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14", "self_ns": 11839841},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1", "self_ns": 229750},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData", "self_ns": 13375},
+            {"calls": 3741, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19", "self_ns": 9890843},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1", "self_ns": 179916},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId", "self_ns": 2041},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx", "self_ns": 14833},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId", "self_ns": 22542},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure", "self_ns": 1166},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit", "self_ns": 18957},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction", "self_ns": 15041},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr", "self_ns": 16208},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote", "self_ns": 1500},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain", "self_ns": 1167},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo", "self_ns": 6083},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes", "self_ns": 1208},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Voter", "self_ns": 1625},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter", "self_ns": 7042},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter", "self_ns": 10500},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter", "self_ns": 5875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.Withdrawals", "self_ns": 13542},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId", "self_ns": 5041},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers", "self_ns": 4500},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure", "self_ns": 3375},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataVote", "self_ns": 3291},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter", "self_ns": 3875},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1", "self_ns": 129792},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1", "self_ns": 220001},
+            {"calls": 2, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData", "self_ns": 17583},
+            {"calls": 87, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19", "self_ns": 5664334},
+            {"calls": 7, "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1", "self_ns": 278625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.TxId", "self_ns": 8417},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.TxOutRef", "self_ns": 1584},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId", "self_ns": 19709},
+            {"calls": 8, "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx", "self_ns": 16833},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId", "self_ns": 5583},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef", "self_ns": 2875},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential", "self_ns": 6750},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep", "self_ns": 1500},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep", "self_ns": 7250},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain", "self_ns": 1375},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence", "self_ns": 1291},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.DRepCredential", "self_ns": 6625},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.Delegatee", "self_ns": 12417},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake", "self_ns": 7667},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote", "self_ns": 9208},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote", "self_ns": 8791},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential", "self_ns": 5583},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.TxCert", "self_ns": 4083},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee", "self_ns": 10459},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking", "self_ns": 11750},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister", "self_ns": 9459},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire", "self_ns": 9375},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep", "self_ns": 9875},
+            {"calls": 5, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg", "self_ns": 12000},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking", "self_ns": 13458},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee", "self_ns": 6917},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep", "self_ns": 9583},
+            {"calls": 4, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking", "self_ns": 11000},
+            {"calls": 3, "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep", "self_ns": 7084},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep", "self_ns": 3709},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee", "self_ns": 3041},
+            {"calls": 1, "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert", "self_ns": 5209},
+            {"calls": 14, "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1", "self_ns": 353708},
+            {"calls": 10, "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1", "self_ns": 327462},
+            {"calls": 16, "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1", "self_ns": 1485249},
+            {"calls": 681, "head": "Decidable.decide", "self_ns": 850719},
+            {"calls": 2212, "head": "Eq", "self_ns": 16524774},
+            {"calls": 13, "head": "Function.comp", "self_ns": 77833},
+            {"calls": 132, "head": "HAdd.hAdd", "self_ns": 907438},
+            {"calls": 181, "head": "HMul.hMul", "self_ns": 1102403},
+            {"calls": 2, "head": "HPow.hPow", "self_ns": 52333},
+            {"calls": 2, "head": "Inhabited.default", "self_ns": 30708},
+            {"calls": 1, "head": "Int", "self_ns": 3292},
+            {"calls": 376, "head": "Int.add", "self_ns": 1230431},
+            {"calls": 1, "head": "Int.instAdd", "self_ns": 3792},
+            {"calls": 1, "head": "Int.instDecidableEq", "self_ns": 6167},
+            {"calls": 1, "head": "Int.instLEInt", "self_ns": 5917},
+            {"calls": 1, "head": "Int.instLTInt", "self_ns": 3917},
+            {"calls": 1, "head": "Int.instMul", "self_ns": 3333},
+            {"calls": 610, "head": "Int.mul", "self_ns": 2072920},
+            {"calls": 244, "head": "Int.natAbs", "self_ns": 288080},
+            {"calls": 124, "head": "Int.neg", "self_ns": 304073},
+            {"calls": 127, "head": "Int.neg.match_1", "self_ns": 3977311},
+            {"calls": 7, "head": "Int.negOfNat.match_1", "self_ns": 135292},
+            {"calls": 5, "head": "Int.negSucc", "self_ns": 17416},
+            {"calls": 15, "head": "Int.ofNat", "self_ns": 42085},
+            {"calls": 3, "head": "Int.pow", "self_ns": 8333},
+            {"calls": 246, "head": "Int.toNat", "self_ns": 622964},
+            {"calls": 350, "head": "LE.le", "self_ns": 1894489},
+            {"calls": 1121, "head": "LT.lt", "self_ns": 5902608},
+            {"calls": 234, "head": "List", "self_ns": 412490},
+            {"calls": 229961, "head": "List.cons", "self_ns": 481276433},
+            {"calls": 7, "head": "List.drop", "self_ns": 4424416},
+            {"calls": 8419, "head": "List.get?Internal", "self_ns": 39619300},
+            {"calls": 556, "head": "List.getLast?.match_1", "self_ns": 7304600},
+            {"calls": 341, "head": "List.isEmpty", "self_ns": 1016240},
+            {"calls": 1025, "head": "List.nil", "self_ns": 1714124},
+            {"calls": 1005, "head": "List.reverse", "self_ns": 3116005},
+            {"calls": 1005, "head": "List.reverseAux", "self_ns": 5487822},
+            {"calls": 13, "head": "List.take.match_1", "self_ns": 314708},
+            {"calls": 124, "head": "Mul.mul", "self_ns": 845083},
+            {"calls": 1, "head": "Nat", "self_ns": 43125},
+            {"calls": 152, "head": "Nat.add", "self_ns": 635176},
+            {"calls": 12, "head": "Nat.add.match_1", "self_ns": 333459},
+            {"calls": 2, "head": "Nat.beq", "self_ns": 10750},
+            {"calls": 14, "head": "Nat.beq.match_1", "self_ns": 362374},
+            {"calls": 2, "head": "Nat.ble", "self_ns": 8417},
+            {"calls": 4, "head": "Nat.mul", "self_ns": 21584},
+            {"calls": 12, "head": "Nat.mul.match_1", "self_ns": 237208},
+            {"calls": 4, "head": "Nat.pow", "self_ns": 15707},
+            {"calls": 6, "head": "Nat.pow.match_1", "self_ns": 121126},
+            {"calls": 2, "head": "Nat.pred", "self_ns": 8375},
+            {"calls": 154, "head": "Nat.sub", "self_ns": 4085414},
+            {"calls": 135, "head": "Nat.succ", "self_ns": 238032},
+            {"calls": 1, "head": "Nat.zero", "self_ns": 2416},
+            {"calls": 2, "head": "NatPow.pow", "self_ns": 29001},
+            {"calls": 475, "head": "Not", "self_ns": 1351920},
+            {"calls": 21, "head": "OfNat.ofNat", "self_ns": 320207},
+            {"calls": 777, "head": "Option", "self_ns": 1254621},
+            {"calls": 2140, "head": "Option.getD.match_1", "self_ns": 28071129},
+            {"calls": 401, "head": "Option.map", "self_ns": 1682548},
+            {"calls": 717, "head": "Option.none", "self_ns": 1283213},
+            {"calls": 7553, "head": "Option.some", "self_ns": 33278406},
+            {"calls": 127, "head": "Or", "self_ns": 909165},
+            {"calls": 512, "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse", "self_ns": 2069244},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString", "self_ns": 7208},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString", "self_ns": 1292},
+            {"calls": 1843, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data", "self_ns": 1684935},
+            {"calls": 558, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length", "self_ns": 553946},
+            {"calls": 3, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk", "self_ns": 6292},
+            {"calls": 1, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString", "self_ns": 7000},
+            {"calls": 38, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString", "self_ns": 66002},
+            {"calls": 26, "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString", "self_ns": 57085},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData", "self_ns": 4375},
+            {"calls": 1, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data", "self_ns": 1792},
+            {"calls": 19822, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B", "self_ns": 20990829},
+            {"calls": 31236, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr", "self_ns": 52749807},
+            {"calls": 10713, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I", "self_ns": 11365024},
+            {"calls": 22123, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List", "self_ns": 26947877},
+            {"calls": 15442, "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map", "self_ns": 22492559},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData", "self_ns": 16251},
+            {"calls": 51, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1", "self_ns": 909165},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr", "self_ns": 84292},
+            {"calls": 19, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1", "self_ns": 149208},
+            {"calls": 10, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList", "self_ns": 74918},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1", "self_ns": 288541},
+            {"calls": 45, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap", "self_ns": 306416},
+            {"calls": 11, "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1", "self_ns": 370000},
+            {"calls": 420, "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData", "self_ns": 594322},
+            {"calls": 538, "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData", "self_ns": 601303},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant", "self_ns": 3834},
+            {"calls": 1, "head": "PlutusCore.Integer.Integer", "self_ns": 7584},
+            {"calls": 82, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger", "self_ns": 198626},
+            {"calls": 244, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger", "self_ns": 337632},
+            {"calls": 136, "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger", "self_ns": 201627},
+            {"calls": 7, "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons", "self_ns": 49916},
+            {"calls": 13, "head": "PlutusCore.List.PlutusCore.ListInternal.nullList", "self_ns": 61877},
+            {"calls": 163, "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair", "self_ns": 617636},
+            {"calls": 456, "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair", "self_ns": 1601926},
+            {"calls": 1022, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse", "self_ns": 1224239},
+            {"calls": 516, "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1", "self_ns": 2827748},
+            {"calls": 37, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1", "self_ns": 572543},
+            {"calls": 38, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString", "self_ns": 71375},
+            {"calls": 26, "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString", "self_ns": 66541},
+            {"calls": 420, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData", "self_ns": 539460},
+            {"calls": 215, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1", "self_ns": 1546968},
+            {"calls": 538, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData", "self_ns": 628295},
+            {"calls": 274, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1", "self_ns": 1513406},
+            {"calls": 80, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData", "self_ns": 101123},
+            {"calls": 45, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1", "self_ns": 863828},
+            {"calls": 1106, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData", "self_ns": 1251760},
+            {"calls": 559, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1", "self_ns": 13098821},
+            {"calls": 785, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3", "self_ns": 3657055},
+            {"calls": 16, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData", "self_ns": 39874},
+            {"calls": 13, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1", "self_ns": 296457},
+            {"calls": 192, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData", "self_ns": 273954},
+            {"calls": 101, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1", "self_ns": 603207},
+            {"calls": 164, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData", "self_ns": 231831},
+            {"calls": 87, "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1", "self_ns": 1940127},
+            {"calls": 9882, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction", "self_ns": 9706134},
+            {"calls": 5041, "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1", "self_ns": 59033445},
+            {"calls": 82, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger", "self_ns": 119336},
+            {"calls": 236, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1", "self_ns": 1437899},
+            {"calls": 244, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger", "self_ns": 304202},
+            {"calls": 136, "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger", "self_ns": 166950},
+            {"calls": 656, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList", "self_ns": 761638},
+            {"calls": 335, "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1", "self_ns": 2514166},
+            {"calls": 2, "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList", "self_ns": 25541},
+            {"calls": 8, "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1", "self_ns": 744459},
+            {"calls": 2004, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList", "self_ns": 2035130},
+            {"calls": 2314, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3", "self_ns": 26847744},
+            {"calls": 276, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5", "self_ns": 3946580},
+            {"calls": 1552, "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7", "self_ns": 8042136},
+            {"calls": 12, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons", "self_ns": 51835},
+            {"calls": 13, "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1", "self_ns": 768707},
+            {"calls": 24, "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList", "self_ns": 57624},
+            {"calls": 1062, "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList", "self_ns": 1138138},
+            {"calls": 324, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair", "self_ns": 379040},
+            {"calls": 623, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1", "self_ns": 3135153},
+            {"calls": 910, "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair", "self_ns": 1023677},
+            {"calls": 488, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData", "self_ns": 613993},
+            {"calls": 249, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1", "self_ns": 1256708},
+            {"calls": 162, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue", "self_ns": 268049},
+            {"calls": 161, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1", "self_ns": 1189623},
+            {"calls": 150, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains", "self_ns": 242619},
+            {"calls": 24, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData", "self_ns": 47500},
+            {"calls": 17, "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1", "self_ns": 254045},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ", "self_ns": 1667},
+            {"calls": 1, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV", "self_ns": 6458},
+            {"calls": 12, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More", "self_ns": 63999},
+            {"calls": 3, "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One", "self_ns": 13166},
+            {"calls": 4016, "head": "PlutusCore.UPLC.Builtins.expectedArgs", "self_ns": 4074893},
+            {"calls": 2108, "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1", "self_ns": 34671147},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame", "self_ns": 1459},
+            {"calls": 3386, "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee", "self_ns": 6829597},
+            {"calls": 5549, "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument", "self_ns": 16144931},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame", "self_ns": 1292},
+            {"calls": 10014, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm", "self_ns": 22377123},
+            {"calls": 3129, "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue", "self_ns": 5674355},
+            {"calls": 7630, "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue", "self_ns": 13203334},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State", "self_ns": 2375},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekMachine.State.Error", "self_ns": 1708},
+            {"calls": 23083, "head": "PlutusCore.UPLC.CekMachine.State.Eval", "self_ns": 67554133},
+            {"calls": 77, "head": "PlutusCore.UPLC.CekMachine.State.Halt", "self_ns": 198626},
+            {"calls": 22083, "head": "PlutusCore.UPLC.CekMachine.State.Return", "self_ns": 55020953},
+            {"calls": 14, "head": "PlutusCore.UPLC.CekMachine.applyParams", "self_ns": 3783750},
+            {"calls": 3, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram", "self_ns": 56794},
+            {"calls": 4, "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1", "self_ns": 89416},
+            {"calls": 9882, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin", "self_ns": 10561102},
+            {"calls": 16088, "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1", "self_ns": 212234794},
+            {"calls": 2, "head": "PlutusCore.UPLC.CekMachine.initialState", "self_ns": 12959},
+            {"calls": 48942, "head": "PlutusCore.UPLC.CekMachine.runSteps", "self_ns": 323361684},
+            {"calls": 46127, "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1", "self_ns": 149961878},
+            {"calls": 89708, "head": "PlutusCore.UPLC.CekMachine.step", "self_ns": 83534104},
+            {"calls": 4131, "head": "PlutusCore.UPLC.CekMachine.step.folding", "self_ns": 20295711},
+            {"calls": 5138, "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1", "self_ns": 11454025},
+            {"calls": 4143, "head": "PlutusCore.UPLC.CekMachine.step.match_1", "self_ns": 11464955},
+            {"calls": 1021, "head": "PlutusCore.UPLC.CekMachine.step.match_11", "self_ns": 3825034},
+            {"calls": 21863, "head": "PlutusCore.UPLC.CekMachine.step.match_13", "self_ns": 60025241},
+            {"calls": 44861, "head": "PlutusCore.UPLC.CekMachine.step.match_15", "self_ns": 119238793},
+            {"calls": 22937, "head": "PlutusCore.UPLC.CekMachine.step.match_3", "self_ns": 71026036},
+            {"calls": 9749, "head": "PlutusCore.UPLC.CekMachine.step.match_5", "self_ns": 28427407},
+            {"calls": 1133, "head": "PlutusCore.UPLC.CekMachine.step.match_7", "self_ns": 3427933},
+            {"calls": 1009, "head": "PlutusCore.UPLC.CekMachine.step.match_9", "self_ns": 3855244},
+            {"calls": 1, "head": "PlutusCore.UPLC.CekValue.CekValue", "self_ns": 1584},
+            {"calls": 4506, "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin", "self_ns": 11295643},
+            {"calls": 50105, "head": "PlutusCore.UPLC.CekValue.CekValue.VCon", "self_ns": 74946292},
+            {"calls": 1008, "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr", "self_ns": 2210078},
+            {"calls": 2328, "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay", "self_ns": 5325750},
+            {"calls": 9569, "head": "PlutusCore.UPLC.CekValue.CekValue.VLam", "self_ns": 21501048},
+            {"calls": 1, "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3", "self_ns": 1792},
+            {"calls": 2, "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk", "self_ns": 15041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun", "self_ns": 1541},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.BData", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224", "self_ns": 959},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul", "self_ns": 1000},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData", "self_ns": 1416},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString", "self_ns": 875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString", "self_ns": 1459},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData", "self_ns": 1166},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IData", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString", "self_ns": 13625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256", "self_ns": 1459},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger", "self_ns": 1500},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData", "self_ns": 1042},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData", "self_ns": 1209},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData", "self_ns": 1084},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger", "self_ns": 1375},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList", "self_ns": 1334},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit", "self_ns": 1458},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger", "self_ns": 1459},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue", "self_ns": 1208},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256", "self_ns": 1584},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger", "self_ns": 1875},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList", "self_ns": 1417},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace", "self_ns": 1041},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData", "self_ns": 1541},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData", "self_ns": 1625},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData", "self_ns": 1333},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue", "self_ns": 1291},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData", "self_ns": 1125},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature", "self_ns": 1542},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature", "self_ns": 1292},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature", "self_ns": 1250},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits", "self_ns": 1167},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString", "self_ns": 1083},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const", "self_ns": 1416},
+            {"calls": 599, "head": "PlutusCore.UPLC.Term.Const.Bool", "self_ns": 1169240},
+            {"calls": 1539, "head": "PlutusCore.UPLC.Term.Const.ByteString", "self_ns": 1524255},
+            {"calls": 29879, "head": "PlutusCore.UPLC.Term.Const.ConstDataList", "self_ns": 46332073},
+            {"calls": 11, "head": "PlutusCore.UPLC.Term.Const.ConstList", "self_ns": 17083},
+            {"calls": 6964, "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList", "self_ns": 10090036},
+            {"calls": 14672, "head": "PlutusCore.UPLC.Term.Const.Data", "self_ns": 17165281},
+            {"calls": 1691, "head": "PlutusCore.UPLC.Term.Const.Integer", "self_ns": 2161264},
+            {"calls": 2426, "head": "PlutusCore.UPLC.Term.Const.Pair", "self_ns": 3976382},
+            {"calls": 136, "head": "PlutusCore.UPLC.Term.Const.PairData", "self_ns": 216701},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Const.Unit", "self_ns": 1458},
+            {"calls": 1365, "head": "PlutusCore.UPLC.Term.Const.Value", "self_ns": 2354698},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Program", "self_ns": 1875},
+            {"calls": 5, "head": "PlutusCore.UPLC.Term.Program.Program", "self_ns": 18627},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term", "self_ns": 1416},
+            {"calls": 532, "head": "PlutusCore.UPLC.Term.Term.Apply", "self_ns": 1123635},
+            {"calls": 29, "head": "PlutusCore.UPLC.Term.Term.Builtin", "self_ns": 54582},
+            {"calls": 78, "head": "PlutusCore.UPLC.Term.Term.Case", "self_ns": 170539},
+            {"calls": 17, "head": "PlutusCore.UPLC.Term.Term.Const", "self_ns": 65376},
+            {"calls": 78, "head": "PlutusCore.UPLC.Term.Term.Constr", "self_ns": 165885},
+            {"calls": 83, "head": "PlutusCore.UPLC.Term.Term.Delay", "self_ns": 147785},
+            {"calls": 1, "head": "PlutusCore.UPLC.Term.Term.Error", "self_ns": 1166},
+            {"calls": 70, "head": "PlutusCore.UPLC.Term.Term.Force", "self_ns": 124909},
+            {"calls": 199, "head": "PlutusCore.UPLC.Term.Term.Lam", "self_ns": 309829},
+            {"calls": 125, "head": "PlutusCore.UPLC.Term.Term.Var", "self_ns": 136461},
+            {"calls": 2, "head": "PlutusCore.UPLC.Term.Version.Version", "self_ns": 12541},
+            {"calls": 1, "head": "PlutusCore.Value.ValueRep", "self_ns": 15666},
+            {"calls": 558, "head": "PlutusCore.Value.ascendingFrom", "self_ns": 666212},
+            {"calls": 286, "head": "PlutusCore.Value.ascendingFrom.match_1", "self_ns": 1043047},
+            {"calls": 72, "head": "PlutusCore.Value.containedInner", "self_ns": 2514255},
+            {"calls": 163, "head": "PlutusCore.Value.containedOuter", "self_ns": 2476878},
+            {"calls": 268, "head": "PlutusCore.Value.hasNegativeAmount", "self_ns": 3055174},
+            {"calls": 252, "head": "PlutusCore.Value.innerHasNegative", "self_ns": 2964288},
+            {"calls": 206, "head": "PlutusCore.Value.innerHasNegative.match_1", "self_ns": 1040417},
+            {"calls": 1077, "head": "PlutusCore.Value.innerToData", "self_ns": 4799950},
+            {"calls": 12, "head": "PlutusCore.Value.lookupCoin", "self_ns": 3238042},
+            {"calls": 9, "head": "PlutusCore.Value.lookupInner", "self_ns": 3316042},
+            {"calls": 1, "head": "PlutusCore.Value.maxKeyLen", "self_ns": 9208},
+            {"calls": 26, "head": "PlutusCore.Value.outerToData", "self_ns": 2868167},
+            {"calls": 368, "head": "PlutusCore.Value.totalSize.match_1", "self_ns": 1454533},
+            {"calls": 488, "head": "PlutusCore.Value.unValueData", "self_ns": 585710},
+            {"calls": 249, "head": "PlutusCore.Value.unValueData.match_1", "self_ns": 1824457},
+            {"calls": 472, "head": "PlutusCore.Value.unValueDataCurrencies", "self_ns": 44060949},
+            {"calls": 187, "head": "PlutusCore.Value.unValueDataCurrencies.match_1", "self_ns": 1966504},
+            {"calls": 187, "head": "PlutusCore.Value.unValueDataCurrencies.match_3", "self_ns": 1945499},
+            {"calls": 268, "head": "PlutusCore.Value.unValueDataTokens", "self_ns": 14044214},
+            {"calls": 241, "head": "PlutusCore.Value.unValueDataTokens.match_1", "self_ns": 4318160},
+            {"calls": 463, "head": "PlutusCore.Value.unValueDataTokens.match_3", "self_ns": 5812591},
+            {"calls": 13, "head": "PlutusCore.Value.unionInner", "self_ns": 221502},
+            {"calls": 1462, "head": "PlutusCore.Value.unionInner.match_1", "self_ns": 24416342},
+            {"calls": 11, "head": "PlutusCore.Value.unionInner.match_3", "self_ns": 399752},
+            {"calls": 91, "head": "PlutusCore.Value.unionOuter", "self_ns": 610793},
+            {"calls": 454, "head": "PlutusCore.Value.unionOuter.match_1", "self_ns": 7267292},
+            {"calls": 8, "head": "PlutusCore.Value.unionOuter.match_3", "self_ns": 145416},
+            {"calls": 56, "head": "PlutusCore.Value.unionOuter.match_5", "self_ns": 644411},
+            {"calls": 162, "head": "PlutusCore.Value.unionValue", "self_ns": 226746},
+            {"calls": 558, "head": "PlutusCore.Value.validKey", "self_ns": 615632},
+            {"calls": 244, "head": "PlutusCore.Value.validQuantity", "self_ns": 318128},
+            {"calls": 150, "head": "PlutusCore.Value.valueContains", "self_ns": 246663},
+            {"calls": 24, "head": "PlutusCore.Value.valueData", "self_ns": 39461},
+            {"calls": 2, "head": "Pow.pow", "self_ns": 42500},
+            {"calls": 10, "head": "Prod", "self_ns": 34585},
+            {"calls": 255, "head": "Prod.fst", "self_ns": 1543493},
+            {"calls": 13066, "head": "Prod.mk", "self_ns": 29069902},
+            {"calls": 497, "head": "Prod.snd", "self_ns": 4405112},
+            {"calls": 1, "head": "String", "self_ns": 1292},
+            {"calls": 1, "head": "String.instLT", "self_ns": 2916},
+            {"calls": 280, "head": "String.length", "self_ns": 925748},
+            {"calls": 2, "head": "WSC.globalInputs1600", "self_ns": 22583},
+            {"calls": 14, "head": "_normalizer", "self_ns": 23366582},
+            {"calls": 2, "head": "instBEqOfDecidableEq", "self_ns": 21958},
+            {"calls": 2, "head": "instHAdd", "self_ns": 18124},
+            {"calls": 3, "head": "instHMul", "self_ns": 19751},
+            {"calls": 2, "head": "instHPow", "self_ns": 19375},
+            {"calls": 1, "head": "instLENat", "self_ns": 7792},
+            {"calls": 1, "head": "instLTNat", "self_ns": 5166},
+            {"calls": 1, "head": "instNatPowNat", "self_ns": 3375},
+            {"calls": 12, "head": "instOfNat", "self_ns": 30415},
+            {"calls": 9, "head": "instOfNatNat", "self_ns": 24042},
+            {"calls": 2, "head": "instPowNat", "self_ns": 16625},
+            {"calls": 1798, "head": "ite", "self_ns": 2560443},
+            {"calls": 1, "head": "programmableLogicGlobal1600", "self_ns": 1033833}
           ],
           "imbalances": 0,
           "schema": 1,

--- a/Benchmarks/cardano/results/attribution/profile-timeout-check.json
+++ b/Benchmarks/cardano/results/attribution/profile-timeout-check.json
@@ -1,0 +1,2951 @@
+{
+  "label": "profile-timeout-check",
+  "repeat": 1,
+  "timeout_seconds": 6.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "4b0ddd06368cd68149074768ed279753fd3e0802",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "4029c6f75ee465b33d90fb208390e4894bd03d52da04940e11f895d841ccf016",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": true,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "timeout",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 1723908096,
+      "prep": {},
+      "source_sha256": "c72f5457ab5df7526b42fa873f2d5bf0da18eb3ad903107505e5ab605286dc62",
+      "elapsed_seconds": 6.123394374968484,
+      "exit_code": -9,
+      "profiles": [
+        {
+          "active_frames": 3311,
+          "cache_bypasses": 462835,
+          "cache_hits": 1537995,
+          "cache_misses": 537165,
+          "contexts": 5131,
+          "elapsed_ns": 2869711625,
+          "events": {
+            "Eq.choice_match": 211,
+            "List.cons.choice_ite": 2,
+            "List.cons.choice_match": 582,
+            "Option.some.choice_ite": 1,
+            "Option.some.choice_match": 213,
+            "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr.choice_match": 280,
+            "PlutusCore.UPLC.CekMachine.State.Eval.choice_match": 2,
+            "PlutusCore.UPLC.CekMachine.applyParams.choice_match": 2,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_ite": 526,
+            "PlutusCore.UPLC.CekMachine.runSteps.choice_match": 1255,
+            "PlutusCore.UPLC.CekValue.CekValue.VCon.choice_match": 3,
+            "PlutusCore.UPLC.Term.Const.Bool.choice_match": 3,
+            "PlutusCore.UPLC.Term.Const.Data.choice_match": 1,
+            "PlutusCore.UPLC.Term.Term.Const.choice_match": 1,
+            "Prod.mk.choice_ite": 2,
+            "Prod.mk.choice_match": 46
+          },
+          "hashcons": 755671,
+          "heads": [
+            {
+              "calls": 126,
+              "head": "Add.add",
+              "self_ns": 839702
+            },
+            {
+              "calls": 8,
+              "head": "And",
+              "self_ns": 83919
+            },
+            {
+              "calls": 545,
+              "head": "BEq.beq",
+              "self_ns": 14578642
+            },
+            {
+              "calls": 810,
+              "head": "Blaster.decide'",
+              "self_ns": 2269085
+            },
+            {
+              "calls": 5591,
+              "head": "Blaster.dite'",
+              "self_ns": 38148984
+            },
+            {
+              "calls": 1,
+              "head": "Bool",
+              "self_ns": 2584
+            },
+            {
+              "calls": 73,
+              "head": "Bool.and",
+              "self_ns": 368114
+            },
+            {
+              "calls": 1,
+              "head": "Bool.false",
+              "self_ns": 1291
+            },
+            {
+              "calls": 251,
+              "head": "Bool.or",
+              "self_ns": 1282588
+            },
+            {
+              "calls": 1,
+              "head": "Bool.true",
+              "self_ns": 1958
+            },
+            {
+              "calls": 239,
+              "head": "CardanoLedgerApi.IsData.Class.IsData.toData",
+              "self_ns": 1868144
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataData",
+              "self_ns": 5708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataInteger",
+              "self_ns": 3083
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption",
+              "self_ns": 29000
+            },
+            {
+              "calls": 15,
+              "head": "CardanoLedgerApi.IsData.Class.instIsDataOption.match_1",
+              "self_ns": 387125
+            },
+            {
+              "calls": 328,
+              "head": "CardanoLedgerApi.IsData.Class.mkDataConstr",
+              "self_ns": 428865
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.IsData.Class.toTerm",
+              "self_ns": 42333
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.Address",
+              "self_ns": 2000
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressCredential",
+              "self_ns": 19625
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V1.Address.Address.addressStakingCredential",
+              "self_ns": 28251
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Address.instIsDataAddress",
+              "self_ns": 3083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Contexts.instIsDataListPubKeyHash",
+              "self_ns": 5125
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData",
+              "self_ns": 29833
+            },
+            {
+              "calls": 3731,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 11035506
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Contexts.txInfoSignatoriesToListData.go.match_1._@.CardanoLedgerApi.V1.Contexts.3037641814._hygCtx._hyg.14",
+              "self_ns": 193500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.Credential",
+              "self_ns": 1167
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.PubKeyCredential",
+              "self_ns": 8125
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.Credential.ScriptCredential",
+              "self_ns": 7500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.PubKeyHash",
+              "self_ns": 8000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential",
+              "self_ns": 2042
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingHash",
+              "self_ns": 8958
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V1.Credential.StakingCredential.StakingPtr",
+              "self_ns": 11542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataCredential",
+              "self_ns": 3875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Credential.instIsDataStakingCredential",
+              "self_ns": 3916
+            },
+            {
+              "calls": 46,
+              "head": "CardanoLedgerApi.V1.Credential.instReprCredential.repr.match_1",
+              "self_ns": 1274875
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V1.Credential.instReprStakingCredential.repr.match_1",
+              "self_ns": 207000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Datum",
+              "self_ns": 4291
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.DatumHash",
+              "self_ns": 5666
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.Redeemer",
+              "self_ns": 12375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Scripts.ScriptHash",
+              "self_ns": 7250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Tx.instIsDataTxId",
+              "self_ns": 4083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.CurrencySymbol",
+              "self_ns": 10875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.Value",
+              "self_ns": 11667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V1.Value.instIsDataValue",
+              "self_ns": 3792
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.DatumMap",
+              "self_ns": 11083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataDatumMap",
+              "self_ns": 3167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Contexts.instIsDataListTxOut",
+              "self_ns": 8750
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData",
+              "self_ns": 13292
+            },
+            {
+              "calls": 3731,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.go._@.CardanoLedgerApi.V2.Contexts.1377661293._hygCtx._hyg.19",
+              "self_ns": 10181078
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoDataToListPairData.match_1",
+              "self_ns": 172667
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData",
+              "self_ns": 23625
+            },
+            {
+              "calls": 399,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.go._@.CardanoLedgerApi.V2.Contexts.3695909053._hygCtx._hyg.14",
+              "self_ns": 6312452
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V2.Contexts.txInfoOutputsToListData.match_1",
+              "self_ns": 287957
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum",
+              "self_ns": 1750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.NoOutputDatum",
+              "self_ns": 1458
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatum",
+              "self_ns": 7958
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V2.Tx.OutputDatum.OutputDatumHash",
+              "self_ns": 8333
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut",
+              "self_ns": 1583
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutAddress",
+              "self_ns": 18250
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutDatum",
+              "self_ns": 17333
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutReferenceScript",
+              "self_ns": 21083
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.TxOut.txOutValue",
+              "self_ns": 19000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataOutputDatum",
+              "self_ns": 3417
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V2.Tx.instIsDataTxOut",
+              "self_ns": 4041
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V2.Tx.instReprOutputDatum.repr.match_1",
+              "self_ns": 196375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.GovernanceVoteMap",
+              "self_ns": 6625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.MintValue",
+              "self_ns": 9875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.RedeemerMap",
+              "self_ns": 12542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext",
+              "self_ns": 1417
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextRedeemer",
+              "self_ns": 13500
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextScriptInfo",
+              "self_ns": 25792
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptContext.scriptContextTxInfo",
+              "self_ns": 14667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo",
+              "self_ns": 1625
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.CertifyingScript",
+              "self_ns": 9667
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.MintingScript",
+              "self_ns": 9583
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.ProposingScript",
+              "self_ns": 8458
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.RewardingScript",
+              "self_ns": 11958
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.SpendingScript",
+              "self_ns": 10959
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptInfo.VotingScript",
+              "self_ns": 6542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose",
+              "self_ns": 1958
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Certifying",
+              "self_ns": 14334
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Minting",
+              "self_ns": 8750
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Proposing",
+              "self_ns": 9666
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Rewarding",
+              "self_ns": 7250
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Spending",
+              "self_ns": 7709
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Contexts.ScriptPurpose.Voting",
+              "self_ns": 8167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo",
+              "self_ns": 1416
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoOutRef",
+              "self_ns": 16417
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInInfo.txInInfoResolved",
+              "self_ns": 11583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo",
+              "self_ns": 1791
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoCurrentTreasuryAmount",
+              "self_ns": 15708
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoData",
+              "self_ns": 13291
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoFee",
+              "self_ns": 23209
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoId",
+              "self_ns": 20083
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoInputs",
+              "self_ns": 12791
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoMint",
+              "self_ns": 15375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoOutputs",
+              "self_ns": 16541
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoProposalProcedures",
+              "self_ns": 21542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoRedeemers",
+              "self_ns": 16125
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoReferenceInputs",
+              "self_ns": 32708
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoSignatories",
+              "self_ns": 18542
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTreasuryDonation",
+              "self_ns": 15333
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoTxCerts",
+              "self_ns": 14000
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoValidRange",
+              "self_ns": 22666
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoVotes",
+              "self_ns": 12875
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.TxInfo.txInfoWdrl",
+              "self_ns": 18167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.VoterMap",
+              "self_ns": 8125
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData",
+              "self_ns": 18041
+            },
+            {
+              "calls": 26,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.3308403429._hygCtx._hyg.19",
+              "self_ns": 3237083
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.governanceVoteMapToListPairData.match_1",
+              "self_ns": 204832
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataGovernanceVoteMap",
+              "self_ns": 4667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListProposalProcedure",
+              "self_ns": 4084
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxCert",
+              "self_ns": 4458
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataListTxInInfo",
+              "self_ns": 2708
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataRedeemerMap",
+              "self_ns": 3667
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptContext",
+              "self_ns": 3875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptInfo",
+              "self_ns": 4000
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataScriptPurpose",
+              "self_ns": 4875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInInfo",
+              "self_ns": 3917
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataTxInfo",
+              "self_ns": 3958
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Contexts.instIsDataVoterMap",
+              "self_ns": 3083
+            },
+            {
+              "calls": 9,
+              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptInfo.repr.match_1",
+              "self_ns": 235750
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V3.Contexts.instReprScriptPurpose.repr.match_1",
+              "self_ns": 461917
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs",
+              "self_ns": 33709
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.rewardingInputs.match_1",
+              "self_ns": 224582
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData",
+              "self_ns": 15667
+            },
+            {
+              "calls": 7556,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.go._@.CardanoLedgerApi.V3.Contexts.2536880513._hygCtx._hyg.14",
+              "self_ns": 14738976
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoInputsToListData.match_1",
+              "self_ns": 333999
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData",
+              "self_ns": 20625
+            },
+            {
+              "calls": 3735,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.go._@.CardanoLedgerApi.V3.Contexts.283897823._hygCtx._hyg.14",
+              "self_ns": 10123911
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoProposalProcsToListData.match_1",
+              "self_ns": 177041
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData",
+              "self_ns": 15584
+            },
+            {
+              "calls": 3869,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2123419846._hygCtx._hyg.19",
+              "self_ns": 10937996
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoRedeemersToListPairData.match_1",
+              "self_ns": 279626
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData",
+              "self_ns": 15541
+            },
+            {
+              "calls": 3847,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.go._@.CardanoLedgerApi.V3.Contexts.1881025222._hygCtx._hyg.14",
+              "self_ns": 11839841
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.txInfoTxCertsToListData.match_1",
+              "self_ns": 229750
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData",
+              "self_ns": 13375
+            },
+            {
+              "calls": 3741,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.go._@.CardanoLedgerApi.V3.Contexts.2345433621._hygCtx._hyg.19",
+              "self_ns": 9890843
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Contexts.voterMapToListPairData.match_1",
+              "self_ns": 179916
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId",
+              "self_ns": 2041
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidGovActionIx",
+              "self_ns": 14833
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.Governance.GovernanceActionId.gaidTxId",
+              "self_ns": 22542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure",
+              "self_ns": 1166
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppDeposit",
+              "self_ns": 18957
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppGovernanceAction",
+              "self_ns": 15041
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.ProposalProcedure.ppReturnAddr",
+              "self_ns": 16208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.Abstain",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteNo",
+              "self_ns": 6083
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Vote.VoteYes",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Voter",
+              "self_ns": 1625
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.CommitteeVoter",
+              "self_ns": 7042
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.DRepVoter",
+              "self_ns": 10500
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.Governance.Voter.StakePoolVoter",
+              "self_ns": 5875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.Withdrawals",
+              "self_ns": 13542
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataGovernanceActionId",
+              "self_ns": 5041
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataNewCommitteeMembers",
+              "self_ns": 4500
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataProposalProcedure",
+              "self_ns": 3375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataVote",
+              "self_ns": 3291
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Governance.instIsDataVoter",
+              "self_ns": 3875
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Governance.instReprVote.repr.match_1",
+              "self_ns": 129792
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Governance.instReprVoter.repr.match_1",
+              "self_ns": 220001
+            },
+            {
+              "calls": 2,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData",
+              "self_ns": 17583
+            },
+            {
+              "calls": 87,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.go._@.CardanoLedgerApi.V3.Governance.329856877._hygCtx._hyg.19",
+              "self_ns": 5664334
+            },
+            {
+              "calls": 7,
+              "head": "CardanoLedgerApi.V3.Governance.newCommitteeToListPairData.match_1",
+              "self_ns": 278625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.TxId",
+              "self_ns": 8417
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef",
+              "self_ns": 1584
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefId",
+              "self_ns": 19709
+            },
+            {
+              "calls": 8,
+              "head": "CardanoLedgerApi.V3.Tx.TxOutRef.txOutRefIdx",
+              "self_ns": 16833
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxId",
+              "self_ns": 5583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.Tx.instIsDataTxOutRef",
+              "self_ns": 2875
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.ColdCommitteeCredential",
+              "self_ns": 6750
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep",
+              "self_ns": 1500
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRep",
+              "self_ns": 7250
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysAbstain",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRep.DRepAlwaysNoConfidence",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.DRepCredential",
+              "self_ns": 6625
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee",
+              "self_ns": 12417
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStake",
+              "self_ns": 7667
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegStakeVote",
+              "self_ns": 9208
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.Delegatee.DelegVote",
+              "self_ns": 8791
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.HotCommitteeCredential",
+              "self_ns": 5583
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert",
+              "self_ns": 4083
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertAuthHotCommittee",
+              "self_ns": 10459
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertDelegStaking",
+              "self_ns": 11750
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRegister",
+              "self_ns": 9459
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertPoolRetire",
+              "self_ns": 9375
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDRep",
+              "self_ns": 9875
+            },
+            {
+              "calls": 5,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegDeleg",
+              "self_ns": 12000
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertRegStaking",
+              "self_ns": 13458
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertResignColdCommittee",
+              "self_ns": 6917
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegDRep",
+              "self_ns": 9583
+            },
+            {
+              "calls": 4,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUnRegStaking",
+              "self_ns": 11000
+            },
+            {
+              "calls": 3,
+              "head": "CardanoLedgerApi.V3.TxCert.TxCert.TxCertUpdateDRep",
+              "self_ns": 7084
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDRep",
+              "self_ns": 3709
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataDelegatee",
+              "self_ns": 3041
+            },
+            {
+              "calls": 1,
+              "head": "CardanoLedgerApi.V3.TxCert.instIsDataTxCert",
+              "self_ns": 5209
+            },
+            {
+              "calls": 14,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprDRep.repr.match_1",
+              "self_ns": 353708
+            },
+            {
+              "calls": 10,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprDelegatee.repr.match_1",
+              "self_ns": 327462
+            },
+            {
+              "calls": 16,
+              "head": "CardanoLedgerApi.V3.TxCert.instReprTxCert.repr.match_1",
+              "self_ns": 1485249
+            },
+            {
+              "calls": 681,
+              "head": "Decidable.decide",
+              "self_ns": 850719
+            },
+            {
+              "calls": 2212,
+              "head": "Eq",
+              "self_ns": 16524774
+            },
+            {
+              "calls": 13,
+              "head": "Function.comp",
+              "self_ns": 77833
+            },
+            {
+              "calls": 132,
+              "head": "HAdd.hAdd",
+              "self_ns": 907438
+            },
+            {
+              "calls": 181,
+              "head": "HMul.hMul",
+              "self_ns": 1102403
+            },
+            {
+              "calls": 2,
+              "head": "HPow.hPow",
+              "self_ns": 52333
+            },
+            {
+              "calls": 2,
+              "head": "Inhabited.default",
+              "self_ns": 30708
+            },
+            {
+              "calls": 1,
+              "head": "Int",
+              "self_ns": 3292
+            },
+            {
+              "calls": 376,
+              "head": "Int.add",
+              "self_ns": 1230431
+            },
+            {
+              "calls": 1,
+              "head": "Int.instAdd",
+              "self_ns": 3792
+            },
+            {
+              "calls": 1,
+              "head": "Int.instDecidableEq",
+              "self_ns": 6167
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLEInt",
+              "self_ns": 5917
+            },
+            {
+              "calls": 1,
+              "head": "Int.instLTInt",
+              "self_ns": 3917
+            },
+            {
+              "calls": 1,
+              "head": "Int.instMul",
+              "self_ns": 3333
+            },
+            {
+              "calls": 610,
+              "head": "Int.mul",
+              "self_ns": 2072920
+            },
+            {
+              "calls": 244,
+              "head": "Int.natAbs",
+              "self_ns": 288080
+            },
+            {
+              "calls": 124,
+              "head": "Int.neg",
+              "self_ns": 304073
+            },
+            {
+              "calls": 127,
+              "head": "Int.neg.match_1",
+              "self_ns": 3977311
+            },
+            {
+              "calls": 7,
+              "head": "Int.negOfNat.match_1",
+              "self_ns": 135292
+            },
+            {
+              "calls": 5,
+              "head": "Int.negSucc",
+              "self_ns": 17416
+            },
+            {
+              "calls": 15,
+              "head": "Int.ofNat",
+              "self_ns": 42085
+            },
+            {
+              "calls": 3,
+              "head": "Int.pow",
+              "self_ns": 8333
+            },
+            {
+              "calls": 246,
+              "head": "Int.toNat",
+              "self_ns": 622964
+            },
+            {
+              "calls": 350,
+              "head": "LE.le",
+              "self_ns": 1894489
+            },
+            {
+              "calls": 1121,
+              "head": "LT.lt",
+              "self_ns": 5902608
+            },
+            {
+              "calls": 234,
+              "head": "List",
+              "self_ns": 412490
+            },
+            {
+              "calls": 229961,
+              "head": "List.cons",
+              "self_ns": 481276433
+            },
+            {
+              "calls": 7,
+              "head": "List.drop",
+              "self_ns": 4424416
+            },
+            {
+              "calls": 8419,
+              "head": "List.get?Internal",
+              "self_ns": 39619300
+            },
+            {
+              "calls": 556,
+              "head": "List.getLast?.match_1",
+              "self_ns": 7304600
+            },
+            {
+              "calls": 341,
+              "head": "List.isEmpty",
+              "self_ns": 1016240
+            },
+            {
+              "calls": 1025,
+              "head": "List.nil",
+              "self_ns": 1714124
+            },
+            {
+              "calls": 1005,
+              "head": "List.reverse",
+              "self_ns": 3116005
+            },
+            {
+              "calls": 1005,
+              "head": "List.reverseAux",
+              "self_ns": 5487822
+            },
+            {
+              "calls": 13,
+              "head": "List.take.match_1",
+              "self_ns": 314708
+            },
+            {
+              "calls": 124,
+              "head": "Mul.mul",
+              "self_ns": 845083
+            },
+            {
+              "calls": 1,
+              "head": "Nat",
+              "self_ns": 43125
+            },
+            {
+              "calls": 152,
+              "head": "Nat.add",
+              "self_ns": 635176
+            },
+            {
+              "calls": 12,
+              "head": "Nat.add.match_1",
+              "self_ns": 333459
+            },
+            {
+              "calls": 2,
+              "head": "Nat.beq",
+              "self_ns": 10750
+            },
+            {
+              "calls": 14,
+              "head": "Nat.beq.match_1",
+              "self_ns": 362374
+            },
+            {
+              "calls": 2,
+              "head": "Nat.ble",
+              "self_ns": 8417
+            },
+            {
+              "calls": 4,
+              "head": "Nat.mul",
+              "self_ns": 21584
+            },
+            {
+              "calls": 12,
+              "head": "Nat.mul.match_1",
+              "self_ns": 237208
+            },
+            {
+              "calls": 4,
+              "head": "Nat.pow",
+              "self_ns": 15707
+            },
+            {
+              "calls": 6,
+              "head": "Nat.pow.match_1",
+              "self_ns": 121126
+            },
+            {
+              "calls": 2,
+              "head": "Nat.pred",
+              "self_ns": 8375
+            },
+            {
+              "calls": 154,
+              "head": "Nat.sub",
+              "self_ns": 4085414
+            },
+            {
+              "calls": 135,
+              "head": "Nat.succ",
+              "self_ns": 238032
+            },
+            {
+              "calls": 1,
+              "head": "Nat.zero",
+              "self_ns": 2416
+            },
+            {
+              "calls": 2,
+              "head": "NatPow.pow",
+              "self_ns": 29001
+            },
+            {
+              "calls": 475,
+              "head": "Not",
+              "self_ns": 1351920
+            },
+            {
+              "calls": 21,
+              "head": "OfNat.ofNat",
+              "self_ns": 320207
+            },
+            {
+              "calls": 777,
+              "head": "Option",
+              "self_ns": 1254621
+            },
+            {
+              "calls": 2140,
+              "head": "Option.getD.match_1",
+              "self_ns": 28071129
+            },
+            {
+              "calls": 401,
+              "head": "Option.map",
+              "self_ns": 1682548
+            },
+            {
+              "calls": 717,
+              "head": "Option.none",
+              "self_ns": 1283213
+            },
+            {
+              "calls": 7553,
+              "head": "Option.some",
+              "self_ns": 33278406
+            },
+            {
+              "calls": 127,
+              "head": "Or",
+              "self_ns": 909165
+            },
+            {
+              "calls": 512,
+              "head": "PlutusCore.Bool.PlutusCore.BoolInternal.ifThenElse",
+              "self_ns": 2069244
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString",
+              "self_ns": 7208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1843,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.data",
+              "self_ns": 1684935
+            },
+            {
+              "calls": 558,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.length",
+              "self_ns": 553946
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.ByteString.mk",
+              "self_ns": 6292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.LTByteString",
+              "self_ns": 7000
+            },
+            {
+              "calls": 38,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.equalsByteString",
+              "self_ns": 66002
+            },
+            {
+              "calls": 26,
+              "head": "PlutusCore.ByteString.PlutusCore.ByteStringInternal.lessThanByteString",
+              "self_ns": 57085
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.BEqData",
+              "self_ns": 4375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data",
+              "self_ns": 1792
+            },
+            {
+              "calls": 19822,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.B",
+              "self_ns": 20990829
+            },
+            {
+              "calls": 31236,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Constr",
+              "self_ns": 52749807
+            },
+            {
+              "calls": 10713,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.I",
+              "self_ns": 11365024
+            },
+            {
+              "calls": 22123,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.List",
+              "self_ns": 26947877
+            },
+            {
+              "calls": 15442,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.Data.Map",
+              "self_ns": 22492559
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData",
+              "self_ns": 16251
+            },
+            {
+              "calls": 51,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqData.match_1",
+              "self_ns": 909165
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr",
+              "self_ns": 84292
+            },
+            {
+              "calls": 19,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataConstr.match_1",
+              "self_ns": 149208
+            },
+            {
+              "calls": 10,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList",
+              "self_ns": 74918
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataList.match_1",
+              "self_ns": 288541
+            },
+            {
+              "calls": 45,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap",
+              "self_ns": 306416
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.eqDataMap.match_1",
+              "self_ns": 370000
+            },
+            {
+              "calls": 420,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.equalsData",
+              "self_ns": 594322
+            },
+            {
+              "calls": 538,
+              "head": "PlutusCore.Data.PlutusCore.DataInternal.mapData",
+              "self_ns": 601303
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantE",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Default.Internal.instInhabitedBuiltinSemanticsVariant",
+              "self_ns": 3834
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Integer.Integer",
+              "self_ns": 7584
+            },
+            {
+              "calls": 82,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.addInteger",
+              "self_ns": 198626
+            },
+            {
+              "calls": 244,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.equalsInteger",
+              "self_ns": 337632
+            },
+            {
+              "calls": 136,
+              "head": "PlutusCore.Integer.PlutusCore.IntegerInternal.lessThanEqualsInteger",
+              "self_ns": 201627
+            },
+            {
+              "calls": 7,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.mkCons",
+              "self_ns": 49916
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.List.PlutusCore.ListInternal.nullList",
+              "self_ns": 61877
+            },
+            {
+              "calls": 163,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.fstPair",
+              "self_ns": 617636
+            },
+            {
+              "calls": 456,
+              "head": "PlutusCore.Pair.PlutusCore.PairInternal.sndPair",
+              "self_ns": 1601926
+            },
+            {
+              "calls": 1022,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse",
+              "self_ns": 1224239
+            },
+            {
+              "calls": 516,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Bool.ifThenElse.match_1",
+              "self_ns": 2827748
+            },
+            {
+              "calls": 37,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.appendByteString.match_1",
+              "self_ns": 572543
+            },
+            {
+              "calls": 38,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.equalsByteString",
+              "self_ns": 71375
+            },
+            {
+              "calls": 26,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.ByteString.lessThanByteString",
+              "self_ns": 66541
+            },
+            {
+              "calls": 420,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData",
+              "self_ns": 539460
+            },
+            {
+              "calls": 215,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.equalsData.match_1",
+              "self_ns": 1546968
+            },
+            {
+              "calls": 538,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData",
+              "self_ns": 628295
+            },
+            {
+              "calls": 274,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.mapData.match_1",
+              "self_ns": 1513406
+            },
+            {
+              "calls": 80,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData",
+              "self_ns": 101123
+            },
+            {
+              "calls": 45,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unBData.match_1",
+              "self_ns": 863828
+            },
+            {
+              "calls": 1106,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData",
+              "self_ns": 1251760
+            },
+            {
+              "calls": 559,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_1",
+              "self_ns": 13098821
+            },
+            {
+              "calls": 785,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unConstrData.match_3",
+              "self_ns": 3657055
+            },
+            {
+              "calls": 16,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData",
+              "self_ns": 39874
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unIData.match_1",
+              "self_ns": 296457
+            },
+            {
+              "calls": 192,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData",
+              "self_ns": 273954
+            },
+            {
+              "calls": 101,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unListData.match_1",
+              "self_ns": 603207
+            },
+            {
+              "calls": 164,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData",
+              "self_ns": 231831
+            },
+            {
+              "calls": 87,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Data.unMapData.match_1",
+              "self_ns": 1940127
+            },
+            {
+              "calls": 9882,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction",
+              "self_ns": 9706134
+            },
+            {
+              "calls": 5041,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Evaluate.evaluateBuiltinFunction.match_1",
+              "self_ns": 59033445
+            },
+            {
+              "calls": 82,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger",
+              "self_ns": 119336
+            },
+            {
+              "calls": 236,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.addInteger.match_1",
+              "self_ns": 1437899
+            },
+            {
+              "calls": 244,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.equalsInteger",
+              "self_ns": 304202
+            },
+            {
+              "calls": 136,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Integer.lessThanEqualsInteger",
+              "self_ns": 166950
+            },
+            {
+              "calls": 656,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList",
+              "self_ns": 761638
+            },
+            {
+              "calls": 335,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.chooseList.match_1",
+              "self_ns": 2514166
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList",
+              "self_ns": 25541
+            },
+            {
+              "calls": 8,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.dropList.match_1",
+              "self_ns": 744459
+            },
+            {
+              "calls": 2004,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList",
+              "self_ns": 2035130
+            },
+            {
+              "calls": 2314,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_3",
+              "self_ns": 26847744
+            },
+            {
+              "calls": 276,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_5",
+              "self_ns": 3946580
+            },
+            {
+              "calls": 1552,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.headList.match_7",
+              "self_ns": 8042136
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons",
+              "self_ns": 51835
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.mkCons.match_1",
+              "self_ns": 768707
+            },
+            {
+              "calls": 24,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.nullList",
+              "self_ns": 57624
+            },
+            {
+              "calls": 1062,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.List.tailList",
+              "self_ns": 1138138
+            },
+            {
+              "calls": 324,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair",
+              "self_ns": 379040
+            },
+            {
+              "calls": 623,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.fstPair.match_1",
+              "self_ns": 3135153
+            },
+            {
+              "calls": 910,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Pair.sndPair",
+              "self_ns": 1023677
+            },
+            {
+              "calls": 488,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData",
+              "self_ns": 613993
+            },
+            {
+              "calls": 249,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unValueData.match_1",
+              "self_ns": 1256708
+            },
+            {
+              "calls": 162,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue",
+              "self_ns": 268049
+            },
+            {
+              "calls": 161,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.unionValue.match_1",
+              "self_ns": 1189623
+            },
+            {
+              "calls": 150,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueContains",
+              "self_ns": 242619
+            },
+            {
+              "calls": 24,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData",
+              "self_ns": 47500
+            },
+            {
+              "calls": 17,
+              "head": "PlutusCore.UPLC.BuiltinFunctions.Value.valueData.match_1",
+              "self_ns": 254045
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgQ",
+              "self_ns": 1667
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArg.ArgV",
+              "self_ns": 6458
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.More",
+              "self_ns": 63999
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.Builtins.ExpectedBuiltinArgs.One",
+              "self_ns": 13166
+            },
+            {
+              "calls": 4016,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs",
+              "self_ns": 4074893
+            },
+            {
+              "calls": 2108,
+              "head": "PlutusCore.UPLC.Builtins.expectedArgs.match_1",
+              "self_ns": 34671147
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame",
+              "self_ns": 1459
+            },
+            {
+              "calls": 3386,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.CaseScrutinee",
+              "self_ns": 6829597
+            },
+            {
+              "calls": 5549,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ConstructorArgument",
+              "self_ns": 16144931
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.ForceFrame",
+              "self_ns": 1292
+            },
+            {
+              "calls": 10014,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToTerm",
+              "self_ns": 22377123
+            },
+            {
+              "calls": 3129,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.LeftApplicationToValue",
+              "self_ns": 5674355
+            },
+            {
+              "calls": 7630,
+              "head": "PlutusCore.UPLC.CekMachine.Frame.RightApplicationOfValue",
+              "self_ns": 13203334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State",
+              "self_ns": 2375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekMachine.State.Error",
+              "self_ns": 1708
+            },
+            {
+              "calls": 23083,
+              "head": "PlutusCore.UPLC.CekMachine.State.Eval",
+              "self_ns": 67554133
+            },
+            {
+              "calls": 77,
+              "head": "PlutusCore.UPLC.CekMachine.State.Halt",
+              "self_ns": 198626
+            },
+            {
+              "calls": 22083,
+              "head": "PlutusCore.UPLC.CekMachine.State.Return",
+              "self_ns": 55020953
+            },
+            {
+              "calls": 14,
+              "head": "PlutusCore.UPLC.CekMachine.applyParams",
+              "self_ns": 3783750
+            },
+            {
+              "calls": 3,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgram",
+              "self_ns": 56794
+            },
+            {
+              "calls": 4,
+              "head": "PlutusCore.UPLC.CekMachine.cekExecuteProgramWithSemanticVariant.match_1",
+              "self_ns": 89416
+            },
+            {
+              "calls": 9882,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin",
+              "self_ns": 10561102
+            },
+            {
+              "calls": 16088,
+              "head": "PlutusCore.UPLC.CekMachine.evalBuiltin.match_1",
+              "self_ns": 212234794
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.CekMachine.initialState",
+              "self_ns": 12959
+            },
+            {
+              "calls": 48942,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps",
+              "self_ns": 323361684
+            },
+            {
+              "calls": 46127,
+              "head": "PlutusCore.UPLC.CekMachine.runSteps.match_1",
+              "self_ns": 149961878
+            },
+            {
+              "calls": 89708,
+              "head": "PlutusCore.UPLC.CekMachine.step",
+              "self_ns": 83534104
+            },
+            {
+              "calls": 4131,
+              "head": "PlutusCore.UPLC.CekMachine.step.folding",
+              "self_ns": 20295711
+            },
+            {
+              "calls": 5138,
+              "head": "PlutusCore.UPLC.CekMachine.step.folding.match_1",
+              "self_ns": 11454025
+            },
+            {
+              "calls": 4143,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_1",
+              "self_ns": 11464955
+            },
+            {
+              "calls": 1021,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_11",
+              "self_ns": 3825034
+            },
+            {
+              "calls": 21863,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_13",
+              "self_ns": 60025241
+            },
+            {
+              "calls": 44861,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_15",
+              "self_ns": 119238793
+            },
+            {
+              "calls": 22937,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_3",
+              "self_ns": 71026036
+            },
+            {
+              "calls": 9749,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_5",
+              "self_ns": 28427407
+            },
+            {
+              "calls": 1133,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_7",
+              "self_ns": 3427933
+            },
+            {
+              "calls": 1009,
+              "head": "PlutusCore.UPLC.CekMachine.step.match_9",
+              "self_ns": 3855244
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.CekValue.CekValue",
+              "self_ns": 1584
+            },
+            {
+              "calls": 4506,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VBuiltin",
+              "self_ns": 11295643
+            },
+            {
+              "calls": 50105,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VCon",
+              "self_ns": 74946292
+            },
+            {
+              "calls": 1008,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VConstr",
+              "self_ns": 2210078
+            },
+            {
+              "calls": 2328,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VDelay",
+              "self_ns": 5325750
+            },
+            {
+              "calls": 9569,
+              "head": "PlutusCore.UPLC.CekValue.CekValue.VLam",
+              "self_ns": 21501048
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusLanguage.PlutusV3",
+              "self_ns": 1792
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.PlutusScript.PlutusScript.mk",
+              "self_ns": 15041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun",
+              "self_ns": 1541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AddInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AndByteString",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendByteString",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.AppendString",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.BData",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_224",
+              "self_ns": 959
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Blake2b_256",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_add",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_compress",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_equal",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_hashToGroup",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_multiScalarMul",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_neg",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_scalarMul",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G1_uncompress",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_add",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_compress",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_equal",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_hashToGroup",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_multiScalarMul",
+              "self_ns": 1000
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_neg",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_scalarMul",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_G2_uncompress",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_finalVerify",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_millerLoop",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Bls12_381_mulMlResult",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ByteStringToInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseData",
+              "self_ns": 1416
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseList",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ChooseUnit",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ComplementByteString",
+              "self_ns": 875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConsByteString",
+              "self_ns": 1459
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ConstrData",
+              "self_ns": 1166
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.CountSetBits",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DecodeUtf8",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DivideInteger",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.DropList",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EncodeUtf8",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsData",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsInteger",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.EqualsString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ExpModInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FindFirstSetBit",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.FstPair",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.HeadList",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IData",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IfThenElse",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IndexByteString",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.InsertCoin",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.IntegerToByteString",
+              "self_ns": 13625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Keccak_256",
+              "self_ns": 1459
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LengthOfByteString",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanByteString",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsByteString",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanEqualsInteger",
+              "self_ns": 1500
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LessThanInteger",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ListData",
+              "self_ns": 1042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.LookupCoin",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MapData",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkCons",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilData",
+              "self_ns": 1209
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkNilPairData",
+              "self_ns": 1084
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MkPairData",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ModInteger",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.MultiplyInteger",
+              "self_ns": 1375
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.NullList",
+              "self_ns": 1334
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.OrByteString",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.QuotientInteger",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReadBit",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RemainderInteger",
+              "self_ns": 1459
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ReplicateByte",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Ripemd_160",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.RotateByteString",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ScaleValue",
+              "self_ns": 1208
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SerializeData",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha2_256",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Sha3_256",
+              "self_ns": 1584
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ShiftByteString",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SliceByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SndPair",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.SubtractInteger",
+              "self_ns": 1875
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.TailList",
+              "self_ns": 1417
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.Trace",
+              "self_ns": 1041
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnBData",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnConstrData",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnIData",
+              "self_ns": 1541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnListData",
+              "self_ns": 1625
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnMapData",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnValueData",
+              "self_ns": 1333
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.UnionValue",
+              "self_ns": 1291
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueContains",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.ValueData",
+              "self_ns": 1125
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEcdsaSecp256k1Signature",
+              "self_ns": 1542
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifyEd25519Signature",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.VerifySchnorrSecp256k1Signature",
+              "self_ns": 1250
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.WriteBits",
+              "self_ns": 1167
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.BuiltinFun.XorByteString",
+              "self_ns": 1083
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const",
+              "self_ns": 1416
+            },
+            {
+              "calls": 599,
+              "head": "PlutusCore.UPLC.Term.Const.Bool",
+              "self_ns": 1169240
+            },
+            {
+              "calls": 1539,
+              "head": "PlutusCore.UPLC.Term.Const.ByteString",
+              "self_ns": 1524255
+            },
+            {
+              "calls": 29879,
+              "head": "PlutusCore.UPLC.Term.Const.ConstDataList",
+              "self_ns": 46332073
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.UPLC.Term.Const.ConstList",
+              "self_ns": 17083
+            },
+            {
+              "calls": 6964,
+              "head": "PlutusCore.UPLC.Term.Const.ConstPairDataList",
+              "self_ns": 10090036
+            },
+            {
+              "calls": 14672,
+              "head": "PlutusCore.UPLC.Term.Const.Data",
+              "self_ns": 17165281
+            },
+            {
+              "calls": 1691,
+              "head": "PlutusCore.UPLC.Term.Const.Integer",
+              "self_ns": 2161264
+            },
+            {
+              "calls": 2426,
+              "head": "PlutusCore.UPLC.Term.Const.Pair",
+              "self_ns": 3976382
+            },
+            {
+              "calls": 136,
+              "head": "PlutusCore.UPLC.Term.Const.PairData",
+              "self_ns": 216701
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Const.Unit",
+              "self_ns": 1458
+            },
+            {
+              "calls": 1365,
+              "head": "PlutusCore.UPLC.Term.Const.Value",
+              "self_ns": 2354698
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Program",
+              "self_ns": 1875
+            },
+            {
+              "calls": 5,
+              "head": "PlutusCore.UPLC.Term.Program.Program",
+              "self_ns": 18627
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term",
+              "self_ns": 1416
+            },
+            {
+              "calls": 532,
+              "head": "PlutusCore.UPLC.Term.Term.Apply",
+              "self_ns": 1123635
+            },
+            {
+              "calls": 29,
+              "head": "PlutusCore.UPLC.Term.Term.Builtin",
+              "self_ns": 54582
+            },
+            {
+              "calls": 78,
+              "head": "PlutusCore.UPLC.Term.Term.Case",
+              "self_ns": 170539
+            },
+            {
+              "calls": 17,
+              "head": "PlutusCore.UPLC.Term.Term.Const",
+              "self_ns": 65376
+            },
+            {
+              "calls": 78,
+              "head": "PlutusCore.UPLC.Term.Term.Constr",
+              "self_ns": 165885
+            },
+            {
+              "calls": 83,
+              "head": "PlutusCore.UPLC.Term.Term.Delay",
+              "self_ns": 147785
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.UPLC.Term.Term.Error",
+              "self_ns": 1166
+            },
+            {
+              "calls": 70,
+              "head": "PlutusCore.UPLC.Term.Term.Force",
+              "self_ns": 124909
+            },
+            {
+              "calls": 199,
+              "head": "PlutusCore.UPLC.Term.Term.Lam",
+              "self_ns": 309829
+            },
+            {
+              "calls": 125,
+              "head": "PlutusCore.UPLC.Term.Term.Var",
+              "self_ns": 136461
+            },
+            {
+              "calls": 2,
+              "head": "PlutusCore.UPLC.Term.Version.Version",
+              "self_ns": 12541
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Value.ValueRep",
+              "self_ns": 15666
+            },
+            {
+              "calls": 558,
+              "head": "PlutusCore.Value.ascendingFrom",
+              "self_ns": 666212
+            },
+            {
+              "calls": 286,
+              "head": "PlutusCore.Value.ascendingFrom.match_1",
+              "self_ns": 1043047
+            },
+            {
+              "calls": 72,
+              "head": "PlutusCore.Value.containedInner",
+              "self_ns": 2514255
+            },
+            {
+              "calls": 163,
+              "head": "PlutusCore.Value.containedOuter",
+              "self_ns": 2476878
+            },
+            {
+              "calls": 268,
+              "head": "PlutusCore.Value.hasNegativeAmount",
+              "self_ns": 3055174
+            },
+            {
+              "calls": 252,
+              "head": "PlutusCore.Value.innerHasNegative",
+              "self_ns": 2964288
+            },
+            {
+              "calls": 206,
+              "head": "PlutusCore.Value.innerHasNegative.match_1",
+              "self_ns": 1040417
+            },
+            {
+              "calls": 1077,
+              "head": "PlutusCore.Value.innerToData",
+              "self_ns": 4799950
+            },
+            {
+              "calls": 12,
+              "head": "PlutusCore.Value.lookupCoin",
+              "self_ns": 3238042
+            },
+            {
+              "calls": 9,
+              "head": "PlutusCore.Value.lookupInner",
+              "self_ns": 3316042
+            },
+            {
+              "calls": 1,
+              "head": "PlutusCore.Value.maxKeyLen",
+              "self_ns": 9208
+            },
+            {
+              "calls": 26,
+              "head": "PlutusCore.Value.outerToData",
+              "self_ns": 2868167
+            },
+            {
+              "calls": 368,
+              "head": "PlutusCore.Value.totalSize.match_1",
+              "self_ns": 1454533
+            },
+            {
+              "calls": 488,
+              "head": "PlutusCore.Value.unValueData",
+              "self_ns": 585710
+            },
+            {
+              "calls": 249,
+              "head": "PlutusCore.Value.unValueData.match_1",
+              "self_ns": 1824457
+            },
+            {
+              "calls": 472,
+              "head": "PlutusCore.Value.unValueDataCurrencies",
+              "self_ns": 44060949
+            },
+            {
+              "calls": 187,
+              "head": "PlutusCore.Value.unValueDataCurrencies.match_1",
+              "self_ns": 1966504
+            },
+            {
+              "calls": 187,
+              "head": "PlutusCore.Value.unValueDataCurrencies.match_3",
+              "self_ns": 1945499
+            },
+            {
+              "calls": 268,
+              "head": "PlutusCore.Value.unValueDataTokens",
+              "self_ns": 14044214
+            },
+            {
+              "calls": 241,
+              "head": "PlutusCore.Value.unValueDataTokens.match_1",
+              "self_ns": 4318160
+            },
+            {
+              "calls": 463,
+              "head": "PlutusCore.Value.unValueDataTokens.match_3",
+              "self_ns": 5812591
+            },
+            {
+              "calls": 13,
+              "head": "PlutusCore.Value.unionInner",
+              "self_ns": 221502
+            },
+            {
+              "calls": 1462,
+              "head": "PlutusCore.Value.unionInner.match_1",
+              "self_ns": 24416342
+            },
+            {
+              "calls": 11,
+              "head": "PlutusCore.Value.unionInner.match_3",
+              "self_ns": 399752
+            },
+            {
+              "calls": 91,
+              "head": "PlutusCore.Value.unionOuter",
+              "self_ns": 610793
+            },
+            {
+              "calls": 454,
+              "head": "PlutusCore.Value.unionOuter.match_1",
+              "self_ns": 7267292
+            },
+            {
+              "calls": 8,
+              "head": "PlutusCore.Value.unionOuter.match_3",
+              "self_ns": 145416
+            },
+            {
+              "calls": 56,
+              "head": "PlutusCore.Value.unionOuter.match_5",
+              "self_ns": 644411
+            },
+            {
+              "calls": 162,
+              "head": "PlutusCore.Value.unionValue",
+              "self_ns": 226746
+            },
+            {
+              "calls": 558,
+              "head": "PlutusCore.Value.validKey",
+              "self_ns": 615632
+            },
+            {
+              "calls": 244,
+              "head": "PlutusCore.Value.validQuantity",
+              "self_ns": 318128
+            },
+            {
+              "calls": 150,
+              "head": "PlutusCore.Value.valueContains",
+              "self_ns": 246663
+            },
+            {
+              "calls": 24,
+              "head": "PlutusCore.Value.valueData",
+              "self_ns": 39461
+            },
+            {
+              "calls": 2,
+              "head": "Pow.pow",
+              "self_ns": 42500
+            },
+            {
+              "calls": 10,
+              "head": "Prod",
+              "self_ns": 34585
+            },
+            {
+              "calls": 255,
+              "head": "Prod.fst",
+              "self_ns": 1543493
+            },
+            {
+              "calls": 13066,
+              "head": "Prod.mk",
+              "self_ns": 29069902
+            },
+            {
+              "calls": 497,
+              "head": "Prod.snd",
+              "self_ns": 4405112
+            },
+            {
+              "calls": 1,
+              "head": "String",
+              "self_ns": 1292
+            },
+            {
+              "calls": 1,
+              "head": "String.instLT",
+              "self_ns": 2916
+            },
+            {
+              "calls": 280,
+              "head": "String.length",
+              "self_ns": 925748
+            },
+            {
+              "calls": 2,
+              "head": "WSC.globalInputs1600",
+              "self_ns": 22583
+            },
+            {
+              "calls": 14,
+              "head": "_normalizer",
+              "self_ns": 23366582
+            },
+            {
+              "calls": 2,
+              "head": "instBEqOfDecidableEq",
+              "self_ns": 21958
+            },
+            {
+              "calls": 2,
+              "head": "instHAdd",
+              "self_ns": 18124
+            },
+            {
+              "calls": 3,
+              "head": "instHMul",
+              "self_ns": 19751
+            },
+            {
+              "calls": 2,
+              "head": "instHPow",
+              "self_ns": 19375
+            },
+            {
+              "calls": 1,
+              "head": "instLENat",
+              "self_ns": 7792
+            },
+            {
+              "calls": 1,
+              "head": "instLTNat",
+              "self_ns": 5166
+            },
+            {
+              "calls": 1,
+              "head": "instNatPowNat",
+              "self_ns": 3375
+            },
+            {
+              "calls": 12,
+              "head": "instOfNat",
+              "self_ns": 30415
+            },
+            {
+              "calls": 9,
+              "head": "instOfNatNat",
+              "self_ns": 24042
+            },
+            {
+              "calls": 2,
+              "head": "instPowNat",
+              "self_ns": 16625
+            },
+            {
+              "calls": 1798,
+              "head": "ite",
+              "self_ns": 2560443
+            },
+            {
+              "calls": 1,
+              "head": "programmableLogicGlobal1600",
+              "self_ns": 1033833
+            }
+          ],
+          "imbalances": 0,
+          "schema": 1,
+          "status": "progress"
+        }
+      ],
+      "phases": [],
+      "acceptance": [],
+      "profile_snapshot_count": 1
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/results/attribution/telemetry-disabled-after.json
+++ b/Benchmarks/cardano/results/attribution/telemetry-disabled-after.json
@@ -1,0 +1,77 @@
+{
+  "label": "telemetry-disabled-after",
+  "repeat": 1,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "4b0ddd06368cd68149074768ed279753fd3e0802",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "4029c6f75ee465b33d90fb208390e4894bd03d52da04940e11f895d841ccf016",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 3432087552,
+      "prep": {
+        "optimize_ms": 55779,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 59.0609006669838,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 31,
+          "command_ms": 57589
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 633904,
+      "profile_snapshot_count": 0
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/results/attribution/telemetry-disabled.json
+++ b/Benchmarks/cardano/results/attribution/telemetry-disabled.json
@@ -1,0 +1,137 @@
+{
+  "label": "telemetry-disabled",
+  "repeat": 3,
+  "timeout_seconds": 240.0,
+  "rss_limit_bytes": 17179869184,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "6575b13cb65a060c03b31103f300d26acda80374",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "d5cca502df3208232b396877c337ec8368175c4e4e96f508d68e35cd190daf5d"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "010e995c8eaa581d1db12fd8f81597de755b9a295a65b888e553a8273e7c4d2f"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "bc8ecf6013b195227b9f08b138b44650c2b2c4b19d820c01f8db36a1416cd7bb",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 1,
+      "status": "completed",
+      "log": "global-1600-1.log",
+      "sampled_peak_rss_bytes": 3448045568,
+      "prep": {
+        "optimize_ms": 57017,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 60.44050979195163,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 31,
+          "command_ms": 58824
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 633904,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 2,
+      "status": "completed",
+      "log": "global-1600-2.log",
+      "sampled_peak_rss_bytes": 3428417536,
+      "prep": {
+        "optimize_ms": 55012,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 58.11818370805122,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 31,
+          "command_ms": 56818
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 633904,
+      "profile_snapshot_count": 0
+    },
+    {
+      "case": "global",
+      "budget": 1600,
+      "repeat": 3,
+      "status": "completed",
+      "log": "global-1600-3.log",
+      "sampled_peak_rss_bytes": 3430449152,
+      "prep": {
+        "optimize_ms": 55859,
+        "hashcons": 15595053,
+        "contexts": 103138,
+        "beta_cache": 2044
+      },
+      "source_sha256": "ac85c1dc62686c44421d752928c46bc571443cf462ca0eab0526b97079b1715d",
+      "elapsed_seconds": 58.86861474998295,
+      "exit_code": 0,
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 32,
+          "command_ms": 57668
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 633904,
+      "profile_snapshot_count": 0
+    }
+  ],
+  "archive_profile_policy": "Last snapshot per run; full intermediate snapshots remain in the local JSONL logs."
+}

--- a/Benchmarks/cardano/summarize_profile.py
+++ b/Benchmarks/cardano/summarize_profile.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Summarize normalization profiles saved by cardano_bench.py.
+
+These are exclusive wall times under syntactic normalization heads. A CEK
+head's time is not a count of CEK transitions, nor proof that it is static.
+"""
+import argparse
+import json
+from pathlib import Path
+
+p = argparse.ArgumentParser(description=__doc__)
+p.add_argument('results', type=Path)
+p.add_argument('--top', type=int, default=15)
+a = p.parse_args()
+for run in json.loads(a.results.read_text())['runs']:
+    if not run.get('profiles'):
+        continue
+    profile = run['profiles'][-1]
+    elapsed = profile['elapsed_ns']
+    accounted = sum(h['self_ns'] for h in profile['heads'])
+    if accounted != elapsed:
+        raise SystemExit('Profile time does not partition elapsed time')
+    if profile['imbalances'] or (profile['status'] == 'complete' and profile['active_frames']):
+        raise SystemExit('Unbalanced normalization frames')
+    print(f"{run['case']}:{run['budget']} {run['status']} profile={profile['status']} "
+          f"seconds={elapsed / 1e9:.3f} active_frames={profile['active_frames']}")
+    print(f"cache hits={profile['cache_hits']} misses={profile['cache_misses']} "
+          f"mvar bypasses={profile['cache_bypasses']}")
+    for head in sorted(profile['heads'], key=lambda h: h['self_ns'], reverse=True)[:a.top]:
+        print(f"  {head['self_ns'] / max(elapsed, 1):6.1%} "
+              f"{head['self_ns'] / 1e9:8.3f}s {head['calls']:10d}  {head['head']}")
+    print('Choice propagation events:')
+    for name, count in sorted(profile['events'].items(), key=lambda e: e[1], reverse=True)[:a.top]:
+        print(f'  {count:10d}  {name}')

--- a/Benchmarks/cardano_bench.py
+++ b/Benchmarks/cardano_bench.py
@@ -152,7 +152,7 @@ theorem seize_arm_rejected :
 end WSC.Benchmark
 '''
             if budget >= 1453:
-                text += '''\nnamespace WSC.Benchmark\n-- Same accepting golden as the independently executed reference gate.\ntheorem nonmember_accepted :\n    PlutusCore.UPLC.Utils.isSuccessful (appliedGlobalPerf.prop Acceptance.nonmemberCS Acceptance.nonmemberCtx) := by\n  blaster (timeout: 30)\nend WSC.Benchmark\n'''
+                text += '''\nnamespace WSC.Benchmark\n-- Same accepting golden as the independently executed reference gate.\ntheorem nonmember_accepted :\n    PlutusCore.UPLC.Utils.isSuccessful (appliedGlobalPerf.prop Acceptance.nonmemberCS Acceptance.nonmemberCtx) := by\n  blaster (timeout: 30)\ntheorem nonmember_returns_unit :\n    Acceptance.outcome (appliedGlobalPerf.prop Acceptance.nonmemberCS Acceptance.nonmemberCtx) =\n      Acceptance.Outcome.unit := by\n  blaster (timeout: 30)\nend WSC.Benchmark\n'''
         else:
             text=(cwd/f'Tests/Scripts/{fixture}/Properties.lean').read_text()
             text=text.replace(f'import Tests.Scripts.{fixture}.{fixture}', 'import Tests.Benchmarks.CardanoPerfCase')
@@ -224,7 +224,7 @@ end WSC.Benchmark
                 try: row['profiles'].append(json.loads(line))
                 except json.JSONDecodeError:
                     row['profile_truncated']=True  # possible kill during the final write
-        row['phases'] = [{k:int(v) for k,v in re.findall(r'(\w+)=(\d+)',m[1])} for m in re.finditer(r'PREP_PHASE (.+)$',content,re.M)]
+        row['phases'] = [] if a.proofs_only or a.acceptance_only else [{k:int(v) for k,v in re.findall(r'(\w+)=(\d+)',m[1])} for m in re.finditer(r'PREP_PHASE (.+)$',content,re.M)]
         row['acceptance'] = re.findall(r'CARDANO_ACCEPTANCE (.+)$',content,re.M)
         if not a.proofs_only:
             for m in re.finditer(r'PREP_METRICS (.+)',content):

--- a/Benchmarks/cardano_bench.py
+++ b/Benchmarks/cardano_bench.py
@@ -26,8 +26,17 @@ parser.add_argument('--sample', action='store_true', help='Take one macOS CPU sa
 parser.add_argument('--reduce-before-arguments', action='store_true', help='Reduce functions and projections before normalizing their arguments')
 parser.add_argument('--retain-constructor-choices', action='store_true', help='Keep conditionals and matches inside constructor fields during preparation')
 parser.add_argument('--retain-choice-types', nargs='*', default=[], help='Label selected inductive types or constructors to retain field choices')
+parser.add_argument('--profile-normalize', action='store_true', help='Opt-in normalization-head timings; diagnostic runs only')
+parser.add_argument('--acceptance-only', action='store_true', help='Validate existing global goldens through the exact interpreter and input conversion')
+parser.add_argument('--conversion-only', action='store_true', help='Normalize input conversion alone, without interpreting the UPLC program')
 parser.add_argument('--proofs-only', action='store_true', help='Check properties against the existing, exactly matching prepared benchmark module')
 a=parser.parse_args()
+if sum([a.proofs_only, a.acceptance_only, a.conversion_only]) > 1:
+    parser.error('choose at most one of proofs-only, acceptance-only and conversion-only')
+if a.acceptance_only and any(c.split(':')[0] != 'global' for c in a.cases):
+    parser.error('acceptance-only currently covers global goldens')
+if a.proofs_only and a.profile_normalize:
+    parser.error('profile-normalize is for preparation or conversion; omit it when checking an existing residual')
 if a.repeat < 1 or a.timeout <= 0 or a.max_rss_gib <= 0:
     parser.error('repeat, timeout and memory limit must be positive')
 if not re.fullmatch(r'[A-Za-z0-9_-]+', a.label):
@@ -66,8 +75,9 @@ result={'label':a.label,'repeat':a.repeat,'timeout_seconds':a.timeout,'rss_limit
         'pins':{p:pin(p) for p in ['cardano','wsc','blaster','plutuscore','plutuscore-wsc']},
         'machine':{'system':platform.system(),'release':platform.release(),'architecture':platform.machine(),'logical_cpus':os.cpu_count()},
         'runner_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        'acceptance_fixture_sha256':hashlib.sha256((Path(__file__).parent/'cardano/fixtures/GlobalAcceptance.lean').read_bytes()).hexdigest(),
         'retain_choice_types':a.retain_choice_types,'retain_constructor_choices':a.retain_constructor_choices,'reduce_before_arguments':a.reduce_before_arguments,
-        'cpu_sample':a.sample,'phase':'proof' if a.proofs_only else 'prep',
+        'cpu_sample':a.sample,'profile_normalize':a.profile_normalize,'phase':('proof' if a.proofs_only else 'acceptance' if a.acceptance_only else 'conversion' if a.conversion_only else 'prep'),
         'allocator_env':{k:v for k,v in os.environ.items() if k.startswith('MIMALLOC_')},'runs':[]}
 
 def save():
@@ -90,6 +100,19 @@ end WSC.Benchmark
         text=re.sub(r'\(stats-file: [^)]*\)|\(stats-interval: [^)]*\)','',text)
         text=re.sub(r'(#prep_uplc[^\n]*?)\d+\s*\n',lambda m:m[1]+str(budget)+'\n',text)
         text=text.replace('\nnamespace ', '\nset_option maxHeartbeats 0\nnamespace ',1)
+    if a.conversion_only:
+        prep_line = next(line for line in text.splitlines() if line.startswith('#prep_uplc '))
+        converter = prep_line.split()[-2]
+        replacement = f'''run_cmd Lean.Elab.Command.liftTermElabM do
+  let expr ← Lean.Elab.Term.elabTermAndSynthesize (← `({converter})) none
+  let started ← IO.monoMsNow
+  let (_, env) ← (Blaster.Optimize.Optimize.main expr).run (default : Blaster.Optimize.TranslateEnv)
+  let o := env.optEnv
+  IO.println s!"PREP_METRICS optimize_ms={{(← IO.monoMsNow) - started}} hashcons={{o.hashConsCache.size}} contexts={{o.options.nextCtxId}} beta_cache={{o.memCache.betaLambdaCache.size}}"
+'''
+        text = text.replace(prep_line, replacement)
+    if a.profile_normalize:
+        text=text.replace('set_option maxHeartbeats 0', 'set_option blaster.profileNormalize true\nset_option maxHeartbeats 0')
     if a.reduce_before_arguments:
         text=text.replace('set_option maxHeartbeats 0', 'set_option blaster.reduceBeforeArguments true\nset_option maxHeartbeats 0')
     if a.retain_constructor_choices:
@@ -98,12 +121,21 @@ end WSC.Benchmark
         text=text.replace('set_option maxHeartbeats 0', 'attribute [local blaster_keep_choices] ' + ' '.join(a.retain_choice_types) + '\nset_option maxHeartbeats 0')
     source=cwd/'Tests/Benchmarks/CardanoPerfCase.lean'
     source.parent.mkdir(parents=True,exist_ok=True)
-    module='CardanoPerfCase'
+    module='CardanoPerfConversion' if a.conversion_only else 'CardanoPerfCase'
+    source=cwd/f'Tests/Benchmarks/{module}.lean'
+    if name=='global':
+        fixture_source=Path(__file__).parent/'cardano/fixtures/GlobalAcceptance.lean'
+        (cwd/'Tests/Benchmarks/GlobalAcceptance.lean').write_text(fixture_source.read_text())
+    if a.acceptance_only:
+        module='GlobalAcceptance'
+        source=cwd/f'Tests/Benchmarks/{module}.lean'
+        text=source.read_text()
     if a.proofs_only:
         if not source.exists() or source.read_text()!=text:
             raise SystemExit('Prepare the requested case and budget first; the existing module does not match.')
         if name=='global':
             text='''import Tests.Benchmarks.CardanoPerfCase
+import Tests.Benchmarks.GlobalAcceptance
 import Blaster
 set_option maxHeartbeats 0
 set_option warn.sorry false
@@ -119,6 +151,8 @@ theorem seize_arm_rejected :
   blaster (timeout: 30)
 end WSC.Benchmark
 '''
+            if budget >= 1453:
+                text += '''\nnamespace WSC.Benchmark\n-- Same accepting golden as the independently executed reference gate.\ntheorem nonmember_accepted :\n    PlutusCore.UPLC.Utils.isSuccessful (appliedGlobalPerf.prop Acceptance.nonmemberCS Acceptance.nonmemberCtx) := by\n  blaster (timeout: 30)\nend WSC.Benchmark\n'''
         else:
             text=(cwd/f'Tests/Scripts/{fixture}/Properties.lean').read_text()
             text=text.replace(f'import Tests.Scripts.{fixture}.{fixture}', 'import Tests.Benchmarks.CardanoPerfCase')
@@ -139,6 +173,10 @@ end WSC.Benchmark
              'sampled_peak_rss_bytes':0,'prep':{},'source_sha256':hashlib.sha256(text.encode()).hexdigest()}
         result['runs'].append(row);save()
         env=os.environ.copy();env['BLASTER_PREP_METRICS']='1'
+        profile_log=logs/(tag+'.profile.jsonl')
+        if a.profile_normalize:
+            profile_log.unlink(missing_ok=True)
+            env['BLASTER_PROFILE_FILE']=str(profile_log)
         started=time.monotonic();sampler=None;sampled=False;next_checkpoint=started+5
         with log.open('w') as f:
             proc=subprocess.Popen(['lake','build',f'Tests.Benchmarks.{module}'],cwd=cwd,env=env,
@@ -180,6 +218,14 @@ end WSC.Benchmark
             if row['status']=='running': row['status']='completed' if proc.returncode==0 else 'error'
             if sampler is not None: sampler.wait(timeout=15)
         content=log.read_text()
+        row['profiles'] = [json.loads(m[1]) for m in re.finditer(r'BLASTER_PROFILE (.+)$',content,re.M)]
+        if a.profile_normalize and profile_log.exists():
+            for line in profile_log.read_text().splitlines():
+                try: row['profiles'].append(json.loads(line))
+                except json.JSONDecodeError:
+                    row['profile_truncated']=True  # possible kill during the final write
+        row['phases'] = [{k:int(v) for k,v in re.findall(r'(\w+)=(\d+)',m[1])} for m in re.finditer(r'PREP_PHASE (.+)$',content,re.M)]
+        row['acceptance'] = re.findall(r'CARDANO_ACCEPTANCE (.+)$',content,re.M)
         if not a.proofs_only:
             for m in re.finditer(r'PREP_METRICS (.+)',content):
                 row['prep']={k:int(v) for k,v in re.findall(r'(\w+)=(\d+)',m[1])}
@@ -187,4 +233,4 @@ end WSC.Benchmark
             row['verdicts']=[line for line in content.splitlines() if 'CardanoPerfProofs.lean:' in line and ('✅' in line or line.startswith('error:'))]
         artifact=cwd/f'.lake/build/lib/lean/Tests/Benchmarks/{module}.olean'
         if row['status']=='completed' and artifact.exists(): row['olean_bytes']=artifact.stat().st_size
-        save();print(json.dumps(row),flush=True)
+        save();print(json.dumps({k:v for k,v in row.items() if k != 'profiles'}),flush=True)

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -330,7 +330,22 @@ def Optimize.mainAux (e : Expr) (applyHashCons := true) : TranslateEnvT Expr := 
 def Optimize.main (e : Expr) (applyHashCons := true) : TranslateEnvT Expr := do
   -- set start local context
   updateLocalContext (← mkLocalContext)
-  Optimize.mainAux e applyHashCons
+  if !(blaster.profileNormalize.get (← getOptions)) then
+    Optimize.mainAux e applyHashCons
+  else
+    let previous := (← get).optEnv.options.profile?
+    let now ← IO.monoNanosNow
+    let ref ← IO.mkRef ({ startedNs := now, lastNs := now } : NormalizationProfile)
+    modify fun env => { env with optEnv.options.profile? := some ref }
+    try
+      let result ← Optimize.mainAux e applyHashCons
+      profileReport "complete"
+      return result
+    catch ex =>
+      profileReport "error"
+      throw ex
+    finally
+      modify fun env => { env with optEnv.options.profile? := previous }
 
 
 /-- Optimize an expression using the given solver options.

--- a/Blaster/Optimize/Env/Profile.lean
+++ b/Blaster/Optimize/Env/Profile.lean
@@ -1,0 +1,85 @@
+import Blaster.Optimize.Env.Types
+
+open Lean
+namespace Blaster.Optimize
+
+register_option blaster.profileNormalize : Bool := {
+  defValue := false
+  descr := "Emit opt-in normalization-head timing and rewrite-cache diagnostics"
+}
+
+/-- Charge elapsed wall time to the innermost uncached normalization head.
+Anonymous expressions inherit their enclosing head. `selfNs` is exclusive of
+nested named heads, includes diagnostic overhead, and is not CPU time.
+-/
+private def charge (p : NormalizationProfile) (now : Nat) : NormalizationProfile := Id.run do
+  let owner := p.owners.headD `_normalizer
+  let entry := p.entries.getD owner {}
+  return { p with
+    lastNs := now
+    entries := p.entries.insert owner { entry with selfNs := entry.selfNs + now - p.lastNs } }
+
+def profileReport (status : String) : TranslateEnvT Unit := do
+  let some ref := (← get).optEnv.options.profile? | return
+  let now ← IO.monoNanosNow
+  ref.modify (charge · now)
+  let p ← ref.get
+  let o := (← get).optEnv
+  let entries := p.entries.toArray.qsort (fun a b => a.1.toString < b.1.toString)
+  let heads := entries.map fun (name, e) => Json.mkObj [
+    ("head", toJson name.toString), ("calls", toJson e.calls), ("self_ns", toJson e.selfNs)]
+  let events := p.events.toArray.qsort (fun a b => a.1.toString < b.1.toString)
+  let payload := (Json.mkObj [
+    ("schema", toJson (1 : Nat)), ("status", toJson status),
+    ("elapsed_ns", toJson (now - p.startedNs)),
+    ("active_frames", toJson p.owners.length), ("imbalances", toJson p.imbalances),
+    ("cache_hits", toJson p.hits), ("cache_misses", toJson p.misses),
+    ("cache_bypasses", toJson p.bypasses),
+    ("hashcons", toJson o.hashConsCache.size), ("contexts", toJson o.options.nextCtxId),
+    ("heads", Json.arr heads),
+    ("events", Json.mkObj (events.toList.map fun (n, count) => (n.toString, toJson count)))]).compress
+  if let some path ← IO.getEnv "BLASTER_PROFILE_FILE" then
+    -- Lean may buffer command stdout. Flush a separate JSONL stream so the
+    -- benchmark runner can retain progress even when it kills the process.
+    IO.FS.withFile path .append fun handle => do
+      handle.putStrLn payload
+      handle.flush
+  else
+    IO.println ("BLASTER_PROFILE " ++ payload)
+
+@[inline] def profileEvent (name : Name) : TranslateEnvT Unit := do
+  if let some ref := (← get).optEnv.options.profile? then
+    ref.modify fun p => { p with events := p.events.insert name (p.events.getD name 0 + 1) }
+
+@[inline] def profileCacheHit : TranslateEnvT Unit := do
+  if let some ref := (← get).optEnv.options.profile? then
+    ref.modify fun p => { p with hits := p.hits + 1 }
+
+def profileEnter (e : Expr) (bypass : Bool) : TranslateEnvT Unit := do
+  let some ref := (← get).optEnv.options.profile? | return
+  let now ← IO.monoNanosNow
+  ref.modify fun p =>
+    let p := charge p now
+    let owner := match e.getAppFn with
+      | .const n _ => n
+      | _ => p.owners.headD `_normalizer
+    let entry := p.entries.getD owner {}
+    { p with
+      owners := owner :: p.owners
+      entries := p.entries.insert owner { entry with calls := entry.calls + 1 }
+      misses := p.misses + (if bypass then 0 else 1)
+      bypasses := p.bypasses + (if bypass then 1 else 0) }
+  let p ← ref.get
+  -- Bounded-frequency snapshots survive a benchmark runner's time/memory kill.
+  if (p.misses + p.bypasses) % 1000000 == 0 then profileReport "progress"
+
+def profileLeave : TranslateEnvT Unit := do
+  let some ref := (← get).optEnv.options.profile? | return
+  let now ← IO.monoNanosNow
+  ref.modify fun p =>
+    let p := charge p now
+    match p.owners with
+    | [] => { p with imbalances := p.imbalances + 1 }
+    | _ :: rest => { p with owners := rest }
+
+end Blaster.Optimize

--- a/Blaster/Optimize/Env/ProfileData.lean
+++ b/Blaster/Optimize/Env/ProfileData.lean
@@ -1,0 +1,26 @@
+import Lean
+
+namespace Blaster.Optimize
+
+/-- Scalar-only diagnostics: never retain expressions, contexts or metavariables. -/
+structure NormalizationProfileEntry where
+  calls : Nat := 0
+  selfNs : Nat := 0
+deriving Inhabited
+
+/-- A separate instance is allocated for each profiled `Optimize.main` invocation.
+The stack mirrors uncached expression-normalization frames, not CEK execution.
+-/
+structure NormalizationProfile where
+  startedNs : Nat
+  lastNs : Nat
+  owners : List Lean.Name := []
+  entries : Std.HashMap Lean.Name NormalizationProfileEntry := {}
+  events : Std.HashMap Lean.Name Nat := {}
+  misses : Nat := 0
+  hits : Nat := 0
+  bypasses : Nat := 0
+  imbalances : Nat := 0
+deriving Inhabited
+
+end Blaster.Optimize

--- a/Blaster/Optimize/Env/Types.lean
+++ b/Blaster/Optimize/Env/Types.lean
@@ -1,4 +1,5 @@
 import Lean
+import Blaster.Optimize.Env.ProfileData
 import Blaster.Data.HashSet
 import Blaster.Data.HashMap
 import Blaster.Optimize.Expr
@@ -100,6 +101,9 @@ structure OptimizeOptions where
   active : HashSet CtxId := HashSet.emptyWithCapacity 123
 
   resetOptions : ResetOptions
+
+  /-- Per-invocation diagnostic state; absent unless profiling is enabled. -/
+  profile? : Option (IO.Ref NormalizationProfile) := none
 
 instance : Inhabited OptimizeOptions where
   default := { normalizeFunCall := true, inFunApp := false, mcDepth := 0, solverOptions := default, resetOptions := default }
@@ -861,7 +865,7 @@ def updateGlobalRewriteCache (a : Expr) (b : Expr) (insertIfNew := false) : Tran
 /-- Update rewrite cache at curCtx with `a := b`. -/
 @[always_inline, inline]
 def updateLocalRewriteCache (a : Expr) (b : Expr) (insertIfNew := false) : TranslateEnvT Unit := do
-  let ⟨_, rewriteCache, _, _, _, _, _, _, _, _, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, rewriteCache, _, _, _, _, _, _, _, _, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
   match rewriteCache.get? curCtx with
   | none =>
        let refEntry ← IO.mkRef $ (HashMap.emptyWithCapacity 256 : HashMap PtrExpr Expr).insert a b
@@ -896,7 +900,7 @@ def updateEqualityMap (lhs : Expr) (rhs : Expr) (ctxId : CtxId) : TranslateEnvT 
     newest entry visible in the current context (tag ∈ active). -/
 @[always_inline, inline]
 def eqMapFind? (lhs : Expr) : TranslateEnvT (Option Expr) := do
-  let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
   if equalityMap.size == 0
   then return none
   else ContextMap.findRaw equalityMap active lhs
@@ -906,7 +910,7 @@ def eqMapFind? (lhs : Expr) : TranslateEnvT (Option Expr) := do
     proof of the newest entry for `e` whose tag is active in the current context. -/
 @[always_inline, inline]
 def hypMapFind? (e : Expr) : TranslateEnvT (Option Expr) := do
-  let ⟨_, _, _, _, _, _, _, ⟨hypothesisMap, _⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, _, _, _, _, _, _, ⟨hypothesisMap, _⟩, _, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
   if hypothesisMap.size == 0
   then return none
   else ContextMap.findRaw hypothesisMap active e
@@ -936,9 +940,9 @@ def setAndCommitCtx (s : CtxScope) : TranslateEnvT Unit :=
 -/
 @[always_inline, inline]
 def endCtx (s : CtxScope) : TranslateEnvT Unit :=
-  modifyOptEnv fun ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7⟩, o12, o13, o14⟩ =>
+  modifyOptEnv fun ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7, profile⟩, o12, o13, o14⟩ =>
                    ⟨o1, rewrite.erase s.current, o3, o4, o5, o6, o7, o8, o9, o10,
-                   ⟨s1, s2, s3, s4, s.parent, s6, active.erase s.current, s7⟩, o12, o13, o14⟩
+                   ⟨s1, s2, s3, s4, s.parent, s6, active.erase s.current, s7, profile⟩, o12, o13, o14⟩
 
 
 
@@ -954,7 +958,7 @@ def ContextReuseMap.findRaw (m : ContextReuseMap) (e : Expr) (idx : USize) (curC
 
 @[always_inline, inline]
 def reuseContext? (e : Expr) (idx : USize) : TranslateEnvT (Option CtxReuseScope) := do
-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
   memCache.contextReuseCache.findRaw e idx curCtx
 
 @[always_inline, inline]
@@ -1199,7 +1203,7 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
 
 
 @[inline] def propagateReuseContext (current : Expr) (next : Expr) (idx : USize) : TranslateEnvT Unit := do
-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
   match ← memCache.contextReuseCache.findRaw current idx curCtx with
   | some reuse => updateContextReuseCache next idx reuse
   | none => return ()
@@ -1213,7 +1217,7 @@ def updateContextReuseCache (e : Expr) (idx : USize) (s : CtxReuseScope) : Trans
                     ⟨o1, rewrite, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12, o13, o14⟩
 
 @[inline] def freeRewriteCacheReuse (e : Expr) (idx : USize) : TranslateEnvT Unit := do
-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
   match ← memCache.contextReuseCache.findRaw e idx curCtx with
   | some reuse =>
       modifyOptEnv

--- a/Blaster/Optimize/OptimizeStack.lean
+++ b/Blaster/Optimize/OptimizeStack.lean
@@ -1,4 +1,5 @@
 import Lean
+import Blaster.Optimize.Env.Profile
 import Blaster.Optimize.Rewriting.OptimizeITE
 import Blaster.Optimize.Rewriting.OptimizeProjection
 import Blaster.Optimize.Telescope
@@ -65,8 +66,8 @@ def resetChoiceContext (h : HypsStackContext) (fvars : Array Expr) (lam : Expr) 
   | some scope =>
        updateContextReuseCache lam idx ⟨scope, fvars⟩
        modifyOptEnv
-         fun ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7⟩, o12, o13, o14⟩ =>
-             ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, scope.parent, s6, active.erase scope.current, s7⟩, o12, o13, o14⟩
+         fun ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, _, s6, active, s7, profile⟩, o12, o13, o14⟩ =>
+             ⟨o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, ⟨s1, s2, s3, s4, scope.parent, s6, active.erase scope.current, s7, profile⟩, o12, o13, o14⟩
   | none => return ()
 
 def restoreMVarDecls (optDecls : Option MVarIdDecls) : TranslateEnvT Unit :=
@@ -103,6 +104,7 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
          updateOptimizeEnvCache optExpr optExpr isGlobal
          if !e.hasMVar && !exprEq e optExpr then updateOptimizeEnvCache e optExpr isGlobal
        restoreMVarDecls mvarDecls
+       profileLeave
        match xs with
        | [] => return Sum.inr optExpr
        | _ => stackContinuity xs optExpr
@@ -383,9 +385,15 @@ def isInOptimizeEnvCache (a : Expr) (stack : List OptimizeStack) (mvarDecls : Op
   let useCache := !a.hasMVar
   if useCache then
     let cached := ← isInOptimizeCache? a isGlobal env
-    if !exprEq cached instCacheMiss then Sum.inr <$> stackContinuity stack cached
-    else return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
-  else return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
+    if !exprEq cached instCacheMiss then
+      profileCacheHit
+      Sum.inr <$> stackContinuity stack cached
+    else
+      profileEnter a false
+      return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
+  else
+    profileEnter a true
+    return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
 
   where
     hasVar (e : Expr) : Bool := e.hasFVar || e.hasMVar

--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
+++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
@@ -138,8 +138,12 @@ def funPropagation?
 
     loop (idx : Nat) (stop : Nat) (args : Array Expr) : TranslateEnvT (Option OptimizeStack) := do
       if idx ≥ stop then return none
-      else if let some re ← diteCstProp? cf args idx then return re
-      else if let some re ← matchCstProp? cf args idx then return re
+      else if let some re ← diteCstProp? cf args idx then
+        profileEvent (Name.str cf.constName! "choice_ite")
+        return re
+      else if let some re ← matchCstProp? cf args idx then
+        profileEvent (Name.str cf.constName! "choice_match")
+        return re
       else loop (idx + 1) stop args
 
     @[always_inline, inline]

--- a/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
@@ -15,7 +15,7 @@ partial def eraseMatchRhsRewriteCache (mInfo : MatchInfo) : TranslateEnvT Unit :
     else
       freeRewriteCacheReuse mInfo.nameExpr (idx - offset)
       visit (idx + 1) stop offset
-  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _⟩, _, _, _⟩ := (← get).optEnv
+  let ⟨_, _, _, _, _, _, _, _, _, memCache, ⟨_, _, _, _, curCtx, _, _, _, _⟩, _, _, _⟩ := (← get).optEnv
   if (← memCache.contextReuseCache.findRaw mInfo.nameExpr 0 curCtx).isSome then
     let start := mInfo.getFirstAltPos.toUSize
     visit start mInfo.arity.toUSize start
@@ -306,7 +306,7 @@ def reduceMatch? (args : Array Expr) (mInfo : MatchInfo) (resolveArgs := false) 
      go mInfo.getFirstDiscrPos mInfo.getFirstAltPos
 
     resolveArgsWithEqualityStack (args : Array Expr) : TranslateEnvT (Array Expr) := do
-     let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
+     let ⟨_, _, _, _, _, _, _, ⟨_, equalityMap⟩, _, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
      let rec visit (idx : Nat) (stop : Nat) (args : Array Expr) : TranslateEnvT (Array Expr) := do
        if idx ≥ stop then return args
        else
@@ -718,7 +718,7 @@ partial def optimizeMatchAlt
        return .InitOptimizeExpr body :: .MatchAltWaitForExpr reuse.fvars (some reuse.scope) currIdx matchInst :: stack
   | none =>
        let alts ← getMatchAlts args mInfo
-       let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _⟩, _, _, _⟩⟩ ← get
+       let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _, _⟩, _, _, _⟩⟩ ← get
        let updatedMCtx ← addNotEqPatternToContext args mInfo alts 0 currIdx nextCtxId false
        forallTelescope alts[currIdx]! fun xs b => do
          let lhs := b.getAppArgs
@@ -827,7 +827,7 @@ where
 
   @[always_inline, inline]
   lastPatternReduction? (mInfo : MatchInfo) (args : Array Expr) : TranslateEnvT (Option MatchElimResult) := do
-     let ⟨_, _, _, _, _, _, _, _, matchInContext, _, ⟨_, _, _, _, _, _, active, _⟩, _, _, _⟩ := (← get).optEnv
+     let ⟨_, _, _, _, _, _, _, _, matchInContext, _, ⟨_, _, _, _, _, _, active, _, _⟩, _, _, _⟩ := (← get).optEnv
      let h := (← get).optEnv.matchInContext
      let alts ← getMatchAlts args mInfo
      for i in [:alts.size - 1] do

--- a/Tests/Optimize.lean
+++ b/Tests/Optimize.lean
@@ -15,3 +15,5 @@ import Tests.Optimize.OptimizeNat
 import Tests.Optimize.OptimizeProp
 import Tests.Optimize.OptimizeRecFun
 import Tests.Optimize.OptimizeUnfold
+
+import Tests.Optimize.Profile

--- a/Tests/Optimize/Profile.lean
+++ b/Tests/Optimize/Profile.lean
@@ -36,7 +36,19 @@ set_option blaster.profileNormalize true
 #blaster (gen-cex: 0) (solve-result: 1) [∀ x : Nat, x = 0]
 end
 
--- A later invocation must not inherit an earlier invocation's diagnostic ref.
+-- Cleanup must happen even when normalization throws, and a following call in
+-- the same environment must allocate independent diagnostic state.
 run_cmd liftTermElabM do
-  let (_, env) ← (Optimize.main (mkConst ``True)).run (default : TranslateEnv)
-  unless env.optEnv.options.profile?.isNone do throwError "profile state leaked across invocations"
+  withOptions (fun opts => opts.setBool `blaster.profileNormalize true) do
+    let check : TranslateEnvT Unit := do
+      let mut failed := false
+      try
+        discard <| Optimize.main (.bvar 0)
+      catch _ => failed := true
+      unless failed do throwError "expected normalization of a loose bvar to fail"
+      unless (← get).optEnv.options.profile?.isNone do
+        throwError "profile state leaked after an exception"
+      discard <| Optimize.main (mkConst ``True)
+      unless (← get).optEnv.options.profile?.isNone do
+        throwError "profile state leaked after successful normalization"
+    check.run' (default : TranslateEnv)

--- a/Tests/Optimize/Profile.lean
+++ b/Tests/Optimize/Profile.lean
@@ -1,0 +1,42 @@
+import Tests.Utils
+
+open Lean Meta Elab Command Blaster.Optimize
+
+-- Compare the actual optimizer with profiling enabled and disabled. Exercise
+-- nested/sibling facts, closures, and constructor choices, not just a counter.
+run_cmd liftTermElabM do
+  let syntaxes := #[
+    (← `(∀ x y : Nat, x = y → y = 0 → x + 1 = 1)),
+    (← `(fun x : Nat => if x = 0 then x + 1 else x + 2)),
+    (← `(fun x y : Nat => (fun a b : Nat => a + b) y x)),
+    (← `(fun p q : Bool => ([if p then 1 else 2, if q then 3 else 4] : List Nat)))
+  ]
+  let inputs ← syntaxes.mapM fun stx => Tests.parseTerm stx
+  for input in inputs do
+    let (expected, baseEnv) ← (Optimize.main input).run (default : TranslateEnv)
+    let now ← IO.monoNanosNow
+    let ref ← IO.mkRef ({ startedNs := now, lastNs := now } : NormalizationProfile)
+    let env := { (default : TranslateEnv) with optEnv.options.profile? := some ref }
+    let (actual, profileEnv) ← (Optimize.main input).run env
+    unless ← isDefEq actual expected do throwError "profiling changed the normalized expression"
+    unless baseEnv.optEnv.hashConsCache.size == profileEnv.optEnv.hashConsCache.size &&
+        baseEnv.optEnv.options.nextCtxId == profileEnv.optEnv.options.nextCtxId do
+      throwError "profiling changed optimizer allocation/context counts"
+    let p ← ref.get
+    unless p.owners.isEmpty && p.imbalances == 0 && p.misses > 0 && p.hits > 0 do
+      throwError "unbalanced or empty normalization profile"
+    let total := p.entries.fold (fun sum _ e => sum + e.selfNs) 0
+    unless total == p.lastNs - p.startedNs do throwError "exclusive profile times do not partition elapsed time"
+
+section
+set_option blaster.profileNormalize true
+#testOptimize ["ProfiledSiblingFacts"]
+  (∀ x : Nat, (if x = 0 then x + 1 else x + 2) =
+    (if x = 0 then 1 else x + 2)) ===> True
+#blaster (gen-cex: 0) (solve-result: 1) [∀ x : Nat, x = 0]
+end
+
+-- A later invocation must not inherit an earlier invocation's diagnostic ref.
+run_cmd liftTermElabM do
+  let (_, env) ← (Optimize.main (mkConst ``True)).run (default : TranslateEnv)
+  unless env.optEnv.options.profile?.isNone do throwError "profile state leaked across invocations"

--- a/docs/design/cardano-staged-preparation.md
+++ b/docs/design/cardano-staged-preparation.md
@@ -109,3 +109,29 @@ uses staged compilation and continuations for symbolic execution.
 WebAssembly interpreter and uses continuations and snapshots. These support
 trying a staged representation, but their concolic/test-generation performance
 results do not predict a speedup for universally quantified Cardano proofs.
+
+
+## First target selected from normalization telemetry
+
+The follow-up [attribution report](../reviews/cardano-preparation-attribution-2026-09-09.md)
+measures input conversion at 58–116 ms in isolation, while global preparation at
+fuel 1600 takes a median 55.859 seconds. From fuel 1400 to 1600, normalization
+requests rise 4.69× and propagation of the remaining `runSteps` computation across
+choices rises 4.73×. Direct `List.cons` match propagation is unchanged. SellNFT
+spends substantial profiled time in CEK control and environment binding checks.
+
+The first prototype should therefore specialize SellNFT's fixed control and
+variable access, with explicit dynamic environment operands and reusable
+continuations. Its measurements must distinguish reducing interpreter overhead
+from moving branch expansion into the residual or SMT phase. Generic constructor
+choice retention remains experimental in PR #240.
+
+The accepting global gate is now concrete: the existing nonmember golden accepts
+at 1453 steps and its prepared result accepts at fuel 1600. The benchmark also
+requires unit as the returned value. The larger existing goldens require 2782
+and 3441 steps. Preserve these gates as the prototype grows.
+
+[PlutusCoreBlaster PR #42](https://github.com/input-output-hk/PlutusCoreBlaster/pull/42)
+already proposes fuel-free step composition lemmas. Review its compatibility
+with the pinned interpreter before using it for block simulation. This section
+selects the next experiment; no staged compiler is implemented by the telemetry PR.

--- a/docs/reviews/cardano-preparation-attribution-2026-09-09.md
+++ b/docs/reviews/cardano-preparation-attribution-2026-09-09.md
@@ -1,0 +1,144 @@
+# Cardano preparation: attribution and accepting executions
+
+This follow-up to PR #239 adds opt-in normalization profiling and an accepting
+global-validator gate. It changes no normalization rule. The measurements select
+the next specialization experiment; they are not an optimization speedup claim.
+
+## Reproduction and validation
+
+Implementation: `6575b13c`, followed by `4b0ddd06` (exception-cleanup tests, a
+stronger prepared unit-return check, and excluding replayed preparation metrics
+from proof-phase timings). Workloads and their exact revisions remain those in
+`Benchmarks/cardano/pins.json`. The benchmark setup patches now also separate
+application construction and declaration checking from normalization. Applying
+them to fresh copies reproduced the measured dependency diffs byte for byte.
+
+Machine: Apple M2 Max, 12 logical CPUs, Lean 4.24.0. Runs were native Lake builds,
+serial after warming dependencies. Solver checks used Z3 4.15.2 with the existing
+30-second cap. Per-run results and final profiles are in `Benchmarks/cardano/results/attribution/`;
+commands and metric definitions are in `Benchmarks/cardano/README.md`.
+
+The full `lake test` suite passes. Its first run hit the previously observed
+`Tests/Smt/SmtNat/SmtNatMod.lean:37` solver timeout while tests were building;
+the retry passed. Focused tests compare normalized expressions and hash-cons/
+context counts with profiling on and off, check exact timing accounting, and
+check cleanup after both success and an exception. A deliberately capped
+six-second preparation retained a valid partial JSONL profile and was reported
+as a timeout, not a completed preparation.
+
+## Input conversion is cheap in isolation
+
+Each row reports three runs normalizing the original input conversion function
+with symbolic arguments, without applying the CEK interpreter.
+
+| Conversion | Normalization milliseconds | Median | Hash-cons entries |
+|---|---|---:|---:|
+| Global | 116, 110, 117 | 116 ms | 41,460 |
+| SellNFT | 58, 56, 58 | 58 ms | 7,317 |
+| Governance | 80, 76, 80 | 80 ms | 15,652 |
+
+These costs cannot simply be subtracted from full preparation. In the full
+global-1600 profile, CardanoLedgerApi normalization heads account for 3.57 seconds,
+including 2.25 seconds under an output-list conversion helper. Conversion-derived
+expressions can be processed again in interpreter branch contexts.
+
+With profiling disabled, full global-1600 normalization takes **57.017, 55.012,
+and 55.859 seconds** (median **55.859 seconds**). Application construction takes
+0–1 ms; final declaration checking/compilation takes 31–32 ms. Whole-module time
+is 58.12–60.44 seconds. Every run retains the same 15,595,053 hash-cons entries,
+103,138 allocated context IDs, and 633,904-byte output module as the earlier
+baseline. The older baseline scout was 59.456 seconds; these are not paired
+evidence of a speedup from the diagnostic hooks. A subsequent unprofiled run
+after collecting profiles takes 55.779 seconds, with the same structural counts.
+
+## The preparation cliff tracks propagation of the remaining computation
+
+One diagnostic run per row. A normalization request is a rewrite-cache hit,
+miss, or metavariable-containing expression for which lookup is bypassed.
+
+| Metric | Global 1400 | Global 1600 | SellNFT 1800 |
+|---|---:|---:|---:|
+| Profiled normalization | 12.39 s | 64.75 s | 40.23 s |
+| Normalization requests | 11,883,838 | 55,686,815 | 41,228,296 |
+| Rewrite-cache hits | 7,106,208 | 33,262,159 | 25,383,164 |
+| Rewrite-cache misses | 2,893,268 | 13,474,894 | 4,259,525 |
+| Metavariable bypasses | 1,884,362 | 8,949,762 | 11,585,607 |
+| Allocated context IDs | 22,056 | 103,138 | 29,063 |
+| `runSteps` match propagation | 7,782 | 35,132 | 9,816 |
+| `runSteps` conditional propagation | 1,540 | 8,994 | 2,859 |
+| `List.cons` match propagation | 582 | 582 | 2 |
+
+The global fuel increase is 14.3%; normalization requests grow **4.69×**, and
+propagation of `runSteps` across choices grows **4.73×**. Direct list-constructor
+match propagation stays at 582. These are optimizer events, not counts of
+feasible program paths, but they identify where the additional work appears.
+
+In global-1600, **19.5%** of profiled time is under `List.cons`, with 6.13 million
+uncached normalization entries. Heads prefixed `PlutusCore.UPLC.CekMachine.`
+account for **41.3%**; builtin dispatch and `runSteps` are prominent. The same
+namespace accounts for **53.0%** in SellNFT, where `ifBoundOtherwiseError` and
+its generated matcher together account for **14.3%**. This makes variable access
+and environment handling an especially useful target in the smaller script.
+
+These are exclusive wall times under syntactic normalization heads. Anonymous
+expressions inherit their enclosing head, and the figures include diagnostic
+overhead. A constructor's time may include work in its fields. A CEK head's time
+does not establish that its work is statically removable. Global-1600 profiling
+adds about **16%** relative to the three-run unprofiled median. All three complete
+profiles have balanced frames and exactly partition their measured interval;
+they preserve the earlier node/context counts and output-module sizes.
+
+## A real accepting execution is now part of the benchmark
+
+The fixture reuses the existing post-#112 global goldens and the exact
+`programmableLogicGlobal1600.script` used by the preparation benchmark. It checks
+the golden literals against their serialized data through the existing
+`TermsCheck` module, successful typed decoding, and an exact round-trip through
+`globalInputs1600`.
+
+| Golden | First terminal transition | Required result |
+|---|---:|---|
+| transfer-nonmember-covering-node | 1,453 | Unit halt |
+| transfer-member-single-policy | 2,782 | Unit halt |
+| transfer-mixed-many-policies | 3,441 | Unit halt |
+| transfer-containment-violation-REJECT | 2,370 | Genuine CEK error |
+
+All four pass executable checks at their terminal budget, one step below it,
+and at ten times that budget. The counting evaluator distinguishes unfinished
+execution from a real error; `runSteps` intentionally maps fuel exhaustion to
+`State.Error`. Accepting results must contain unit, not just any halting value.
+
+At fuel 1600, Blaster also proves the nonmember golden accepts against the
+**prepared `.prop`**, alongside the existing universal SeizeAct rejection
+property. The final fixture additionally proves that the prepared result
+returns unit. All three properties pass in three serial runs: 1.672, 1.668, and
+1.674 seconds for the proof phase after preparation. Fuel 1400 is too low for this particular witness; fuel 1600 is
+sufficient. Larger member and mixed-policy witnesses remain useful future
+targets at 2782 and 3441.
+
+The executable checks use `native_decide`, which trusts native compilation.
+They are regression gates, not a kernel-reduced equivalence certificate between
+`.prop` and `.exec`, and they do not establish every ledger validity condition.
+The proposed staged compiler still needs a separate correctness argument.
+
+## Selected first specialization experiment
+
+Start with **SellNFT's fixed CEK control and variable access**, keeping dynamic
+environments and the remaining computation shared. The global results motivate
+sharing continuations across symbolic state choices; merely changing constructor
+distribution has already failed the end-to-end gate in draft PR #240.
+
+Keep the first experiment bounded: a small set of fixed-program blocks with
+explicit dynamic operands, exact CEK fuel costs, and an interpreter fallback for
+unsupported operations. Measure whether it actually reduces normalization
+requests and `runSteps` distribution, then check preparation plus proofs and the
+accepting golden. Neither the namespace percentages nor staging papers predict
+the obtainable speedup.
+
+[PlutusCoreBlaster PR #42](https://github.com/input-output-hk/PlutusCoreBlaster/pull/42),
+checked at `dce72b54641fa5e0959a54cb5d22f2350f410576`, already proposes fuel-free
+step iteration and composition lemmas. Reuse or adapt that work when proving
+block simulation; do not duplicate it. It currently targets `main` and notes
+overlap with PRs #34 and #40, so compatibility with the pinned CIP-153 interpreter
+must be checked explicitly. See the updated staged-preparation design for the
+remaining semantic and performance gates.


### PR DESCRIPTION
Global-validator preparation at fuel 1600 spends a median 55.859 seconds in normalization, while final declaration checking/compilation takes about 31 ms. This adds opt-in attribution and an accepting-execution gate so the next optimization can target that cost and preserve useful proofs.

Stacked on #239. No normalization rule changes.

- Add `blaster.profileNormalize`: exclusive timing under normalization heads, rewrite-cache hits/misses/metavariable bypasses, and choice-propagation counts. State is per invocation and retains names/counters rather than expression graphs. Flushed JSONL checkpoints survive a bounded runner timeout.
- Extend the Cardano harness with conversion-only and acceptance-only runs, preparation phase timings, and Blaster acceptance/unit-return checks against the measured residual.
- Reuse four existing global goldens. Verify typed-input round-trips, exact terminal step counts, one-step-short exhaustion, and stable outcomes at ten times the terminal budget. The nonmember golden accepts at 1453 steps and its prepared result accepts and returns unit at fuel 1600.
- Commit measurements and the next specialization target: SellNFT's fixed CEK control and environment access, with shared continuations.

The global fuel increase from 1400 to 1600 multiplies normalization requests by 4.69 and propagation of `runSteps` across choices by 4.73; direct list-constructor match propagation stays unchanged. Input conversion alone takes only 58–116 ms on the measured scripts. Profiling adds about 16% to global-1600 normalization, so diagnostic runs are separate from performance comparisons. This PR does not claim a preparation speedup or implement the staged compiler.

Validation: full `lake test` passes (the previously observed `SmtNatMod.lean:37` timeout occurred on the initial busy run; retry passed), profiling preserves normalized terms and structural counts in focused tests, exception cleanup and time accounting pass, all four native golden gates pass, and three serial prepared proof runs pass in about 1.67 seconds each. Dependency setup patches reproduce the measured tracked diffs. The six-second timeout test retains a valid partial profile. Native golden checks use `native_decide`; they do not replace the proposed compiler's future equivalence proof.

Existing work checked: #160 covers cache retention diagnostics; input-output-hk/PlutusCoreBlaster#42 already proposes CEK step-composition lemmas and is referenced for the next prototype. Constructor retention remains experimental in #240.
