### PR TITLE
Fix cyclic beta-cache assignments on re-entry

### DIFF
--- a/Blaster/Optimize/Env/InstantiateMVars.lean
+++ b/Blaster/Optimize/Env/InstantiateMVars.lean
@@ -94,7 +94,7 @@ def instantiateSharedMVars (e : Expr) : TranslateEnvT Expr :=
          (HashMap.emptyWithCapacity 64)
 
 
-private unsafe def instantiateSharedMVarsAux' (cur : Expr) (isResult : Bool) (stk : Array HashConsStack) (cache : InstCache) (assign : MVarAssignments) : TranslateEnvT Expr := do
+private unsafe def instantiateSharedMVarsAux' (cur : Expr) (isResult : Bool) (stk : Array HashConsStack) (cache : InstCache) (assign : MVarAssignments) (allowUnassigned : Bool := false) : TranslateEnvT Expr := do
   if isResult then
       let r := cur
       if stk.usize > 0 then
@@ -103,72 +103,80 @@ private unsafe def instantiateSharedMVarsAux' (cur : Expr) (isResult : Bool) (st
         match next with
         | .WaitAppFun e a =>
              let stk := stk.uset topIdx (.WaitAppArg e r) lcProof
-             instantiateSharedMVarsAux' a false stk cache assign
+             instantiateSharedMVarsAux' a false stk cache assign allowUnassigned
         | .WaitAppArg e f =>
              let r' ← e.updateAppExpr! f r
-             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign
+             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign allowUnassigned
         | .WaitForallType e b =>
              let stk := stk.uset topIdx (.WaitForallBody e r) lcProof
-             instantiateSharedMVarsAux' b false stk cache assign
+             instantiateSharedMVarsAux' b false stk cache assign allowUnassigned
         | .WaitForallBody e t =>
              let r' ← e.updateForallExpr! t r
-             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign
+             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign allowUnassigned
         | .WaitLambdaType e b =>
              let stk := stk.uset topIdx (.WaitLambdaBody e r) lcProof
-             instantiateSharedMVarsAux' b false stk cache assign
+             instantiateSharedMVarsAux' b false stk cache assign allowUnassigned
         | .WaitLambdaBody e t =>
              let r' ← e.updateLambdaExpr! t r
-             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign
+             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign allowUnassigned
         | .WaitLetType e v b =>
              let stk := stk.uset topIdx (.WaitLetValue e r b) lcProof
-             instantiateSharedMVarsAux' v false stk cache assign
+             instantiateSharedMVarsAux' v false stk cache assign allowUnassigned
         | .WaitLetValue e t b =>
              let stk := stk.uset topIdx (.WaitLetBody e t r) lcProof
-             instantiateSharedMVarsAux' b false stk cache assign
+             instantiateSharedMVarsAux' b false stk cache assign allowUnassigned
         | .WaitLetBody e t v =>
              let r' ← e.updateLetExpr! t v r
-             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign
+             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign allowUnassigned
         | .WaitMData e =>
              let r' ← e.updateMDataExpr! r
-             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign
+             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign allowUnassigned
         | .WaitProjExpr e =>
              let r' ← e.updateProjExpr! r
