### PR TITLE
Preserve dependent matcher motives and reduce known indexed branches

### DIFF
--- a/Blaster/Optimize/Rewriting/NormalizeMatch.lean
+++ b/Blaster/Optimize/Rewriting/NormalizeMatch.lean
@@ -551,6 +551,12 @@ def matchExprRewriter
            := ⊥  otherwise
 -/
 def normMatchExpr? (args : Array Expr) (mInfo : MatchInfo) : TranslateEnvT (Option Expr) := do
+  -- A nondependent conditional cannot replace a matcher whose result type
+  -- refers to a discriminator. Stripping that motive's lambdas would expose
+  -- loose bound variables and give branches incompatible result types.
+  -- Check each motive before consulting the matcher-name cache: the same
+  -- matcher can also be instantiated with a nondependent motive.
+  if (getLambdaBody args[mInfo.getFirstDiscrPos - 1]!).hasLooseBVars then return none
   match (← get).optEnv.memCache.isMatchToIte.get? mInfo.name with
   | some b => if b then matchExprRewriter mInfo args normMatchExprAux?
                    else return none

--- a/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
@@ -258,27 +258,32 @@ partial def instantiateUnifiedMVars (mvars : Array Expr) (margs : Array Expr) (m
       else visit (idx + 1) stop mvars
   visit 0 mvars.size mvars
 
-/-- Given `m := f x₁ ... xₙ` with `f` corresponding to a match function
-    and `mInfo` the corresponding matcher info, perform the following:
-     - When `¬ allMatchDiscrsAreCtor x₁ ... xₙ minfo`:
-          - return none
-     - When `m := b` is already in the weak head cache
-         - return `b`
-     - Otherwise:
-      - When .reduced e ← reduceMatcher? m
-          - update cache with `m := some e`
-          - return `some e`
-      - Otherwise
-          - update cache with `m := none`
-          - return `none`
-    Assume that `m` is a match expression.
-    Assume that `normChoiceApplication` has already applied to push extra arguments in match rhs`
+/-- Reduce a matcher with constructor or proof discriminators. Try structural
+    pattern unification first, then Lean's definitional matcher reduction when
+    parameter syntax prevents unification. Return `none` if neither selects a
+    branch. `normChoiceApplication` must already have pushed extra arguments
+    into the alternatives.
 -/
 def reduceMatch? (args : Array Expr) (mInfo : MatchInfo) (resolveArgs := false) : TranslateEnvT (Option BetaLambdaResult) := do
  let args ← resolveArgsWithEqualityStack args
  if !(← allMatchDiscrsAreCtor args) then return none
  let alts ← getMatchAlts args mInfo
- visit_alts? args alts mInfo.getFirstAltPos mInfo.arity false
+ if let some result ← visit_alts? args alts mInfo.getFirstAltPos mInfo.arity false then
+   return some result
+ -- Implicit parameters can be definitionally equal without having identical
+ -- normalized syntax (for example, `Plan (OfNat.ofNat 1)` and `Plan 1`).
+ -- Let Lean reduce a known matcher when structural pattern matching is stuck.
+ -- Keep its metavariable changes separate from the optimizer's assignments.
+ let app ← mkAppNExpr mInfo.nameExpr args
+ let app ← if app.hasMVar then instantiateSharedMVars app else pure app
+ let result ← withLocalContext <| withoutModifyingMCtx <| withNewMCtxDepth do
+   match ← reduceMatcher? app with
+   | .reduced result => return some (← instantiateMVars result)
+   | _ => return none
+ if let some result := result then
+   eraseMatchRhsRewriteCache mInfo
+   return some ⟨← hashcons result, none⟩
+ return none
 
    where
 

--- a/Tests/FixedIssues.lean
+++ b/Tests/FixedIssues.lean
@@ -41,3 +41,4 @@ import Tests.FixedIssues.Issue233
 import Tests.FixedIssues.Issue231
 import Tests.FixedIssues.Issue232
 import Tests.FixedIssues.Issue242
+import Tests.FixedIssues.Issue245

--- a/Tests/FixedIssues/Issue245.lean
+++ b/Tests/FixedIssues/Issue245.lean
@@ -1,0 +1,41 @@
+import Tests.Utils
+namespace Tests.Issue245
+structure Plan (n : Nat) where
+  worker : Nat → Nat
+
+def recognize (n : Nat) : Option (Plan n) :=
+  match n with
+  | 0 => some { worker := fun x => x+1 }
+  | _ => none
+
+def run (fuel n x : Nat) : Nat :=
+  match fuel with
+  | 0 => x
+  | fuel+1 =>
+    match recognize n with
+    | none => x
+    | some plan =>
+      let remaining := plan.worker fuel
+      if h : remaining < fuel then run remaining n x else x+1
+termination_by fuel
+
+example (x : Nat) : run 3 1 x = x := by simp [run, recognize]
+attribute [local blaster_specialize 1] run
+#testOptimize ["IndexedPlanFallback"] (fun x : Nat => run 3 1 x) ===> (fun x : Nat => x)
+
+#testOptimize ["IndexedPlanSelected"] (norm-result: 1)
+  (fun x : Nat => run 3 0 x) ===> (fun x : Nat => Nat.add 1 x)
+
+#testOptimize ["IndexedPlanSymbolicFallback"]
+  (fun n x : Nat => run 3 (n + 1) x) ===> (fun _ x : Nat => x)
+
+def witness (n : Nat) : Option (PLift (n = 0)) :=
+  match n with
+  | 0 => some ⟨rfl⟩
+  | _ => none
+
+def hasWitness (n : Nat) : Bool := (witness n).isSome
+
+#testOptimize ["IndexedProofSelected"] hasWitness 0 ===> true
+#testOptimize ["IndexedProofFallback"] hasWitness 1 ===> false
+end Tests.Issue245


### PR DESCRIPTION
## Description

Normalizing a recursive fallback that returns `Option (Plan n)` could fail with `optimizeExpr: unexpected bound variable #0`. The match-to-conditional rewrite removed the motive's lambda even when its result type depended on that binder. Preserve those dependent matches, checking each application before consulting the matcher-name cache.

Known branches must still reduce: implicit indices such as `Plan (OfNat.ofNat 1)` and `Plan 1` can be definitionally equal but fail structural pattern unification. After that fast path fails on constructor/proof discriminators, use Lean's matcher reducer in the optimizer's local context, with isolated metavariable changes, and hash-cons the result.

## Type of Change

- [x] Bug fix
- [x] Test updates

## Related Issue

Fixes #245. Stacked on #244 (`perf/cardano-static-lookup`). No overlapping open matcher-fix PR was found.

## Testing

- `Tests/FixedIssues/Issue245.lean` contains the minimal reproducer and five passing `#testOptimize` checks: indexed fallback, selected worker, symbolic fallback, and selected/rejected proof witnesses. Imported by the standard fixed-issue test module.
- The original reproducer failed on #244's `47c8364d` base; its reference equation is kernel checked with `simp`.
- `lake build Tests` passes, including the new regression. One repeat under concurrent compilation hit the existing 30-second Z3 timeout in `SmtNatMod`; the serial retry passed without changing the test or timeout.
- All 27 symbolic CEK integration controls pass, covering captured environments, shadowing, recognized and rejected loop templates, malformed data, and exact fuel boundaries. The experimental CEK integration is separate from this PR.
- `git diff --check` passes.

The observed bug was an invalid intermediate expression and optimizer exception; this report does not claim a demonstrated false `Valid` verdict.