-             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign
+             instantiateSharedMVarsAux' r' true stk.pop (saveInitMVarInto cache e r') assign allowUnassigned
       else return r
   else
       let e := cur
       let cached := cache.getD (mkInstKey e 0) instCacheMiss
-      if !exprEq cached instCacheMiss then instantiateSharedMVarsAux' cached true stk cache assign
+      if !exprEq cached instCacheMiss then instantiateSharedMVarsAux' cached true stk cache assign allowUnassigned
       else
           if e.hasExprMVar then
            match e with
            | .mvar _ =>
                 let v := assign.getD e instCacheMiss
-                let r ← if exprEq v instCacheMiss then getMVarAssignment! e else pure v
-                if r.hasMVar
-                then instantiateSharedMVarsAux' r false stk cache assign
-                else instantiateSharedMVarsAux' r true stk (saveInitMVarInto cache e r) assign
+                let r ←
+                  if !exprEq v instCacheMiss then pure v
+                  else if !allowUnassigned then getMVarAssignment! e
+                  else
+                    match ← getExprMVarAssignment? e.mvarId! with
+                    | some value => hashcons value
+                    | none => pure e
+                if allowUnassigned && exprEq r e then
+                  instantiateSharedMVarsAux' e true stk (saveInitMVarInto cache e e) assign allowUnassigned
+                else if r.hasMVar
+                then instantiateSharedMVarsAux' r false stk cache assign allowUnassigned
+                else instantiateSharedMVarsAux' r true stk (saveInitMVarInto cache e r) assign allowUnassigned
            | .bvar .. | .const .. | .fvar .. | .sort .. | .lit .. =>
-                instantiateSharedMVarsAux' e true stk (saveInitMVarInto cache e e) assign
+                instantiateSharedMVarsAux' e true stk (saveInitMVarInto cache e e) assign allowUnassigned
            | .app f a =>
                 let stk := stk.push (.WaitAppFun e a)
-                instantiateSharedMVarsAux' f false stk cache assign
+                instantiateSharedMVarsAux' f false stk cache assign allowUnassigned
            | .letE _ t v b _ =>
                 let stk := stk.push (.WaitLetType e v b)
-                instantiateSharedMVarsAux' t false stk cache assign
+                instantiateSharedMVarsAux' t false stk cache assign allowUnassigned
            | .forallE _ t b _ =>
                 let stk := stk.push (.WaitForallType e b)
-                instantiateSharedMVarsAux' t false stk cache assign
+                instantiateSharedMVarsAux' t false stk cache assign allowUnassigned
            | .lam _ t b _ =>
                 let stk := stk.push (.WaitLambdaType e b)
-                instantiateSharedMVarsAux' t false stk cache assign
+                instantiateSharedMVarsAux' t false stk cache assign allowUnassigned
            | .mdata _ b =>
                 let stk := stk.push (.WaitMData e)
-                instantiateSharedMVarsAux' b false stk cache assign
+                instantiateSharedMVarsAux' b false stk cache assign allowUnassigned
            | .proj _ _ b =>
                 let stk := stk.push (.WaitProjExpr e)
-                instantiateSharedMVarsAux' b false stk cache assign
-          else instantiateSharedMVarsAux' e true stk (saveInitMVarInto cache e e) assign
+                instantiateSharedMVarsAux' b false stk cache assign allowUnassigned
+          else instantiateSharedMVarsAux' e true stk (saveInitMVarInto cache e e) assign allowUnassigned
 
 
 /-- Instantiate MVars will guaranteeing maximum sharing.
@@ -178,5 +186,12 @@ private unsafe def instantiateSharedMVarsAux' (cur : Expr) (isResult : Bool) (st
 def instantiateSharedMVars' (e : Expr) (assign : MVarAssignments) : TranslateEnvT Expr :=
   unsafe instantiateSharedMVarsAux' e false (Array.emptyWithCapacity e.approxDepth.toNat)
          (HashMap.emptyWithCapacity 64) assign
+
+/-- Resolve assigned metavariables under a fixed assignment snapshot, leaving
+    unassigned pattern variables intact. Used before beta-cache rebinding. -/
+@[always_inline, inline]
+def snapshotSharedMVars (e : Expr) (assign : MVarAssignments) : TranslateEnvT Expr :=
+  unsafe instantiateSharedMVarsAux' e false (Array.emptyWithCapacity e.approxDepth.toNat)
+         (HashMap.emptyWithCapacity 64) assign true
 
 end Blaster.Optimize

--- a/Blaster/Optimize/Env/Utils.lean
+++ b/Blaster/Optimize/Env/Utils.lean
@@ -336,6 +336,16 @@ partial def betaLambdaEnv (lam : Expr) (args : Array Expr) : TranslateEnvT BetaL
   then return ⟨lam, none⟩
   else if lam.isLambda then
     let nbEffective := if nbParamsU < nbArgs then nbParamsU else nbArgs
+    -- A nested invocation may refer to this cache entry's current parameters,
+    -- including through another assignment. Snapshot every argument under the
+    -- old environment before rebinding any parameter. Include over-application
+    -- arguments: they are appended after the rebinding below.
+    let args ←
+      if args.any (·.hasExprMVar) &&
+          (← get).optEnv.memCache.betaLambdaCache.contains (mkInstKey lam nbEffective) then
+        let assignments := (← get).optEnv.mAssignments
+        args.mapM (snapshotSharedMVars · assignments)
+      else pure args
     let betaRes ← getBetaReduce lam args nbEffective
     if nbParamsU < nbArgs
     then return { betaRes with betaReduced := ← mkAppRangeExpr betaRes.betaReduced nbParams nbArgs.toNat args }

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -40,3 +40,4 @@ import Tests.FixedIssues.Issue228
 import Tests.FixedIssues.Issue233
 import Tests.FixedIssues.Issue231
 import Tests.FixedIssues.Issue232
+import Tests.FixedIssues.Issue242

--- a/Tests/FixedIssues/Issue242.lean
+++ b/Tests/FixedIssues/Issue242.lean
@@ -1,0 +1,80 @@
+import Tests.Utils
+
+open Lean Meta Elab Command Blaster.Optimize
+namespace Tests.Issue242
+
+-- Enter the same beta-cache entry while its previous invocation is still live.
+-- Detect cycles before expanding them, so the unfixed regression fails quickly.
+run_cmd liftTermElabM do
+  let listId ← Tests.parseTerm (← `(fun xs : List Nat => xs))
+  let pair ← Tests.parseTerm (← `(fun x y : Nat => (x, y)))
+  let funId ← Tests.parseTerm (← `(fun f : Nat → Nat => f))
+  let twice ← Tests.parseTerm (← `(fun x : Nat => x + x))
+  let check : TranslateEnvT (Expr × Expr) := do
+    let nat ← hashcons (mkConst ``Nat)
+    let nil ← mkAppExpr (mkConst ``List.nil [levelZero]) nat
+    let cons (n : Nat) (xs : Expr) :=
+      mkApp3Expr (mkConst ``List.cons [levelZero]) nat (mkNatLit n) xs
+    let listId ← hashcons listId
+    let first ← betaLambdaEnv listId #[nil]
+    let second ← betaLambdaEnv listId #[← cons 0 first.betaReduced]
+    let assigned ← getMVarValue second.betaReduced
+    if (assigned.find? (fun e => exprEq e second.betaReduced)).isSome then
+      throwError "beta-cache reuse created a cyclic metavariable assignment"
+    let nested ← instantiateSharedMVars second.betaReduced
+    unless ← isDefEq nested (← cons 0 nil) do throwError "nested beta argument changed value"
+    restoreMVarDecls second.prevMVarIdDecls
+    unless ← isDefEq (← instantiateSharedMVars first.betaReduced) nil do
+      throwError "outer beta assignment was not restored"
+
+    -- The dependency can pass through another assigned metavariable.
+    let alias ← hashcons (← mkFreshExprMVar none)
+    assignMVar alias first.betaReduced
+    let viaAlias ← betaLambdaEnv listId #[← cons 1 alias]
+    unless ← isDefEq (← instantiateSharedMVars viaAlias.betaReduced) (← cons 1 nil) do
+      throwError "transitive beta argument changed value"
+    restoreMVarDecls viaAlias.prevMVarIdDecls
+
+    -- Match reduction can legitimately pass unassigned pattern variables.
+    let pending ← hashcons (← mkFreshExprMVar (some (mkApp (mkConst ``List [levelZero]) nat)))
+    let withPending ← betaLambdaEnv listId #[pending]
+    unless exprEq (← getMVarValue withPending.betaReduced) pending do
+      throwError "an unassigned pattern variable was not preserved"
+    restoreMVarDecls withPending.prevMVarIdDecls
+
+    -- Resolve all right-hand sides before assigning any left-hand side.
+    let pair ← hashcons pair
+    discard <| betaLambdaEnv pair #[mkNatLit 1, mkNatLit 2]
+    let some cached := (← get).optEnv.memCache.betaLambdaCache.get? (mkInstKey pair 2)
+      | throwError "expected cached pair lambda"
+    let swapped ← betaLambdaEnv pair #[cached.mvarArgs[1]!, cached.mvarArgs[0]!]
+    let expected ← mkApp4Expr (mkConst ``Prod.mk [levelZero, levelZero]) nat nat (mkNatLit 2) (mkNatLit 1)
+    unless ← isDefEq (← instantiateSharedMVars swapped.betaReduced) expected do
+      throwError "beta-cache substitution was not simultaneous"
+    restoreMVarDecls swapped.prevMVarIdDecls
+
+    -- An extra argument also refers to the old assignment. Snapshotting only
+    -- the arguments consumed by the lambda would change twice (succ 3) to 12.
+    let funId ← hashcons funId
+    let outer ← betaLambdaEnv funId #[← hashcons (mkConst ``Nat.succ)]
+    let extra ← mkAppExpr outer.betaReduced (mkNatLit 3)
+    let applied ← betaLambdaEnv funId #[← hashcons twice, extra]
+    let overApplied ← instantiateSharedMVars applied.betaReduced
+    restoreMVarDecls applied.prevMVarIdDecls
+    unless ← isDefEq (← instantiateSharedMVars outer.betaReduced) (← hashcons (mkConst ``Nat.succ)) do
+      throwError "over-application did not restore its outer function"
+    return (nested, overApplied)
+  let (nested, overApplied) ← check.run' (default : TranslateEnv)
+  for (name, value) in [(`Tests.Issue242.nestedResult, nested),
+                         (`Tests.Issue242.overAppliedResult, overApplied)] do
+    addDecl <| .defnDecl {
+      name, levelParams := [], type := ← inferType value, value,
+      hints := .abbrev, safety := .safe }
+
+#testOptimize ["Issue242NestedCachedBeta"] (norm-result: 1)
+  nestedResult ===> ([0] : List Nat)
+#testOptimize ["Issue242OverAppliedCachedBeta"] (norm-result: 1)
+  overAppliedResult ===> (8 : Nat)
+#blaster [overAppliedResult = 8]
+
+end Tests.Issue242


### PR DESCRIPTION
Re-entering a cached lambda with an argument such as `0 :: previousResult` could assign its parameter to an expression containing itself. Resolve assigned metavariables under the old assignment environment before rebinding the cache entry, while preserving unassigned matcher variables. Snapshot every argument, including arguments applied to the lambda's result, so substitution remains simultaneous.

Fixes #242. Stacked on #241; this PR contains only the cache fix and its regression coverage.

`Tests/FixedIssues/Issue242.lean` detects the original cycle without expanding it, checks alias chains, simultaneous swaps, unassigned pattern variables, outer-scope restoration, and over-application. It then checks the computed results with two `#testOptimize` calls and Blaster. The regression fails on the parent commit and passes here.

Validation: native `lake build Blaster`; focused regression and matcher/state-machine checks; full `lake test` passes. This fixes a demonstrated cyclic assignment/nontermination hazard, without claiming a demonstrated false `Valid` verdict.
