### PR TITLE
Lift two SellNFT recursive searches with certified Lean workers

### DIFF
--- a/Benchmarks/cardano/README.md
+++ b/Benchmarks/cardano/README.md
@@ -90,6 +90,11 @@ show that an accepting execution is covered by the bound.
 
 ## Experimental flags and evidence
 
+The [certified recursive-search adapter](overlays/lifted-search/README.md) adds
+`--lifted-search` to setup and measurement for the named CEK. It targets two
+SellNFT loops, preserves exact bounded semantics, and remains opt-in. It does
+not yet support Governance's recursion patterns or the indexed WSC interpreter.
+
 The [review](../../docs/reviews/cardano-preparation-2026-09-09.md) records the
 baseline and explains the rejected prototypes. Archived patches and focused
 tests are under `experiments/`. They are not part of Blaster's imported code.

--- a/Benchmarks/cardano/fixtures/LiftedTemplateSource.lean
+++ b/Benchmarks/cardano/fixtures/LiftedTemplateSource.lean
@@ -1,0 +1,33 @@
+import PlutusCore.UPLC
+open PlutusCore.UPLC.Term
+namespace LiftedTemplateSource
+set_option maxHeartbeats 0
+set_option maxRecDepth 10000
+
+#import_uplc sellNFT PlutusV2 single_cbor_hex "Tests/Scripts/SellNFT/sell_nft.flat"
+
+def child (t : Term) (i : Nat) : Option Term :=
+  match t, i with
+  | .Lam _ b, 0 | .Force b, 0 | .Delay b, 0 => some b
+  | .Apply f _, 0 => some f
+  | .Apply _ a, 1 => some a
+  | _, _ => none
+
+def atPath (path : List Nat) (t : Term) : Option Term :=
+  match path with
+  | [] => some t
+  | i :: rest => (child t i).bind (fun next => atPath rest next)
+
+-- These certificates check the actual decoded production script, independently
+-- of the diagnostic JSON export. They use neither native_decide nor axioms.
+theorem LiftedSearch_in_script :
+    (match sellNFT.script with | .Program _ body => atPath [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1] body) =
+      some PlutusCore.UPLC.LiftedSearch.originalSelf := by rfl
+#print axioms LiftedSearch_in_script
+
+theorem LiftedMapSearch_in_script :
+    (match sellNFT.script with | .Program _ body => atPath [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1] body) =
+      some PlutusCore.UPLC.LiftedMapSearch.originalSelf := by rfl
+#print axioms LiftedMapSearch_in_script
+
+end LiftedTemplateSource

--- a/Benchmarks/cardano/fixtures/LoopCekControl.lean
+++ b/Benchmarks/cardano/fixtures/LoopCekControl.lean
@@ -1,0 +1,246 @@
+import PlutusCore.UPLC
+import Tests.Benchmarks.OptimizeTestUtils
+
+open PlutusCore.UPLC.CekMachine PlutusCore.UPLC.CekValue
+open PlutusCore.UPLC.Builtins PlutusCore.UPLC.Term
+
+namespace CardanoLoopCekControl
+set_option maxHeartbeats 0
+
+-- These equations are kernel checked against the pinned interpreter. The
+-- optimization annotation changes only reduction order, never CEK fuel.
+theorem lookup_hit (s : Stack) (env : Environment) (x : String) (v : CekValue) :
+    ifBoundOtherwiseError s (.NonEmptyEnvironment env x v) x = .Return s v := by
+  simp [ifBoundOtherwiseError]
+
+theorem lookup_skip (s : Stack) (env : Environment) (x y : String)
+    (v : CekValue) (h : x ≠ y) :
+    ifBoundOtherwiseError s (.NonEmptyEnvironment env y v) x =
+      ifBoundOtherwiseError s env x := by
+  simp [ifBoundOtherwiseError, h]
+
+theorem static_access (s : Stack) (env : Environment) (v discarded : CekValue) :
+    ifBoundOtherwiseError s
+      (.NonEmptyEnvironment (.NonEmptyEnvironment env "x" v) "unused" discarded)
+      "x" = .Return s v := by
+  simp [ifBoundOtherwiseError]
+
+theorem variable_fuel_one (sv : PlutusCore.Default.BuiltinSemanticsVariant) (v : CekValue) :
+    runSteps sv (.Eval [] (.NonEmptyEnvironment .EmptyEnvironment "x" v) (.Var "x")) 1 =
+      .Error := by
+  simp [runSteps, step, ifBoundOtherwiseError]
+
+theorem variable_fuel_two (sv : PlutusCore.Default.BuiltinSemanticsVariant) (v : CekValue) :
+    runSteps sv (.Eval [] (.NonEmptyEnvironment .EmptyEnvironment "x" v) (.Var "x")) 2 =
+      .Halt v := by
+  simp [runSteps, step, ifBoundOtherwiseError]
+
+attribute [local blaster_specialize 2] PlutusCore.UPLC.LoopCek.eval PlutusCore.UPLC.LoopCek.ret
+attribute [local blaster_specialize 1] PlutusCore.UPLC.LoopCek.lookupValue
+
+open PlutusCore.UPLC
+attribute [local blaster_specialize 1] StagedCek.lookupValue
+attribute [local blaster_specialize 2] LiftedSearch.recognizeCall
+attribute [local blaster_specialize 1] LiftedSearch.bodyWitness LiftedSearch.readyWitness LiftedSearch.bindingsWitness LiftedSearch.scan
+attribute [local blaster_specialize 3] LiftedSearch.worker
+attribute [local blaster_specialize 2] LiftedSearch.recognizeFast
+attribute [local blaster_specialize 1] LiftedSearch.bodyMatches LiftedSearch.readyMatch LiftedSearch.bindingsMatch
+attribute [local blaster_specialize 2] RecursiveCalls.recognize LiftedMapSearch.recognizeFast
+attribute [local blaster_specialize 1] LiftedMapSearch.bodyWitness LiftedMapSearch.bodyMatches LiftedMapSearch.readyMatch LiftedMapSearch.bindingsMatch LiftedMapSearch.scan
+attribute [local blaster_specialize 3] LiftedMapSearch.worker
+
+#testOptimize ["LoopCekShadowing"]
+  (fun v discarded : CekValue =>
+    PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+      (.Eval [] (.NonEmptyEnvironment (.NonEmptyEnvironment .EmptyEnvironment "x" discarded) "x" v)
+        (.Var "x")) 2) ===>
+  (fun v _ : CekValue => State.Halt v)
+
+#testOptimize ["LoopCekMissingName"]
+  (fun v : CekValue => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Eval [] (.NonEmptyEnvironment .EmptyEnvironment "other" v) (.Var "x")) 2) ===>
+  (fun _ : CekValue => State.Error)
+
+#testOptimize ["LoopCekLookupFuel"]
+  (fun v : CekValue => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Eval [] (.NonEmptyEnvironment .EmptyEnvironment "x" v) (.Var "x")) 1) ===>
+  (fun _ : CekValue => State.Error)
+
+#testOptimize ["LoopCekCapturedEnvironment"]
+  (fun v other : CekValue => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.RightApplicationOfValue
+      (.VLam "argument" (.Var "captured") (.NonEmptyEnvironment .EmptyEnvironment "captured" v))]
+      other) 3) ===>
+  (fun v _ : CekValue => State.Halt v)
+
+#testOptimize ["LoopCekHaltAtZeroFuel"]
+  (fun v : CekValue => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA (.Halt v) 0) ===>
+  (fun v : CekValue => State.Halt v)
+
+#testOptimize ["LoopCekErrorAtZeroFuel"]
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA .Error 0) ===> State.Error
+
+#testOptimize ["LoopCekApplyNonFunction"]
+  (fun c : Const => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.RightApplicationOfValue (.VCon c)] (.VCon .Unit)) 3) ===>
+  (fun _ : Const => State.Error)
+
+#testOptimize ["LoopCekWrongForceTag"]
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.ForceFrame] (.VBuiltin .AddInteger [] (.One .ArgV))) 3) ===>
+  State.Error
+
+#testOptimize ["LoopCekConstructor"] (norm-result: 1)
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Eval [] .EmptyEnvironment (.Constr 0 [])) 2) ===>
+  State.Halt (.VConstr 0 [])
+
+#testOptimize ["LoopCekApplication"]
+  (fun c : Const => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Eval [] .EmptyEnvironment (.Apply (.Lam "x" (.Var "x")) (.Const c))) 7) ===>
+  (fun c : Const => State.Halt (.VCon c))
+
+#testOptimize ["LoopCekApplicationExhaustion"]
+  (fun c : Const => PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Eval [] .EmptyEnvironment (.Apply (.Lam "x" (.Var "x")) (.Const c))) 6) ===>
+  (fun _ : Const => State.Error)
+
+#testOptimize ["LoopCekConstructorFieldOrder"] (norm-result: 1)
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.ConstructorArgument 0 [.VCon (.Integer 1)] [] .EmptyEnvironment] (.VCon (.Integer 2))) 2) ===>
+  State.Halt (.VConstr 0 [.VCon (.Integer 1), .VCon (.Integer 2)])
+
+#testOptimize ["LoopCekCaseApplicationOrder"] (norm-result: 1)
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Eval [] .EmptyEnvironment (.Case (.Constr 0 [.Const (.Integer 7), .Const (.Integer 9)])
+      [.Lam "a" (.Lam "b" (.Var "a"))])) 20) ===>
+  State.Halt (.VCon (.Integer 7))
+
+#testOptimize ["LoopCekCaseOutOfBounds"]
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.CaseScrutinee [.Const .Unit] .EmptyEnvironment] (.VConstr 1 [])) 4) ===> State.Error
+
+#testOptimize ["LoopCekPrimitiveCase"]
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.CaseScrutinee [.Const .Unit] .EmptyEnvironment] (.VCon (.Bool false))) 3) ===>
+  State.Halt (.VCon .Unit)
+
+#testOptimize ["LoopCekPrimitiveCaseArity"]
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.CaseScrutinee [.Const .Unit] .EmptyEnvironment] (.VCon (.Bool true))) 3) ===> State.Error
+
+#testOptimize ["LoopCekNegativeCaseIndex"]
+  (PlutusCore.UPLC.LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.CaseScrutinee [.Const .Unit] .EmptyEnvironment] (.VCon (.Integer (-1)))) 3) ===> State.Error
+
+open PlutusCore.UPLC
+
+def base : Environment :=
+  let e := Environment.EmptyEnvironment
+  let e := Environment.NonEmptyEnvironment e "dbi_0" (.VBuiltin .TailList [] (.One .ArgV))
+  let e := Environment.NonEmptyEnvironment e "dbi_1" (.VBuiltin .HeadList [] (.One .ArgV))
+  let e := Environment.NonEmptyEnvironment e "dbi_2" (.VBuiltin .MkCons [] (.More .ArgV (.One .ArgV)))
+  let e := Environment.NonEmptyEnvironment e "dbi_3" (.VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV))))
+  let e := Environment.NonEmptyEnvironment e "dbi_4" (.VBuiltin .SndPair [] (.One .ArgV))
+  let e := Environment.NonEmptyEnvironment e "dbi_5" (.VBuiltin .FstPair [] (.One .ArgV))
+  Environment.NonEmptyEnvironment e "dbi_6" (.VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV))))
+
+def call (captured : Environment) (xs : List (PlutusCore.Data.Data × PlutusCore.Data.Data)) : State :=
+  .Return [Frame.RightApplicationOfValue
+    (.VLam "dbi_23" LiftedSearch.originalBody (LiftedSearch.recurEnv captured))] (.VCon (.ConstPairDataList xs))
+
+#testOptimize ["LoopCekRecognizesUnusedCapture"]
+  (fun unused : CekValue => (LiftedSearch.readyWitness
+    (LiftedSearch.recurEnv (.NonEmptyEnvironment base "unused" unused))).isSome) ===>
+  (fun _ : CekValue => true)
+
+#testOptimize ["LoopCekRejectsShadowedBuiltin"]
+  (LiftedSearch.readyWitness (.NonEmptyEnvironment (LiftedSearch.recurEnv base) "dbi_0" (.VCon .Unit))).isSome ===> false
+
+#testOptimize ["LoopCekLiftedHit"] (norm-result: 1)
+  (fun i : Int => LoopCek.run .defaultFunSemanticsVariantA (call base [(.B {data := ""}, .I i)]) 105) ===>
+  (fun i : Int => State.Halt (.VCon (.Data (.Constr 0 [.I i]))))
+
+#testOptimize ["LoopCekLiftedHitFuel"]
+  (fun i : Int => LoopCek.run .defaultFunSemanticsVariantA (call base [(.B {data := ""}, .I i)]) 104) ===>
+  (fun _ : Int => State.Error)
+
+#testOptimize ["LoopCekLiftedRecursion"] (norm-result: 1)
+  (fun i : Int => LoopCek.run .defaultFunSemanticsVariantA
+    (call base [(.B {data := "x"}, .I 0), (.B {data := ""}, .I i)]) 197) ===>
+  (fun i : Int => State.Halt (.VCon (.Data (.Constr 0 [.I i]))))
+
+#testOptimize ["LoopCekLiftedRecursiveFuel"]
+  (fun i : Int => LoopCek.run .defaultFunSemanticsVariantA
+    (call base [(.B {data := "x"}, .I 0), (.B {data := ""}, .I i)]) 196) ===>
+  (fun _ : Int => State.Error)
+
+#testOptimize ["LoopCekLiftedMalformedUnmatchedPayload"]
+  (LoopCek.run .defaultFunSemanticsVariantA
+    (call base [(.B {data := "x"}, .List []), (.B {data := ""}, .I 42)]) 1000) ===> State.Error
+
+#testOptimize ["LoopCekFallbackPreservesUnusedBadBinding"] (norm-result: 1)
+  (LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.RightApplicationOfValue (.VLam "dbi_23" LiftedSearch.originalBody
+      (.NonEmptyEnvironment (LiftedSearch.recurEnv base) "dbi_0" (.VCon .Unit)))] (.VCon (.ConstPairDataList []))) 18) ===>
+  State.Halt (.VCon (.Data (.Constr 1 [])))
+
+def changedBody : Term := (.Force (.Apply (.Apply (.Apply (.Var "dbi_3") (.Var "dbi_23")) (.Delay (.Const (.Data (.Constr 1 []))))) (.Delay (.Apply (.Lam "dbi_24" (.Apply (.Lam "dbi_25" (.Apply (.Lam "dbi_26" (.Apply (.Lam "dbi_27" (.Force (.Apply (.Apply (.Apply (.Var "dbi_6") (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString) (.Const (.ByteString { data := "x" }))) (.Var "dbi_26"))) (.Delay (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.ConstrData) (.Const (.Integer 0))) (.Apply (.Apply (.Var "dbi_2") (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.IData) (.Var "dbi_27"))) (.Const (.ConstDataList [])))))) (.Delay (.Apply (.Apply (.Var "dbi_22") (.Var "dbi_22")) (.Var "dbi_25")))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnIData) (.Apply (.Var "dbi_4") (.Var "dbi_24"))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnBData) (.Apply (.Var "dbi_5") (.Var "dbi_24"))))) (.Apply (.Var "dbi_0") (.Var "dbi_23")))) (.Apply (.Var "dbi_1") (.Var "dbi_23"))))))
+
+#testOptimize ["LoopCekRejectsDifferentKeyTemplate"]
+  (LiftedSearch.bodyWitness changedBody).isSome ===> false
+
+#testOptimize ["LoopCekFallbackUsesChangedKey"] (norm-result: 1)
+  (fun i : Int => LoopCek.run .defaultFunSemanticsVariantA
+    (.Return [Frame.RightApplicationOfValue (.VLam "dbi_23" changedBody (LiftedSearch.recurEnv base))]
+      (.VCon (.ConstPairDataList [(.B {data := "x"}, .I i)]))) 105) ===>
+  (fun i : Int => State.Halt (.VCon (.Data (.Constr 0 [.I i]))))
+
+
+def mapCall (captured : Environment) (xs : List (PlutusCore.Data.Data × PlutusCore.Data.Data)) : State :=
+  .Return [Frame.RightApplicationOfValue
+    (.VLam "dbi_20" LiftedMapSearch.originalBody (LiftedMapSearch.recurEnv captured))] (.VCon (.ConstPairDataList xs))
+
+#testOptimize ["LoopCekMapRecognizesUnusedCapture"]
+  (fun unused : CekValue => LiftedMapSearch.readyMatch
+    (LiftedMapSearch.recurEnv (.NonEmptyEnvironment base "unused" unused))) ===>
+  (fun _ : CekValue => true)
+
+#testOptimize ["LoopCekMapRejectsShadowedBuiltin"]
+  LiftedMapSearch.readyMatch (.NonEmptyEnvironment (LiftedMapSearch.recurEnv base) "dbi_0" (.VCon .Unit)) ===> false
+
+#testOptimize ["LoopCekMapHit"] (norm-result: 1)
+  (fun payload : List (PlutusCore.Data.Data × PlutusCore.Data.Data) =>
+    LoopCek.run .defaultFunSemanticsVariantA (mapCall base [(.B {data := ""}, .Map payload)]) 105) ===>
+  (fun payload : List (PlutusCore.Data.Data × PlutusCore.Data.Data) => State.Halt (.VCon (.Data (.Constr 0 [.Map payload]))))
+
+#testOptimize ["LoopCekMapHitFuel"]
+  (fun payload : List (PlutusCore.Data.Data × PlutusCore.Data.Data) =>
+    LoopCek.run .defaultFunSemanticsVariantA (mapCall base [(.B {data := ""}, .Map payload)]) 104) ===>
+  (fun _ : List (PlutusCore.Data.Data × PlutusCore.Data.Data) => State.Error)
+
+#testOptimize ["LoopCekMapRecursion"] (norm-result: 1)
+  (fun payload : List (PlutusCore.Data.Data × PlutusCore.Data.Data) => LoopCek.run .defaultFunSemanticsVariantA
+    (mapCall base [(.B {data := "x"}, .Map []), (.B {data := ""}, .Map payload)]) 197) ===>
+  (fun payload : List (PlutusCore.Data.Data × PlutusCore.Data.Data) => State.Halt (.VCon (.Data (.Constr 0 [.Map payload]))))
+
+#testOptimize ["LoopCekMapRecursiveFuel"]
+  (fun payload : List (PlutusCore.Data.Data × PlutusCore.Data.Data) => LoopCek.run .defaultFunSemanticsVariantA
+    (mapCall base [(.B {data := "x"}, .Map []), (.B {data := ""}, .Map payload)]) 196) ===>
+  (fun _ : List (PlutusCore.Data.Data × PlutusCore.Data.Data) => State.Error)
+
+#testOptimize ["LoopCekMapMalformedUnmatchedPayload"]
+  (LoopCek.run .defaultFunSemanticsVariantA
+    (mapCall base [(.B {data := "x"}, .I 0), (.B {data := ""}, .Map [])]) 1000) ===> State.Error
+
+#testOptimize ["LoopCekMapMalformedKey"]
+  (LoopCek.run .defaultFunSemanticsVariantA (mapCall base [(.I 0, .Map [])]) 1000) ===> State.Error
+
+#testOptimize ["LoopCekMapEmpty"] (norm-result: 1)
+  (LoopCek.run .defaultFunSemanticsVariantA (mapCall base []) 18) ===>
+  State.Halt (.VCon (.Data (.Constr 1 [])))
+
+#testOptimize ["LoopCekMapEmptyFuel"]
+  (LoopCek.run .defaultFunSemanticsVariantA (mapCall base []) 17) ===> State.Error
+
+end CardanoLoopCekControl

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/CekBlocks.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/CekBlocks.lean
@@ -1,0 +1,65 @@
+import PlutusCore.UPLC.StagedCekProofs
+open PlutusCore.UPLC.CekMachine PlutusCore.UPLC.CekValue
+open PlutusCore.Default
+namespace PlutusCore.UPLC.CekBlocks
+
+/-- Run a finite block while preserving terminal states and the final live state. -/
+def advance (sv : BuiltinSemanticsVariant) (n : Nat) (st : State) : State :=
+  match n, st with
+  | 0, _ => st
+  | _, .Halt _ | _, .Error => st
+  | n+1, _ => advance sv n (step sv st)
+
+theorem compose (sv : BuiltinSemanticsVariant) (n : Nat) (st : State) (fuel : Nat) :
+    runSteps sv st (n+fuel) = runSteps sv (advance sv n st) fuel := by
+  induction n generalizing st with
+  | zero => simp [advance]
+  | succ n ih =>
+    cases st <;> simp only [advance, Nat.succ_add, runSteps]
+    all_goals first | rfl | exact ih _
+
+theorem run_terminal (sv : BuiltinSemanticsVariant) (n : Nat) (st : State) :
+    runSteps sv st n = .Error ∨ ∃ v, runSteps sv st n = .Halt v := by
+  induction n generalizing st with
+  | zero => cases st <;> simp [runSteps]
+  | succ n ih =>
+    cases st <;> simp only [runSteps]
+    all_goals first | simp | exact ih _
+
+theorem extend_halt (sv : BuiltinSemanticsVariant) (n : Nat) (st : State)
+    (v : CekValue) (h : runSteps sv st n = .Halt v) (extra : Nat) :
+    runSteps sv st (n+extra) = .Halt v := by
+  induction n generalizing st with
+  | zero => cases st <;> simp_all [runSteps]
+  | succ n ih =>
+    cases st <;> simp_all only [Nat.succ_add, runSteps]
+    all_goals first | rfl | exact ih _ h
+
+theorem shorter_error (sv : BuiltinSemanticsVariant) (n : Nat) (st : State)
+    (h : runSteps sv st n = .Error) (fuel : Nat) (le : fuel ≤ n) :
+    runSteps sv st fuel = .Error := by
+  rcases run_terminal sv fuel st with done | ⟨v,hv⟩
+  · exact done
+  · have extended := extend_halt sv fuel st v hv (n-fuel)
+    rw [Nat.add_sub_of_le le, h] at extended
+    cases extended
+
+theorem shortcut (sv : BuiltinSemanticsVariant) (n : Nat) (st next : State)
+    (h : advance sv n st = next) (live : runSteps sv next 0 = .Error) (fuel : Nat) :
+    runSteps sv st fuel = if n ≤ fuel then runSteps sv next (fuel-n) else .Error := by
+  by_cases enough : n ≤ fuel
+  · simp only [enough, if_true]
+    have eq := compose sv n st (fuel-n)
+    simpa only [Nat.add_sub_of_le enough, h] using eq
+  · simp only [enough, if_false]
+    apply shorter_error sv n st _ fuel (by omega)
+    have eq := compose sv n st 0
+    simpa only [Nat.add_zero, h, live] using eq
+
+theorem block_error (sv : BuiltinSemanticsVariant) (n : Nat) (st : State)
+    (h : advance sv n st = .Error) (fuel : Nat) : runSteps sv st fuel = .Error := by
+  simpa only [runSteps, ite_self] using shortcut sv n st .Error h rfl fuel
+
+#print axioms compose
+#print axioms shorter_error
+end PlutusCore.UPLC.CekBlocks

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearch.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearch.lean
@@ -1,0 +1,79 @@
+import PlutusCore.UPLC.CekBlocks
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data PlutusCore.Default
+namespace PlutusCore.UPLC.LiftedMapSearch
+set_option maxHeartbeats 0
+set_option maxRecDepth 10000
+
+def originalBody : Term := (.Force (.Apply (.Apply (.Apply (.Var "dbi_3") (.Var "dbi_20")) (.Delay (.Const (.Data (.Constr 1 []))))) (.Delay (.Apply (.Lam "dbi_21" (.Apply (.Lam "dbi_22" (.Apply (.Lam "dbi_23" (.Apply (.Lam "dbi_24" (.Force (.Apply (.Apply (.Apply (.Var "dbi_6") (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString) (.Const (.ByteString { data := "" }))) (.Var "dbi_23"))) (.Delay (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.ConstrData) (.Const (.Integer 0))) (.Apply (.Apply (.Var "dbi_2") (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.MapData) (.Var "dbi_24"))) (.Const (.ConstDataList [])))))) (.Delay (.Apply (.Apply (.Var "dbi_19") (.Var "dbi_19")) (.Var "dbi_22")))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnMapData) (.Apply (.Var "dbi_4") (.Var "dbi_21"))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnBData) (.Apply (.Var "dbi_5") (.Var "dbi_21"))))) (.Apply (.Var "dbi_0") (.Var "dbi_20")))) (.Apply (.Var "dbi_1") (.Var "dbi_20"))))))
+def originalSelf : Term := .Lam "dbi_19" (.Lam "dbi_20" originalBody)
+def v0 : CekValue := .VBuiltin .TailList [] (.One .ArgV)
+def v1 : CekValue := .VBuiltin .HeadList [] (.One .ArgV)
+def v2 : CekValue := .VBuiltin .MkCons [] (.More .ArgV (.One .ArgV))
+def v3 : CekValue := .VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV)))
+def v4 : CekValue := .VBuiltin .SndPair [] (.One .ArgV)
+def v5 : CekValue := .VBuiltin .FstPair [] (.One .ArgV)
+def v6 : CekValue := .VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV)))
+
+structure Valid (env : Environment) : Prop where
+  bound0 : ∀ s, ifBoundOtherwiseError s env "dbi_0" = .Return s v0
+  bound1 : ∀ s, ifBoundOtherwiseError s env "dbi_1" = .Return s v1
+  bound2 : ∀ s, ifBoundOtherwiseError s env "dbi_2" = .Return s v2
+  bound3 : ∀ s, ifBoundOtherwiseError s env "dbi_3" = .Return s v3
+  bound4 : ∀ s, ifBoundOtherwiseError s env "dbi_4" = .Return s v4
+  bound5 : ∀ s, ifBoundOtherwiseError s env "dbi_5" = .Return s v5
+  bound6 : ∀ s, ifBoundOtherwiseError s env "dbi_6" = .Return s v6
+
+structure Ready (env : Environment) where
+  captured : Environment
+  currentValid : Valid env
+  capturedValid : Valid captured
+  recursiveBinding : ∀ s, ifBoundOtherwiseError s env "dbi_19" =
+    .Return s (.VLam "dbi_19" (.Lam "dbi_20" originalBody) captured)
+
+def recurEnv (captured : Environment) : Environment :=
+  .NonEmptyEnvironment captured "dbi_19" (.VLam "dbi_19" (.Lam "dbi_20" originalBody) captured)
+
+def recurReady (captured : Environment) (valid : Valid captured) : Ready (recurEnv captured) where
+  captured := captured
+  capturedValid := valid
+  currentValid := by
+    constructor
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound0]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound1]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound2]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound3]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound4]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound5]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound6]
+  recursiveBinding := by intro s; simp [recurEnv, ifBoundOtherwiseError]
+
+def entry (env : Environment) (s : Stack) (xs : List (Data × Data)) : State :=
+  .Eval s (.NonEmptyEnvironment env "dbi_20" (.VCon (.ConstPairDataList xs))) originalBody
+
+/-- Consume the entire search, returning the original remaining CEK fuel. -/
+def scan (fuel : Nat) (xs : List (Data × Data)) : Option (Nat × Data) :=
+  match xs with
+  | [] => if 16 ≤ fuel then some (fuel-16, .Constr 1 []) else none
+  | (.B b, .Map i) :: tail =>
+    if "" == b.data then
+      if 103 ≤ fuel then some (fuel-103, .Constr 0 [.Map i]) else none
+    else
+      if 92 ≤ fuel then scan (fuel-92) tail else none
+  | _ => none
+termination_by xs.length
+
+theorem scan_fuel_lt (xs : List (Data × Data)) (fuel remaining : Nat) (result : Data)
+    (h : scan fuel xs = some (remaining,result)) : remaining < fuel := by
+  induction xs generalizing fuel with
+  | nil => simp only [scan] at h; split at h <;> simp_all; omega
+  | cons pair tail ih =>
+    rcases pair with ⟨key,value⟩
+    cases key <;> cases value <;> simp only [scan] at h <;> try contradiction
+    split at h
+    · split at h <;> simp_all; omega
+    · split at h
+      · have lt := ih _ h; omega
+      · contradiction
+
+end PlutusCore.UPLC.LiftedMapSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearchFastRecognize.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearchFastRecognize.lean
@@ -1,0 +1,92 @@
+import PlutusCore.UPLC.LiftedMapSearchRecognize
+import PlutusCore.UPLC.LiftedSearchFastRecognize
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data
+namespace PlutusCore.UPLC.LiftedMapSearch
+set_option maxRecDepth 10000
+set_option maxHeartbeats 0
+
+/-! Runtime recognition uses ordinary booleans and a nonindexed worker record.
+The correspondence with the proof-carrying recognizer is established below,
+so preparation need not normalize types indexed by the full closure environment. -/
+
+def bodyMatches (t : Term) : Bool := (bodyWitness t).isSome
+
+theorem bodyMatches_eq (t : Term) : bodyMatches t = (bodyWitness t).isSome := rfl
+
+def bindingsMatch (env : Environment) : Bool :=
+  match StagedCek.lookupValue env "dbi_0" with
+  | some (.VBuiltin .TailList [] (.One .ArgV)) =>
+    match StagedCek.lookupValue env "dbi_1" with
+    | some (.VBuiltin .HeadList [] (.One .ArgV)) =>
+      match StagedCek.lookupValue env "dbi_2" with
+      | some (.VBuiltin .MkCons [] (.More .ArgV (.One .ArgV))) =>
+        match StagedCek.lookupValue env "dbi_3" with
+        | some (.VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV)))) =>
+          match StagedCek.lookupValue env "dbi_4" with
+          | some (.VBuiltin .SndPair [] (.One .ArgV)) =>
+            match StagedCek.lookupValue env "dbi_5" with
+            | some (.VBuiltin .FstPair [] (.One .ArgV)) =>
+              match StagedCek.lookupValue env "dbi_6" with
+              | some (.VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV)))) => true
+              | _ => false
+            | _ => false
+          | _ => false
+        | _ => false
+      | _ => false
+    | _ => false
+  | _ => false
+
+theorem bindingsMatch_eq (env : Environment) : bindingsMatch env = (bindingsWitness env).isSome := by
+  unfold bindingsMatch bindingsWitness
+  repeat' first | rfl | (solve | simp_all) | (split <;> try simp_all)
+
+def readyMatch (env : Environment) : Bool :=
+  match StagedCek.lookupValue env "dbi_19" with
+  | some (.VLam "dbi_19" (.Lam "dbi_20" body) captured) =>
+      bodyMatches body && bindingsMatch env && bindingsMatch captured
+  | _ => false
+
+theorem readyMatch_eq (env : Environment) : readyMatch env = (readyWitness env).isSome := by
+  unfold readyMatch readyWitness
+  simp only [bodyMatches_eq, bindingsMatch_eq]
+  repeat' first | rfl | (solve | simp_all) | (split <;> try simp_all)
+  all_goals
+    obtain ⟨rfl, rfl⟩ := ‹_ = _ ∧ _ = _›
+    simp_all [Option.isSome_iff_exists]
+  all_goals
+    intro b hb c hc
+    apply Option.eq_none_iff_forall_ne_some.mpr
+    intro d hd
+    solve_by_elim
+
+abbrev CallPlan := LiftedSearch.CallPlan
+
+def recognizeFast (binder : String) (body : Term) (env : Environment) (arg : CekValue) : Option CallPlan :=
+  match binder, arg with
+  | "dbi_20", .VCon (.ConstPairDataList xs) =>
+      if bodyMatches body && readyMatch env then some ⟨worker xs⟩ else none
+  | _, _ => none
+
+theorem recognizeFast_eq (binder : String) (body : Term) (env : Environment) (arg : CekValue) :
+    recognizeFast binder body env arg =
+      (recognizeCall binder body env arg).map (fun p => LiftedSearch.CallPlan.mk p.worker) := by
+  unfold recognizeFast recognizeCall
+  split
+  · simp only [bodyMatches_eq, readyMatch_eq]
+    cases bodyWitness body <;> cases readyWitness env <;> rfl
+  · split <;> simp_all
+
+theorem recognizeFast_sound (binder : String) (body : Term) (env : Environment) (arg : CekValue)
+    (plan : CallPlan) (h : recognizeFast binder body env arg = some plan) :
+    ∃ cert : SpecializedCall binder body env arg, cert.worker = plan.worker := by
+  rw [recognizeFast_eq] at h
+  cases hc : recognizeCall binder body env arg with
+  | none => simp [hc] at h
+  | some cert =>
+      simp only [hc, Option.map_some, Option.some.injEq] at h
+      cases h
+      exact ⟨cert, rfl⟩
+
+#print axioms recognizeFast_sound
+end PlutusCore.UPLC.LiftedMapSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearchProofs.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearchProofs.lean
@@ -1,0 +1,127 @@
+import PlutusCore.UPLC.LiftedMapSearch
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data PlutusCore.Default
+namespace PlutusCore.UPLC.LiftedMapSearch
+open CekBlocks
+set_option maxHeartbeats 0
+set_option maxRecDepth 10000
+
+theorem empty_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env) (s : Stack) :
+    advance sv 16 (entry env s []) = .Return s (.VCon (.Data (.Constr 1 []))) := by
+  simp [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList,                                 v3, ready.currentValid.bound3]
+
+theorem hit_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (i : List (Data × Data)) (tail : List (Data × Data)) :
+    advance sv 103 (entry env s ((.B { data := "" }, .Map i) :: tail)) =
+      .Return s (.VCon (.Data (.Constr 0 [.Map i]))) := by
+  simp [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair, BuiltinFunctions.Pair.sndPair,
+    BuiltinFunctions.Data.unBData, BuiltinFunctions.Data.unMapData,
+    BuiltinFunctions.ByteString.equalsByteString, BuiltinFunctions.Bool.ifThenElse,
+    BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData, PlutusCore.Data.unMapData,
+    PlutusCore.ByteString.equalsByteString, PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString,
+    PlutusCore.Bool.ifThenElse, PlutusCore.Pair.fstPair, PlutusCore.Pair.sndPair,
+    Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v2, ready.currentValid.bound2, v3, ready.currentValid.bound3, v4, ready.currentValid.bound4, v5, ready.currentValid.bound5, v6, ready.currentValid.bound6, BuiltinFunctions.Data.constrData, BuiltinFunctions.Data.mapData,
+    BuiltinFunctions.List.mkCons, PlutusCore.Data.constrData, PlutusCore.Data.mapData, PlutusCore.List.mkCons]
+
+theorem miss_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (b : PlutusCore.ByteString.ByteString) (i : List (Data × Data)) (tail : List (Data × Data))
+    (h : ("" == b.data) = false) :
+    advance sv 92 (entry env s ((.B b, .Map i) :: tail)) = entry (recurEnv ready.captured) s tail := by
+  simp [advance, entry, recurEnv, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair, BuiltinFunctions.Pair.sndPair,
+    BuiltinFunctions.Data.unBData, BuiltinFunctions.Data.unMapData,
+    BuiltinFunctions.ByteString.equalsByteString, BuiltinFunctions.Bool.ifThenElse,
+    BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData, PlutusCore.Data.unMapData,
+    PlutusCore.ByteString.equalsByteString, PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString,
+    PlutusCore.Bool.ifThenElse, PlutusCore.Pair.fstPair, PlutusCore.Pair.sndPair,
+    Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v3, ready.currentValid.bound3, v4, ready.currentValid.bound4, v5, ready.currentValid.bound5, v6, ready.currentValid.bound6, ready.recursiveBinding, h]
+
+theorem invalid_key_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (key value : Data) (tail : List (Data × Data)) (h : ∀ b, key ≠ Data.B b) :
+    advance sv 45 (entry env s ((key,value) :: tail)) = .Error := by
+  cases key
+  all_goals try simp_all [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair,     BuiltinFunctions.Data.unBData,         BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData,         PlutusCore.Pair.fstPair,     Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v3, ready.currentValid.bound3, v5, ready.currentValid.bound5]
+
+theorem invalid_value_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (b : PlutusCore.ByteString.ByteString) (value : Data)
+    (tail : List (Data × Data)) (h : ∀ i, value ≠ Data.Map i) :
+    advance sv 58 (entry env s ((.B b,value) :: tail)) = .Error := by
+  cases value
+  all_goals try simp_all [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair, BuiltinFunctions.Pair.sndPair,
+    BuiltinFunctions.Data.unBData, BuiltinFunctions.Data.unMapData,
+        BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData, PlutusCore.Data.unMapData,
+        PlutusCore.Pair.fstPair, PlutusCore.Pair.sndPair,
+    Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v3, ready.currentValid.bound3, v4, ready.currentValid.bound4, v5, ready.currentValid.bound5]
+
+def finish (sv : BuiltinSemanticsVariant) (s : Stack) (result : Option (Nat × Data)) : State :=
+  match result with
+  | none => .Error
+  | some (remaining,d) => runSteps sv (.Return s (.VCon (.Data d))) remaining
+
+/-- The whole loop is independent of irrelevant captured bindings, provided the
+checked builtin and self bindings hold in the current and recursive environments. -/
+theorem scan_correct (sv : BuiltinSemanticsVariant) (xs : List (Data × Data))
+    (env : Environment) (ready : Ready env) (fuel : Nat) (s : Stack) :
+    finish sv s (scan fuel xs) = runSteps sv (entry env s xs) fuel := by
+  induction xs generalizing env fuel with
+  | nil =>
+    rw [shortcut sv 16 _ _ (empty_block sv env ready s) rfl]
+    simp only [scan]
+    split <;> simp_all [finish]
+  | cons pair tail ih =>
+    rcases pair with ⟨key,value⟩
+    cases key <;> try {
+      simp only [scan, finish]
+      symm
+      apply block_error sv 45
+      apply invalid_key_block sv env ready
+      intro b; simp }
+    case B b =>
+      cases value <;> try {
+        simp only [scan, finish]
+        symm
+        apply block_error sv 58
+        apply invalid_value_block sv env ready
+        intro i; simp }
+      case Map i =>
+        by_cases eq : ("" == b.data) = true
+        · have beq : b = { data := "" } := by cases b; simp_all
+          subst b
+          rw [shortcut sv 103 _ _ (hit_block sv env ready s i tail) rfl]
+          simp only [scan, beq_self_eq_true, if_true]
+          split <;> simp_all [finish]
+        · have neq : ("" == b.data) = false := by simpa using eq
+          rw [shortcut sv 92 _ _ (miss_block sv env ready s b i tail neq) rfl]
+          simp only [scan, neq, Bool.false_eq_true, if_false]
+          split
+          · exact ih _ (recurReady _ ready.capturedValid) _
+          · rfl
+
+#print axioms scan_correct
+
+#print axioms empty_block
+#print axioms hit_block
+#print axioms miss_block
+end PlutusCore.UPLC.LiftedMapSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearchRecognize.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedMapSearchRecognize.lean
@@ -1,0 +1,121 @@
+import PlutusCore.UPLC.LiftedMapSearchProofs
+import PlutusCore.UPLC.SpecializedCall
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data
+namespace PlutusCore.UPLC.LiftedMapSearch
+set_option maxRecDepth 10000
+set_option maxHeartbeats 0
+
+/-- Recognize this exact template and retain a kernel-checked equality witness.
+The prototype deliberately falls back for other alpha-renamings. -/
+def bodyWitness (t : Term) : Option (PLift (t = originalBody)) :=
+  match t with
+  | (.Force (.Apply (.Apply (.Apply (.Var "dbi_3") (.Var "dbi_20")) (.Delay (.Const (.Data (.Constr 1 []))))) (.Delay (.Apply (.Lam "dbi_21" (.Apply (.Lam "dbi_22" (.Apply (.Lam "dbi_23" (.Apply (.Lam "dbi_24" (.Force (.Apply (.Apply (.Apply (.Var "dbi_6") (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString) (.Const (.ByteString { data := "" }))) (.Var "dbi_23"))) (.Delay (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.ConstrData) (.Const (.Integer 0))) (.Apply (.Apply (.Var "dbi_2") (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.MapData) (.Var "dbi_24"))) (.Const (.ConstDataList [])))))) (.Delay (.Apply (.Apply (.Var "dbi_19") (.Var "dbi_19")) (.Var "dbi_22")))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnMapData) (.Apply (.Var "dbi_4") (.Var "dbi_21"))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnBData) (.Apply (.Var "dbi_5") (.Var "dbi_21"))))) (.Apply (.Var "dbi_0") (.Var "dbi_20")))) (.Apply (.Var "dbi_1") (.Var "dbi_20")))))) => some ⟨rfl⟩
+  | _ => none
+
+theorem lookup_step (env : Environment) (x : String) (v : CekValue)
+    (h : StagedCek.lookupValue env x = some v) (s : Stack) :
+    ifBoundOtherwiseError s env x = .Return s v := by
+  cases env with
+  | EmptyEnvironment => simp [StagedCek.lookupValue] at h
+  | NonEmptyEnvironment rest y value =>
+      by_cases eq : x = y
+      · simpa [StagedCek.lookupValue, ifBoundOtherwiseError, eq] using h
+      · simp only [StagedCek.lookupValue, eq, if_false] at h
+        simpa only [ifBoundOtherwiseError, eq, if_false] using lookup_step rest x v h s
+termination_by sizeOf env
+
+/-- Certificates are proof-only; unused captured environments are not copied into
+runtime scan results. Each lookup obeys the original shadowing rules. -/
+def bindingsWitness (env : Environment) : Option (PLift (Valid env)) :=
+  match h0 : StagedCek.lookupValue env "dbi_0" with
+  | some (.VBuiltin .TailList [] (.One .ArgV)) =>
+    match h1 : StagedCek.lookupValue env "dbi_1" with
+    | some (.VBuiltin .HeadList [] (.One .ArgV)) =>
+      match h2 : StagedCek.lookupValue env "dbi_2" with
+      | some (.VBuiltin .MkCons [] (.More .ArgV (.One .ArgV))) =>
+        match h3 : StagedCek.lookupValue env "dbi_3" with
+        | some (.VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV)))) =>
+          match h4 : StagedCek.lookupValue env "dbi_4" with
+          | some (.VBuiltin .SndPair [] (.One .ArgV)) =>
+            match h5 : StagedCek.lookupValue env "dbi_5" with
+            | some (.VBuiltin .FstPair [] (.One .ArgV)) =>
+              match h6 : StagedCek.lookupValue env "dbi_6" with
+              | some (.VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV)))) =>
+                some ⟨{
+                  bound0 := lookup_step env "dbi_0" v0 h0
+                  bound1 := lookup_step env "dbi_1" v1 h1
+                  bound2 := lookup_step env "dbi_2" v2 h2
+                  bound3 := lookup_step env "dbi_3" v3 h3
+                  bound4 := lookup_step env "dbi_4" v4 h4
+                  bound5 := lookup_step env "dbi_5" v5 h5
+                  bound6 := lookup_step env "dbi_6" v6 h6
+                }⟩
+              | _ => none
+            | _ => none
+          | _ => none
+        | _ => none
+      | _ => none
+    | _ => none
+  | _ => none
+
+def readyWitness (env : Environment) : Option (PLift (Nonempty (Ready env))) :=
+  match hs : StagedCek.lookupValue env "dbi_19" with
+  | some (.VLam "dbi_19" (.Lam "dbi_20" body) captured) =>
+    match bodyWitness body, bindingsWitness env, bindingsWitness captured with
+    | some bodyEq, some currentValid, some capturedValid =>
+      some ⟨⟨{
+        captured := captured
+        currentValid := currentValid.down
+        capturedValid := capturedValid.down
+        recursiveBinding := by
+          intro s
+          have hit := lookup_step env "dbi_19" _ hs s
+          simpa only [bodyEq.down] using hit
+      }⟩⟩
+    | _, _, _ => none
+  | _ => none
+
+def worker (xs : List (Data × Data)) (_sv : PlutusCore.Default.BuiltinSemanticsVariant)
+    (fuel : Nat) : Option (Nat × CekValue) :=
+  match scan fuel xs with
+  | none => none
+  | some (remaining,d) => some (remaining, .VCon (.Data d))
+
+def recognizeCall (binder : String) (body : Term) (env : Environment) (arg : CekValue) :
+    Option (SpecializedCall binder body env arg) :=
+  match binder, arg with
+  | "dbi_20", .VCon (.ConstPairDataList xs) =>
+    match bodyWitness body, readyWitness env with
+    | some bodyEq, some envReady =>
+      some {
+        worker := worker xs
+        spends := by
+          intro sv fuel remaining result h
+          unfold worker at h
+          cases eq : scan fuel xs with
+          | none => simp [eq] at h
+          | some pair =>
+            rcases pair with ⟨rest,d⟩
+            simp only [eq, Option.some.injEq, Prod.mk.injEq] at h
+            rcases h with ⟨rfl,rfl⟩
+            exact scan_fuel_lt xs fuel rest d eq
+        correct := by
+          intro sv fuel s
+          rcases envReady.down with ⟨ready⟩
+          rw [bodyEq.down]
+          have correct := scan_correct sv xs env ready fuel s
+          cases eq : scan fuel xs with
+          | none => simpa only [worker, finish, entry, eq] using correct
+          | some pair =>
+            rcases pair with ⟨remaining,d⟩
+            simpa only [worker, finish, entry, eq] using correct
+      }
+    | _, _ => none
+  | _, _ => none
+
+#print axioms recognizeCall
+
+#print axioms bodyWitness
+#print axioms readyWitness
+end PlutusCore.UPLC.LiftedMapSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearch.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearch.lean
@@ -1,0 +1,79 @@
+import PlutusCore.UPLC.CekBlocks
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data PlutusCore.Default
+namespace PlutusCore.UPLC.LiftedSearch
+set_option maxHeartbeats 0
+set_option maxRecDepth 10000
+
+def originalBody : Term := (.Force (.Apply (.Apply (.Apply (.Var "dbi_3") (.Var "dbi_23")) (.Delay (.Const (.Data (.Constr 1 []))))) (.Delay (.Apply (.Lam "dbi_24" (.Apply (.Lam "dbi_25" (.Apply (.Lam "dbi_26" (.Apply (.Lam "dbi_27" (.Force (.Apply (.Apply (.Apply (.Var "dbi_6") (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString) (.Const (.ByteString { data := "" }))) (.Var "dbi_26"))) (.Delay (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.ConstrData) (.Const (.Integer 0))) (.Apply (.Apply (.Var "dbi_2") (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.IData) (.Var "dbi_27"))) (.Const (.ConstDataList [])))))) (.Delay (.Apply (.Apply (.Var "dbi_22") (.Var "dbi_22")) (.Var "dbi_25")))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnIData) (.Apply (.Var "dbi_4") (.Var "dbi_24"))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnBData) (.Apply (.Var "dbi_5") (.Var "dbi_24"))))) (.Apply (.Var "dbi_0") (.Var "dbi_23")))) (.Apply (.Var "dbi_1") (.Var "dbi_23"))))))
+def originalSelf : Term := .Lam "dbi_22" (.Lam "dbi_23" originalBody)
+def v0 : CekValue := .VBuiltin .TailList [] (.One .ArgV)
+def v1 : CekValue := .VBuiltin .HeadList [] (.One .ArgV)
+def v2 : CekValue := .VBuiltin .MkCons [] (.More .ArgV (.One .ArgV))
+def v3 : CekValue := .VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV)))
+def v4 : CekValue := .VBuiltin .SndPair [] (.One .ArgV)
+def v5 : CekValue := .VBuiltin .FstPair [] (.One .ArgV)
+def v6 : CekValue := .VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV)))
+
+structure Valid (env : Environment) : Prop where
+  bound0 : ∀ s, ifBoundOtherwiseError s env "dbi_0" = .Return s v0
+  bound1 : ∀ s, ifBoundOtherwiseError s env "dbi_1" = .Return s v1
+  bound2 : ∀ s, ifBoundOtherwiseError s env "dbi_2" = .Return s v2
+  bound3 : ∀ s, ifBoundOtherwiseError s env "dbi_3" = .Return s v3
+  bound4 : ∀ s, ifBoundOtherwiseError s env "dbi_4" = .Return s v4
+  bound5 : ∀ s, ifBoundOtherwiseError s env "dbi_5" = .Return s v5
+  bound6 : ∀ s, ifBoundOtherwiseError s env "dbi_6" = .Return s v6
+
+structure Ready (env : Environment) where
+  captured : Environment
+  currentValid : Valid env
+  capturedValid : Valid captured
+  recursiveBinding : ∀ s, ifBoundOtherwiseError s env "dbi_22" =
+    .Return s (.VLam "dbi_22" (.Lam "dbi_23" originalBody) captured)
+
+def recurEnv (captured : Environment) : Environment :=
+  .NonEmptyEnvironment captured "dbi_22" (.VLam "dbi_22" (.Lam "dbi_23" originalBody) captured)
+
+def recurReady (captured : Environment) (valid : Valid captured) : Ready (recurEnv captured) where
+  captured := captured
+  capturedValid := valid
+  currentValid := by
+    constructor
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound0]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound1]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound2]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound3]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound4]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound5]
+    · intro s; simp [recurEnv, ifBoundOtherwiseError, valid.bound6]
+  recursiveBinding := by intro s; simp [recurEnv, ifBoundOtherwiseError]
+
+def entry (env : Environment) (s : Stack) (xs : List (Data × Data)) : State :=
+  .Eval s (.NonEmptyEnvironment env "dbi_23" (.VCon (.ConstPairDataList xs))) originalBody
+
+/-- Consume the entire search, returning the original remaining CEK fuel. -/
+def scan (fuel : Nat) (xs : List (Data × Data)) : Option (Nat × Data) :=
+  match xs with
+  | [] => if 16 ≤ fuel then some (fuel-16, .Constr 1 []) else none
+  | (.B b, .I i) :: tail =>
+    if "" == b.data then
+      if 103 ≤ fuel then some (fuel-103, .Constr 0 [.I i]) else none
+    else
+      if 92 ≤ fuel then scan (fuel-92) tail else none
+  | _ => none
+termination_by xs.length
+
+theorem scan_fuel_lt (xs : List (Data × Data)) (fuel remaining : Nat) (result : Data)
+    (h : scan fuel xs = some (remaining,result)) : remaining < fuel := by
+  induction xs generalizing fuel with
+  | nil => simp only [scan] at h; split at h <;> simp_all; omega
+  | cons pair tail ih =>
+    rcases pair with ⟨key,value⟩
+    cases key <;> cases value <;> simp only [scan] at h <;> try contradiction
+    split at h
+    · split at h <;> simp_all; omega
+    · split at h
+      · have lt := ih _ h; omega
+      · contradiction
+
+end PlutusCore.UPLC.LiftedSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearchFastRecognize.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearchFastRecognize.lean
@@ -1,0 +1,92 @@
+import PlutusCore.UPLC.LiftedSearchRecognize
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data
+namespace PlutusCore.UPLC.LiftedSearch
+set_option maxRecDepth 10000
+set_option maxHeartbeats 0
+
+/-! Runtime recognition uses ordinary booleans and a nonindexed worker record.
+The correspondence with the proof-carrying recognizer is established below,
+so preparation need not normalize types indexed by the full closure environment. -/
+
+def bodyMatches (t : Term) : Bool := (bodyWitness t).isSome
+
+theorem bodyMatches_eq (t : Term) : bodyMatches t = (bodyWitness t).isSome := rfl
+
+def bindingsMatch (env : Environment) : Bool :=
+  match StagedCek.lookupValue env "dbi_0" with
+  | some (.VBuiltin .TailList [] (.One .ArgV)) =>
+    match StagedCek.lookupValue env "dbi_1" with
+    | some (.VBuiltin .HeadList [] (.One .ArgV)) =>
+      match StagedCek.lookupValue env "dbi_2" with
+      | some (.VBuiltin .MkCons [] (.More .ArgV (.One .ArgV))) =>
+        match StagedCek.lookupValue env "dbi_3" with
+        | some (.VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV)))) =>
+          match StagedCek.lookupValue env "dbi_4" with
+          | some (.VBuiltin .SndPair [] (.One .ArgV)) =>
+            match StagedCek.lookupValue env "dbi_5" with
+            | some (.VBuiltin .FstPair [] (.One .ArgV)) =>
+              match StagedCek.lookupValue env "dbi_6" with
+              | some (.VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV)))) => true
+              | _ => false
+            | _ => false
+          | _ => false
+        | _ => false
+      | _ => false
+    | _ => false
+  | _ => false
+
+theorem bindingsMatch_eq (env : Environment) : bindingsMatch env = (bindingsWitness env).isSome := by
+  unfold bindingsMatch bindingsWitness
+  repeat' first | rfl | (solve | simp_all) | (split <;> try simp_all)
+
+def readyMatch (env : Environment) : Bool :=
+  match StagedCek.lookupValue env "dbi_22" with
+  | some (.VLam "dbi_22" (.Lam "dbi_23" body) captured) =>
+      bodyMatches body && bindingsMatch env && bindingsMatch captured
+  | _ => false
+
+theorem readyMatch_eq (env : Environment) : readyMatch env = (readyWitness env).isSome := by
+  unfold readyMatch readyWitness
+  simp only [bodyMatches_eq, bindingsMatch_eq]
+  repeat' first | rfl | (solve | simp_all) | (split <;> try simp_all)
+  all_goals
+    obtain ⟨rfl, rfl⟩ := ‹_ = _ ∧ _ = _›
+    simp_all [Option.isSome_iff_exists]
+  all_goals
+    intro b hb c hc
+    apply Option.eq_none_iff_forall_ne_some.mpr
+    intro d hd
+    solve_by_elim
+
+structure CallPlan where
+  worker : PlutusCore.Default.BuiltinSemanticsVariant → Nat → Option (Nat × CekValue)
+
+def recognizeFast (binder : String) (body : Term) (env : Environment) (arg : CekValue) : Option CallPlan :=
+  match binder, arg with
+  | "dbi_23", .VCon (.ConstPairDataList xs) =>
+      if bodyMatches body && readyMatch env then some ⟨worker xs⟩ else none
+  | _, _ => none
+
+theorem recognizeFast_eq (binder : String) (body : Term) (env : Environment) (arg : CekValue) :
+    recognizeFast binder body env arg =
+      (recognizeCall binder body env arg).map (fun p => CallPlan.mk p.worker) := by
+  unfold recognizeFast recognizeCall
+  split
+  · simp only [bodyMatches_eq, readyMatch_eq]
+    cases bodyWitness body <;> cases readyWitness env <;> rfl
+  · split <;> simp_all
+
+theorem recognizeFast_sound (binder : String) (body : Term) (env : Environment) (arg : CekValue)
+    (plan : CallPlan) (h : recognizeFast binder body env arg = some plan) :
+    ∃ cert : SpecializedCall binder body env arg, cert.worker = plan.worker := by
+  rw [recognizeFast_eq] at h
+  cases hc : recognizeCall binder body env arg with
+  | none => simp [hc] at h
+  | some cert =>
+      simp only [hc, Option.map_some, Option.some.injEq] at h
+      cases h
+      exact ⟨cert, rfl⟩
+
+#print axioms recognizeFast_sound
+end PlutusCore.UPLC.LiftedSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearchProofs.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearchProofs.lean
@@ -1,0 +1,127 @@
+import PlutusCore.UPLC.LiftedSearch
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data PlutusCore.Default
+namespace PlutusCore.UPLC.LiftedSearch
+open CekBlocks
+set_option maxHeartbeats 0
+set_option maxRecDepth 10000
+
+theorem empty_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env) (s : Stack) :
+    advance sv 16 (entry env s []) = .Return s (.VCon (.Data (.Constr 1 []))) := by
+  simp [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList,                                 v3, ready.currentValid.bound3]
+
+theorem hit_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (i : Int) (tail : List (Data × Data)) :
+    advance sv 103 (entry env s ((.B { data := "" }, .I i) :: tail)) =
+      .Return s (.VCon (.Data (.Constr 0 [.I i]))) := by
+  simp [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair, BuiltinFunctions.Pair.sndPair,
+    BuiltinFunctions.Data.unBData, BuiltinFunctions.Data.unIData,
+    BuiltinFunctions.ByteString.equalsByteString, BuiltinFunctions.Bool.ifThenElse,
+    BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData, PlutusCore.Data.unIData,
+    PlutusCore.ByteString.equalsByteString, PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString,
+    PlutusCore.Bool.ifThenElse, PlutusCore.Pair.fstPair, PlutusCore.Pair.sndPair,
+    Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v2, ready.currentValid.bound2, v3, ready.currentValid.bound3, v4, ready.currentValid.bound4, v5, ready.currentValid.bound5, v6, ready.currentValid.bound6, BuiltinFunctions.Data.constrData, BuiltinFunctions.Data.iData,
+    BuiltinFunctions.List.mkCons, PlutusCore.Data.constrData, PlutusCore.Data.iData, PlutusCore.List.mkCons]
+
+theorem miss_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (b : PlutusCore.ByteString.ByteString) (i : Int) (tail : List (Data × Data))
+    (h : ("" == b.data) = false) :
+    advance sv 92 (entry env s ((.B b, .I i) :: tail)) = entry (recurEnv ready.captured) s tail := by
+  simp [advance, entry, recurEnv, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair, BuiltinFunctions.Pair.sndPair,
+    BuiltinFunctions.Data.unBData, BuiltinFunctions.Data.unIData,
+    BuiltinFunctions.ByteString.equalsByteString, BuiltinFunctions.Bool.ifThenElse,
+    BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData, PlutusCore.Data.unIData,
+    PlutusCore.ByteString.equalsByteString, PlutusCore.ByteString.PlutusCore.ByteStringInternal.BEqByteString,
+    PlutusCore.Bool.ifThenElse, PlutusCore.Pair.fstPair, PlutusCore.Pair.sndPair,
+    Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v3, ready.currentValid.bound3, v4, ready.currentValid.bound4, v5, ready.currentValid.bound5, v6, ready.currentValid.bound6, ready.recursiveBinding, h]
+
+theorem invalid_key_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (key value : Data) (tail : List (Data × Data)) (h : ∀ b, key ≠ Data.B b) :
+    advance sv 45 (entry env s ((key,value) :: tail)) = .Error := by
+  cases key
+  all_goals try simp_all [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair,     BuiltinFunctions.Data.unBData,         BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData,         PlutusCore.Pair.fstPair,     Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v3, ready.currentValid.bound3, v5, ready.currentValid.bound5]
+
+theorem invalid_value_block (sv : BuiltinSemanticsVariant) (env : Environment) (ready : Ready env)
+    (s : Stack) (b : PlutusCore.ByteString.ByteString) (value : Data)
+    (tail : List (Data × Data)) (h : ∀ i, value ≠ Data.I i) :
+    advance sv 58 (entry env s ((.B b,value) :: tail)) = .Error := by
+  cases value
+  all_goals try simp_all [advance, entry, originalBody, step,
+    ifBoundOtherwiseError, ifArgVOtherwiseError, evalBuiltin,
+    BuiltinFunctions.Evaluate.evaluateBuiltinFunction,
+    BuiltinFunctions.List.chooseList, BuiltinFunctions.List.headList, BuiltinFunctions.List.tailList,
+    BuiltinFunctions.Pair.fstPair, BuiltinFunctions.Pair.sndPair,
+    BuiltinFunctions.Data.unBData, BuiltinFunctions.Data.unIData,
+        BuiltinFunctions.Utils.tryCatchSome, PlutusCore.List.headList, PlutusCore.List.tailList,
+    PlutusCore.Data.unBData, PlutusCore.Data.unIData,
+        PlutusCore.Pair.fstPair, PlutusCore.Pair.sndPair,
+    Pure.pure, Except.pure, expectedArgs, v0, ready.currentValid.bound0, v1, ready.currentValid.bound1, v3, ready.currentValid.bound3, v4, ready.currentValid.bound4, v5, ready.currentValid.bound5]
+
+def finish (sv : BuiltinSemanticsVariant) (s : Stack) (result : Option (Nat × Data)) : State :=
+  match result with
+  | none => .Error
+  | some (remaining,d) => runSteps sv (.Return s (.VCon (.Data d))) remaining
+
+/-- The whole loop is independent of irrelevant captured bindings, provided the
+checked builtin and self bindings hold in the current and recursive environments. -/
+theorem scan_correct (sv : BuiltinSemanticsVariant) (xs : List (Data × Data))
+    (env : Environment) (ready : Ready env) (fuel : Nat) (s : Stack) :
+    finish sv s (scan fuel xs) = runSteps sv (entry env s xs) fuel := by
+  induction xs generalizing env fuel with
+  | nil =>
+    rw [shortcut sv 16 _ _ (empty_block sv env ready s) rfl]
+    simp only [scan]
+    split <;> simp_all [finish]
+  | cons pair tail ih =>
+    rcases pair with ⟨key,value⟩
+    cases key <;> try {
+      simp only [scan, finish]
+      symm
+      apply block_error sv 45
+      apply invalid_key_block sv env ready
+      intro b; simp }
+    case B b =>
+      cases value <;> try {
+        simp only [scan, finish]
+        symm
+        apply block_error sv 58
+        apply invalid_value_block sv env ready
+        intro i; simp }
+      case I i =>
+        by_cases eq : ("" == b.data) = true
+        · have beq : b = { data := "" } := by cases b; simp_all
+          subst b
+          rw [shortcut sv 103 _ _ (hit_block sv env ready s i tail) rfl]
+          simp only [scan, beq_self_eq_true, if_true]
+          split <;> simp_all [finish]
+        · have neq : ("" == b.data) = false := by simpa using eq
+          rw [shortcut sv 92 _ _ (miss_block sv env ready s b i tail neq) rfl]
+          simp only [scan, neq, Bool.false_eq_true, if_false]
+          split
+          · exact ih _ (recurReady _ ready.capturedValid) _
+          · rfl
+
+#print axioms scan_correct
+
+#print axioms empty_block
+#print axioms hit_block
+#print axioms miss_block
+end PlutusCore.UPLC.LiftedSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearchRecognize.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LiftedSearchRecognize.lean
@@ -1,0 +1,121 @@
+import PlutusCore.UPLC.LiftedSearchProofs
+import PlutusCore.UPLC.SpecializedCall
+open PlutusCore.UPLC PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.CekValue PlutusCore.UPLC.Builtins PlutusCore.Data
+namespace PlutusCore.UPLC.LiftedSearch
+set_option maxRecDepth 10000
+set_option maxHeartbeats 0
+
+/-- Recognize this exact template and retain a kernel-checked equality witness.
+The prototype deliberately falls back for other alpha-renamings. -/
+def bodyWitness (t : Term) : Option (PLift (t = originalBody)) :=
+  match t with
+  | (.Force (.Apply (.Apply (.Apply (.Var "dbi_3") (.Var "dbi_23")) (.Delay (.Const (.Data (.Constr 1 []))))) (.Delay (.Apply (.Lam "dbi_24" (.Apply (.Lam "dbi_25" (.Apply (.Lam "dbi_26" (.Apply (.Lam "dbi_27" (.Force (.Apply (.Apply (.Apply (.Var "dbi_6") (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.EqualsByteString) (.Const (.ByteString { data := "" }))) (.Var "dbi_26"))) (.Delay (.Apply (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.ConstrData) (.Const (.Integer 0))) (.Apply (.Apply (.Var "dbi_2") (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.IData) (.Var "dbi_27"))) (.Const (.ConstDataList [])))))) (.Delay (.Apply (.Apply (.Var "dbi_22") (.Var "dbi_22")) (.Var "dbi_25")))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnIData) (.Apply (.Var "dbi_4") (.Var "dbi_24"))))) (.Apply (.Builtin PlutusCore.UPLC.Term.BuiltinFun.UnBData) (.Apply (.Var "dbi_5") (.Var "dbi_24"))))) (.Apply (.Var "dbi_0") (.Var "dbi_23")))) (.Apply (.Var "dbi_1") (.Var "dbi_23")))))) => some ⟨rfl⟩
+  | _ => none
+
+theorem lookup_step (env : Environment) (x : String) (v : CekValue)
+    (h : StagedCek.lookupValue env x = some v) (s : Stack) :
+    ifBoundOtherwiseError s env x = .Return s v := by
+  cases env with
+  | EmptyEnvironment => simp [StagedCek.lookupValue] at h
+  | NonEmptyEnvironment rest y value =>
+      by_cases eq : x = y
+      · simpa [StagedCek.lookupValue, ifBoundOtherwiseError, eq] using h
+      · simp only [StagedCek.lookupValue, eq, if_false] at h
+        simpa only [ifBoundOtherwiseError, eq, if_false] using lookup_step rest x v h s
+termination_by sizeOf env
+
+/-- Certificates are proof-only; unused captured environments are not copied into
+runtime scan results. Each lookup obeys the original shadowing rules. -/
+def bindingsWitness (env : Environment) : Option (PLift (Valid env)) :=
+  match h0 : StagedCek.lookupValue env "dbi_0" with
+  | some (.VBuiltin .TailList [] (.One .ArgV)) =>
+    match h1 : StagedCek.lookupValue env "dbi_1" with
+    | some (.VBuiltin .HeadList [] (.One .ArgV)) =>
+      match h2 : StagedCek.lookupValue env "dbi_2" with
+      | some (.VBuiltin .MkCons [] (.More .ArgV (.One .ArgV))) =>
+        match h3 : StagedCek.lookupValue env "dbi_3" with
+        | some (.VBuiltin .ChooseList [] (.More .ArgV (.More .ArgV (.One .ArgV)))) =>
+          match h4 : StagedCek.lookupValue env "dbi_4" with
+          | some (.VBuiltin .SndPair [] (.One .ArgV)) =>
+            match h5 : StagedCek.lookupValue env "dbi_5" with
+            | some (.VBuiltin .FstPair [] (.One .ArgV)) =>
+              match h6 : StagedCek.lookupValue env "dbi_6" with
+              | some (.VBuiltin .IfThenElse [] (.More .ArgV (.More .ArgV (.One .ArgV)))) =>
+                some ⟨{
+                  bound0 := lookup_step env "dbi_0" v0 h0
+                  bound1 := lookup_step env "dbi_1" v1 h1
+                  bound2 := lookup_step env "dbi_2" v2 h2
+                  bound3 := lookup_step env "dbi_3" v3 h3
+                  bound4 := lookup_step env "dbi_4" v4 h4
+                  bound5 := lookup_step env "dbi_5" v5 h5
+                  bound6 := lookup_step env "dbi_6" v6 h6
+                }⟩
+              | _ => none
+            | _ => none
+          | _ => none
+        | _ => none
+      | _ => none
+    | _ => none
+  | _ => none
+
+def readyWitness (env : Environment) : Option (PLift (Nonempty (Ready env))) :=
+  match hs : StagedCek.lookupValue env "dbi_22" with
+  | some (.VLam "dbi_22" (.Lam "dbi_23" body) captured) =>
+    match bodyWitness body, bindingsWitness env, bindingsWitness captured with
+    | some bodyEq, some currentValid, some capturedValid =>
+      some ⟨⟨{
+        captured := captured
+        currentValid := currentValid.down
+        capturedValid := capturedValid.down
+        recursiveBinding := by
+          intro s
+          have hit := lookup_step env "dbi_22" _ hs s
+          simpa only [bodyEq.down] using hit
+      }⟩⟩
+    | _, _, _ => none
+  | _ => none
+
+def worker (xs : List (Data × Data)) (_sv : PlutusCore.Default.BuiltinSemanticsVariant)
+    (fuel : Nat) : Option (Nat × CekValue) :=
+  match scan fuel xs with
+  | none => none
+  | some (remaining,d) => some (remaining, .VCon (.Data d))
+
+def recognizeCall (binder : String) (body : Term) (env : Environment) (arg : CekValue) :
+    Option (SpecializedCall binder body env arg) :=
+  match binder, arg with
+  | "dbi_23", .VCon (.ConstPairDataList xs) =>
+    match bodyWitness body, readyWitness env with
+    | some bodyEq, some envReady =>
+      some {
+        worker := worker xs
+        spends := by
+          intro sv fuel remaining result h
+          unfold worker at h
+          cases eq : scan fuel xs with
+          | none => simp [eq] at h
+          | some pair =>
+            rcases pair with ⟨rest,d⟩
+            simp only [eq, Option.some.injEq, Prod.mk.injEq] at h
+            rcases h with ⟨rfl,rfl⟩
+            exact scan_fuel_lt xs fuel rest d eq
+        correct := by
+          intro sv fuel s
+          rcases envReady.down with ⟨ready⟩
+          rw [bodyEq.down]
+          have correct := scan_correct sv xs env ready fuel s
+          cases eq : scan fuel xs with
+          | none => simpa only [worker, finish, entry, eq] using correct
+          | some pair =>
+            rcases pair with ⟨remaining,d⟩
+            simpa only [worker, finish, entry, eq] using correct
+      }
+    | _, _ => none
+  | _, _ => none
+
+#print axioms recognizeCall
+
+#print axioms bodyWitness
+#print axioms readyWitness
+end PlutusCore.UPLC.LiftedSearch

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LoopCek.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LoopCek.lean
@@ -1,0 +1,210 @@
+import PlutusCore.UPLC.RecursiveCalls
+
+/-! Fuse CEK evaluation with certified recursive-body specializations. Worker
+results are resumed at their exact remaining fuel with this same interpreter. -/
+namespace PlutusCore.UPLC.LoopCek
+open PlutusCore.Default CekMachine CekValue Term Builtins
+open BuiltinFunctions.Evaluate
+
+/-- Select only the needed binding; discard the rest of the environment. -/
+def lookupValue (env : Environment) (x : String) : Option CekValue :=
+  match env with
+  | .EmptyEnvironment => none
+  | .NonEmptyEnvironment rest y v =>
+      if x = y then some v else lookupValue rest x
+
+mutual
+  def eval (sv : BuiltinSemanticsVariant) (fuel : Nat)
+      (s : Stack) (env : Environment) (t : Term) : State :=
+    match fuel with
+    | 0 => .Error
+    | n + 1 =>
+      match t with
+      | .Var x =>
+          match lookupValue env x with
+          | some v => ret sv n s v
+          | none => .Error
+      | .Const c => ret sv n s (.VCon c)
+      | .Lam x body => ret sv n s (.VLam x body env)
+      | .Delay body => ret sv n s (.VDelay body env)
+      | .Force body => eval sv n (.ForceFrame :: s) env body
+      | .Apply f a => eval sv n (.LeftApplicationToTerm a env :: s) env f
+      | .Builtin b => ret sv n s (.VBuiltin b [] (expectedArgs b))
+      | .Error => .Error
+      | .Constr i ts =>
+          match ts with
+          | body :: rest => eval sv n (.ConstructorArgument i [] rest env :: s) env body
+          | [] => ret sv n s (.VConstr i [])
+      | .Case body branches => eval sv n (.CaseScrutinee branches env :: s) env body
+  termination_by fuel
+  decreasing_by all_goals omega
+
+  def ret (sv : BuiltinSemanticsVariant) (fuel : Nat)
+      (s : Stack) (v : CekValue) : State :=
+    match fuel with
+    | 0 => .Error
+    | n + 1 =>
+      match s with
+      | [] => .Halt v
+      | .LeftApplicationToTerm body env :: rest =>
+          eval sv n (.RightApplicationOfValue v :: rest) env body
+      | .RightApplicationOfValue f :: rest =>
+          match f with
+          | .VLam x body env =>
+              match RecursiveCalls.recognize x body env v with
+              | none => eval sv n rest (.NonEmptyEnvironment env x v) body
+              | some plan =>
+                match plan.worker sv n with
+                | none => .Error
+                | some (remaining,result) =>
+                  if h : remaining < n then ret sv remaining rest result else .Error
+          | .VBuiltin b vs expected =>
+              match expected with
+              | .More .ArgV tail => ret sv n rest (.VBuiltin b (v :: vs) tail)
+              | .One .ArgV =>
+                  match evaluateBuiltinFunction sv b (v :: vs) with
+                  | some result => ret sv n rest result
+                  | none => .Error
+              | _ => .Error
+          | _ => .Error
+      | .LeftApplicationToValue arg :: rest =>
+          match v with
+          | .VLam x body env => eval sv n rest (.NonEmptyEnvironment env x arg) body
+          | .VBuiltin b vs expected =>
+              match expected with
+              | .More .ArgV tail => ret sv n rest (.VBuiltin b (arg :: vs) tail)
+              | .One .ArgV =>
+                  match evaluateBuiltinFunction sv b (arg :: vs) with
+                  | some result => ret sv n rest result
+                  | none => .Error
+              | _ => .Error
+          | _ => .Error
+      | .ForceFrame :: rest =>
+          match v with
+          | .VDelay body env => eval sv n rest env body
+          | .VBuiltin b vs expected =>
+              match expected with
+              | .More .ArgQ tail => ret sv n rest (.VBuiltin b vs tail)
+              | .One .ArgQ =>
+                  match evaluateBuiltinFunction sv b vs with
+                  | some result => ret sv n rest result
+                  | none => .Error
+              | _ => .Error
+          | _ => .Error
+      | .ConstructorArgument i vs ts env :: rest =>
+          match ts with
+          | body :: remaining => eval sv n (.ConstructorArgument i (v :: vs) remaining env :: rest) env body
+          | [] => ret sv n rest (.VConstr i (List.reverse (v :: vs)))
+      | .CaseScrutinee Ms ρ :: rest =>
+          match v with
+          | CekValue.VConstr i Vs =>
+               match Ms[i]? with
+               | some mi => eval sv n (step.folding Vs rest) ρ mi
+               | none => .Error
+
+          | CekValue.VCon (Const.Integer value) =>
+               if 0 ≤ value && value.toNat < Ms.length then
+                 match Ms[value.toNat]? with
+                 | some mi => eval sv n rest ρ mi
+                 | none => .Error
+               else .Error
+
+          | CekValue.VCon (Const.Bool false) =>
+               if Ms.length == 1 || Ms.length == 2 then
+                 match Ms[0]? with
+                 | some mi => eval sv n rest ρ mi
+                 | none => .Error
+               else .Error
+
+          | CekValue.VCon (Const.Bool true) =>
+               if Ms.length == 2 then
+                 match Ms[1]? with
+                 | some mi => eval sv n rest ρ mi
+                 | none => .Error
+               else .Error
+
+          | CekValue.VCon Const.Unit =>
+                if Ms.length == 1 then
+                  match Ms[0]? with
+                  | some mi => eval sv n rest ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.Pair p) =>
+                if Ms.length == 1 then
+                  let Vs := [CekValue.VCon p.1, CekValue.VCon p.2]
+                  match Ms[0]? with
+                  | some mi => eval sv n (step.folding Vs rest) ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.PairData p) =>
+                if Ms.length == 1 then
+                  let Vs := [CekValue.VCon (Const.Data p.1), CekValue.VCon (Const.Data p.2)]
+                  match Ms[0]? with
+                  | some mi => eval sv n (step.folding Vs rest) ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.ConstList (c :: cs)) =>
+                if Ms.length == 1 || Ms.length == 2 then
+                  let Vs := [CekValue.VCon c, CekValue.VCon (Const.ConstList cs)]
+                  match Ms[0]? with
+                  | some mi => eval sv n (step.folding Vs rest) ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.ConstList []) =>
+                if Ms.length == 2 then
+                  match Ms[1]? with
+                  | some mi => eval sv n rest ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.ConstDataList (c :: cs)) =>
+                if Ms.length == 1 || Ms.length == 2 then
+                  let Vs := [CekValue.VCon (.Data c), CekValue.VCon (Const.ConstDataList cs)]
+                  match Ms[0]? with
+                  | some mi => eval sv n (step.folding Vs rest) ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.ConstDataList []) =>
+                if Ms.length == 2 then
+                  match Ms[1]? with
+                  | some mi => eval sv n rest ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.ConstPairDataList (c :: cs)) =>
+                if Ms.length == 1 || Ms.length == 2 then
+                  let Vs := [CekValue.VCon (.PairData c), CekValue.VCon (Const.ConstPairDataList cs)]
+                  match Ms[0]? with
+                  | some mi => eval sv n (step.folding Vs rest) ρ mi
+                  | none => .Error
+                else .Error
+
+          | CekValue.VCon (Const.ConstPairDataList []) =>
+                if Ms.length == 2 then
+                  match Ms[1]? with
+                  | some mi => eval sv n rest ρ mi
+                  | none => .Error
+                else .Error
+
+          | _ => .Error
+  termination_by fuel
+  decreasing_by all_goals omega
+end
+
+/-- Entry point preserving the existing machine's terminal-state convention. -/
+def run (sv : BuiltinSemanticsVariant) (state : State) (fuel : Nat) : State :=
+  match state with
+  | .Eval s env t => eval sv fuel s env t
+  | .Return s v => ret sv fuel s v
+  | .Halt _ | .Error => state
+
+def execute (p : Program) (params : List Term) (fuel : Nat) : State :=
+  match p with
+  | .Program _ body => run default (initialState (applyParams body params)) fuel
+
+end PlutusCore.UPLC.LoopCek

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LoopCekProofs.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LoopCekProofs.lean
@@ -54,6 +54,7 @@ theorem eval_ret_correct (sv : BuiltinSemanticsVariant) (fuel : Nat) :
                 cases hp : RecursiveCalls.recognize x body env v with
                 | none => simpa only [hp] using ih.1 rest (.NonEmptyEnvironment env x v) body
                 | some plan =>
+                  simp only [hp]
                   obtain ⟨cert, hworker⟩ := RecursiveCalls.recognize_sound x body env v plan hp
                   have correct := cert.correct sv n rest
                   rw [hworker] at correct
@@ -62,7 +63,7 @@ theorem eval_ret_correct (sv : BuiltinSemanticsVariant) (fuel : Nat) :
                   | some pair =>
                     rcases pair with ⟨remaining,result⟩
                     have lt := cert.spends sv n remaining result (by simpa only [hworker] using hw)
-                    simp only [lt]
+                    simp only [hw, lt]
                     rw [(strong remaining (by omega)).2]
                     simpa only [hw] using correct
               case VBuiltin b vs expected =>

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LoopCekProofs.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/LoopCekProofs.lean
@@ -1,0 +1,121 @@
+import PlutusCore.UPLC.LoopCek
+
+namespace PlutusCore.UPLC.LoopCek
+open PlutusCore.Default CekMachine CekValue Term Builtins
+open BuiltinFunctions.Evaluate
+set_option maxHeartbeats 0
+
+private theorem lookup_correct (sv : BuiltinSemanticsVariant) (n : Nat)
+    (s : Stack) (env : Environment) (x : String) :
+    (match lookupValue env x with
+     | some v => runSteps sv (.Return s v) n
+     | none => .Error) =
+      runSteps sv (ifBoundOtherwiseError s env x) n := by
+  cases env with
+  | EmptyEnvironment => simp [lookupValue, ifBoundOtherwiseError, runSteps]
+  | NonEmptyEnvironment rest y v =>
+    by_cases h : x = y
+    · simp [lookupValue, ifBoundOtherwiseError, h]
+    · simpa only [lookupValue, ifBoundOtherwiseError, h, if_false] using
+        lookup_correct sv n s rest x
+termination_by sizeOf env
+
+
+theorem eval_ret_correct (sv : BuiltinSemanticsVariant) (fuel : Nat) :
+    (∀ s env t, eval sv fuel s env t = runSteps sv (.Eval s env t) fuel) ∧
+    (∀ s v, ret sv fuel s v = runSteps sv (.Return s v) fuel) := by
+  induction fuel using Nat.strongRecOn with
+  | ind fuel strong =>
+    cases fuel with
+    | zero =>
+        constructor <;> intros <;> simp [eval, ret, runSteps]
+    | succ n =>
+      have ih := strong n (Nat.lt_succ_self n)
+      constructor
+      · intro s env t
+        cases t <;> try simp only [eval]
+        all_goals try simp only [ih.1, ih.2]
+        case Var x =>
+          simpa only [runSteps, step] using (lookup_correct sv n s env x)
+        case Constr i ts => cases ts <;> simp only [eval, ih.1, ih.2, runSteps, step]
+        all_goals first | rfl | simp [runSteps, step]
+      · intro s v
+        cases s with
+        | nil => simp [ret, runSteps, step]
+        | cons frame rest =>
+          cases frame with
+          | LeftApplicationToTerm body env =>
+              simp only [ret, ih.1]
+              rfl
+          | RightApplicationOfValue f =>
+              cases f <;> try simp only [ret, ih.1]
+              case VLam x body env =>
+                change _ = runSteps sv (.Eval rest (.NonEmptyEnvironment env x v) body) n
+                cases hp : RecursiveCalls.recognize x body env v with
+                | none => simpa only [hp] using ih.1 rest (.NonEmptyEnvironment env x v) body
+                | some plan =>
+                  obtain ⟨cert, hworker⟩ := RecursiveCalls.recognize_sound x body env v plan hp
+                  have correct := cert.correct sv n rest
+                  rw [hworker] at correct
+                  cases hw : plan.worker sv n with
+                  | none => simpa only [hw] using correct
+                  | some pair =>
+                    rcases pair with ⟨remaining,result⟩
+                    have lt := cert.spends sv n remaining result (by simpa only [hworker] using hw)
+                    simp only [lt]
+                    rw [(strong remaining (by omega)).2]
+                    simpa only [hw] using correct
+              case VBuiltin b vs expected =>
+                cases expected with
+                | More arg tail => cases arg <;> simp [ret, ih.2, runSteps, step, ifArgVOtherwiseError]
+                | One arg =>
+                    cases arg <;> simp only [ret, ih.2, runSteps, step, ifArgVOtherwiseError, evalBuiltin]
+                    case ArgV => split <;> simp_all [runSteps]
+              all_goals first | rfl | simp [runSteps, step]
+          | LeftApplicationToValue arg =>
+              cases v <;> try simp only [ret, ih.1]
+              case VBuiltin b vs expected =>
+                cases expected with
+                | More next tail => cases next <;> simp [ret, ih.2, runSteps, step, ifArgVOtherwiseError]
+                | One next =>
+                    cases next <;> simp only [ret, ih.2, runSteps, step, ifArgVOtherwiseError, evalBuiltin]
+                    case ArgV => split <;> simp_all [runSteps]
+              all_goals first | rfl | simp [runSteps, step]
+          | ForceFrame =>
+              cases v <;> try simp only [ret, ih.1]
+              case VBuiltin b vs expected =>
+                cases expected with
+                | More next tail => cases next <;> simp [ret, ih.2, runSteps, step, ifArgQOtherwiseError]
+                | One next =>
+                    cases next <;> simp only [ret, ih.2, runSteps, step, ifArgQOtherwiseError, evalBuiltin]
+                    case ArgQ => split <;> simp_all [runSteps]
+              all_goals first | rfl | simp [runSteps, step]
+          | ConstructorArgument i vs ts env =>
+              cases ts <;> simp [ret, ih.1, ih.2, runSteps, step]
+          | CaseScrutinee ts env =>
+              rw [ret.eq_def]
+              simp only [ih.1, runSteps]
+              unfold step
+              split <;> simp_all [runSteps] <;>
+                repeat (first | assumption | rfl | (split <;> simp_all [runSteps]))
+              all_goals by_cases h : ts.length = 1 ∨ ts.length = 2 <;>
+                simp_all [runSteps] <;> split <;> simp_all [runSteps]
+
+/-- Kernel-checked equality for every machine state, fuel, and builtin semantics
+variant, including constructor fields and primitive case branches. -/
+theorem run_eq_runSteps (sv : BuiltinSemanticsVariant) (s : State) (fuel : Nat) :
+    run sv s fuel = runSteps sv s fuel := by
+  cases s with
+  | Eval stack env t => exact (eval_ret_correct sv fuel).1 stack env t
+  | Return stack v => exact (eval_ret_correct sv fuel).2 stack v
+  | Halt v => simp [run, runSteps]
+  | Error => simp [run, runSteps]
+
+theorem execute_eq (p : Program) (params : List Term) (fuel : Nat) :
+    execute p params fuel = cekExecuteProgram p params fuel := by
+  cases p
+  simp only [execute, cekExecuteProgram, cekExecuteProgramWithSemanticVariant, run_eq_runSteps]
+
+#print axioms run_eq_runSteps
+#print axioms execute_eq
+end PlutusCore.UPLC.LoopCek

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/RecursiveCalls.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/RecursiveCalls.lean
@@ -1,0 +1,25 @@
+import PlutusCore.UPLC.LiftedMapSearchFastRecognize
+
+namespace PlutusCore.UPLC.RecursiveCalls
+open Term CekMachine CekValue
+
+/-- Select a certified recursive-body worker. Binder names only route the
+check; each candidate still verifies its full body and captured bindings. -/
+def recognize (binder : String) (body : Term) (env : Environment) (arg : CekValue) :
+    Option LiftedSearch.CallPlan :=
+  if binder = "dbi_23" then LiftedSearch.recognizeFast binder body env arg
+  else if binder = "dbi_20" then LiftedMapSearch.recognizeFast binder body env arg
+  else none
+
+theorem recognize_sound (binder : String) (body : Term) (env : Environment) (arg : CekValue)
+    (plan : LiftedSearch.CallPlan) (h : recognize binder body env arg = some plan) :
+    ∃ cert : SpecializedCall binder body env arg, cert.worker = plan.worker := by
+  simp only [recognize] at h
+  split at h
+  · exact LiftedSearch.recognizeFast_sound binder body env arg plan h
+  · split at h
+    · exact LiftedMapSearch.recognizeFast_sound binder body env arg plan h
+    · contradiction
+
+#print axioms recognize_sound
+end PlutusCore.UPLC.RecursiveCalls

--- a/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/SpecializedCall.lean
+++ b/Benchmarks/cardano/overlays/lifted-search/PlutusCore/UPLC/SpecializedCall.lean
@@ -1,0 +1,18 @@
+import PlutusCore.UPLC.StagedCekProofs
+open PlutusCore.UPLC.Term PlutusCore.UPLC.CekMachine PlutusCore.UPLC.CekValue
+open PlutusCore.Default
+namespace PlutusCore.UPLC
+
+/-- A verified specialization of a lambda body for one captured environment and
+argument. Successful workers consume original CEK fuel and return the remaining
+fuel. Their result is resumed with the existing continuation. -/
+structure SpecializedCall (binder : String) (body : Term) (env : Environment) (arg : CekValue) where
+  worker : BuiltinSemanticsVariant → Nat → Option (Nat × CekValue)
+  spends : ∀ sv fuel remaining result, worker sv fuel = some (remaining,result) → remaining < fuel
+  correct : ∀ sv fuel s,
+    (match worker sv fuel with
+      | none => State.Error
+      | some (remaining,result) => runSteps sv (.Return s result) remaining) =
+    runSteps sv (.Eval s (.NonEmptyEnvironment env binder arg) body) fuel
+
+end PlutusCore.UPLC

--- a/Benchmarks/cardano/overlays/lifted-search/README.md
+++ b/Benchmarks/cardano/overlays/lifted-search/README.md
@@ -1,0 +1,89 @@
+# Certified recursive searches for the legacy Cardano interpreter
+
+This opt-in adapter recognizes two literal SellNFT search bodies and replaces
+their repeated CEK interpretation with direct Lean recursion. One searches an
+association list for an integer payload; the other searches for a map payload.
+Both use the empty byte-string key. This is an adapter for the pinned CEK with
+named variables used by the Cardano examples. It is not an implementation for
+the indexed interpreter in PlutusCore PR #44.
+
+## Installation and measurement
+
+Add `--staged-cek --lifted-search --blaster-rev YOUR_CANDIDATE_COMMIT` to the
+[`prepare_local.py`](../../prepare_local.py) invocation documented in the
+[benchmark guide](../../README.md). The script installs these modules in the
+named PlutusCore checkout, applies the preparation switch, and builds the
+integration and production-template checks. The indexed WSC adapter is not
+extended by this flag.
+
+```sh
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-candidate \
+  --label search-preparation --cases sellnft:1800 \
+  --staged-cek --lifted-search --timeout 120 --max-rss-gib 12
+python3 Benchmarks/cardano_bench.py --root /tmp/cardano-candidate \
+  --label search-proofs --cases sellnft:1800 --proofs-only \
+  --staged-cek --lifted-search --timeout 120 --max-rss-gib 12
+```
+
+Keep the flags identical between preparation and proofs. Omit `--lifted-search`
+for the fused CEK reference. The runner records and checks actual interpreter
+activation. All timing comparisons must run serially after dependency builds.
+
+Inside the prepared legacy workspace, the opt-in switch is
+`set_option plutuscore.liftedSearch true`, together with
+`set_option plutuscore.stagedCek true` and the specialization annotations emitted
+by the runner. Its default is false. The `.exec` definition retains the original
+CEK evaluator.
+
+## Exact semantics
+
+The syntax check alone does not authorize a replacement. Recognition also
+checks the captured builtin bindings and recursive closure, preserving lexical
+shadowing. Unrelated captured bindings are allowed. Other bodies, alpha-renamed
+templates, unsupported arguments, and failed environment checks use the
+ordinary interpreter path.
+
+`SpecializedCall` describes a worker that returns a value and its remaining
+original CEK fuel. Its certificate proves both fuel decrease and equality to
+the reference evaluation under every continuation and semantics variant.
+`CekBlocks` supplies composition and short-fuel lemmas. Each search proves:
+
+- Empty list: 16 transitions to Return.
+- Matching well-formed entry: 103 transitions to Return.
+- Nonmatching well-formed entry: 92 transitions to the next loop entry.
+- Invalid key: Error after 45 transitions; invalid payload: Error after 58.
+
+Insufficient fuel is included in the proof. Malformed payloads still fail even
+when their key does not match. The continuation resumes at the exact remaining
+fuel; no larger budget or stronger input assumption is introduced.
+
+Runtime dispatch uses booleans and an unindexed `CallPlan`. Theorems relate it
+to the indexed certificate, avoiding repeated normalization of types containing
+the captured environment. `LoopCekProofs.run_eq_runSteps` and `execute_eq` cover
+all states, programs, inputs, and fuel. The equivalence proofs use only Lean's
+standard `propext`, `Classical.choice`, and `Quot.sound` axioms. They do not use
+`sorry`, `native_decide`, or `blasterProven`.
+
+`LiftedTemplateSource.lean` separately proves that both templates occur in the
+actual decoded production SellNFT script, without axioms. These certificates
+do not rely on the diagnostic JSON export. `LoopCekControl.lean` contains 37
+`#testOptimize` controls for captures, shadowing, fallback behavior, malformed
+data, constructor/case behavior, and exact fuel boundaries.
+
+## Scope and evidence
+
+See the [measurement report](../../results/recursive-search-2026-09-09/README.md).
+The current SellNFT preparation remains above 10 seconds. Governance has no
+matching supported loop and incurs dispatch overhead when this flag is forced;
+leave it disabled there. The remaining predicate search and Governance's
+Z-combinator and mutual-recursion bodies are future specialization targets.
+
+The first integrated, indexed-plan prototype regressed preparation and a
+negative-control outcome. An unindexed single-search version reduced work but
+still timed out on that control. The two-search candidate restores the original
+outcomes in the measured runs. SellNFT still has its pre-existing 30-second
+solver timeout; it is not counted as a successful proof.
+
+The integration exposed Lean-blaster issue #245, fixed separately by PR #246
+with `Issue245.lean`. This adapter is stacked on that fix. No new language
+primitive or unproved rewrite is introduced into the solver.

--- a/Benchmarks/cardano/patches/plutuscore-lifted-search.patch
+++ b/Benchmarks/cardano/patches/plutuscore-lifted-search.patch
@@ -1,0 +1,45 @@
+--- a/PlutusCore/UPLC/PreProcess.lean
++++ b/PlutusCore/UPLC/PreProcess.lean
+@@ -1,6 +1,7 @@
+ import Lean
+ import PlutusCore.UPLC.CekMachine
+ import PlutusCore.UPLC.StagedCekProofs
++import PlutusCore.UPLC.LoopCekProofs
+ import PlutusCore.UPLC.PlutusScript
+ import Blaster.Optimize.Basic
+ open Lean Elab Command Term Meta Blaster.Optimize
+@@ -8,6 +9,11 @@
+ register_option plutuscore.stagedCek : Bool := {
+   defValue := false
+   descr := "Use the verified fused CEK interpreter during preparation (experimental)."
++}
++
++register_option plutuscore.liftedSearch : Bool := {
++  defValue := false
++  descr := "Use certified recursive search workers during staged preparation."
+ }
+ 
+ namespace PlutusCore.UPLC.PreProcess
+@@ -49,14 +55,19 @@
+         if metrics then IO.println s!"PREP_PHASE input_construct_ms={(← IO.monoMsNow) - inputStarted}"
+         let prepStarted ← IO.monoMsNow
+         let staged := plutuscore.stagedCek.get (← getOptions)
++        let lifted := plutuscore.liftedSearch.get (← getOptions)
++        if lifted && !staged then throwError "lifted search requires plutuscore.stagedCek"
++        -- Both replacements preserve all states and fuel by their execute_eq theorem.
++        -- The executable definition below retains the reference CEK.
++        let entry := if lifted then ``LoopCek.execute else ``StagedCek.execute
+         let optApp := if staged then
+           app.replace fun e => match e with
+-            | .const ``cekExecuteProgram ls => some (.const ``StagedCek.execute ls)
++            | .const ``cekExecuteProgram ls => some (.const entry ls)
+             | _ => none
+           else app
+-        if staged && (optApp.find? (·.isConstOf ``StagedCek.execute)).isNone then
++        if staged && (optApp.find? (·.isConstOf entry)).isNone then
+           throwError "staged CEK entry point was not installed"
+-        if metrics then IO.println s!"PREP_INTERPRETER staged={staged}"
++        if metrics then IO.println s!"PREP_INTERPRETER staged={staged} lifted_search={lifted}"
+         let (e, prepEnv) ← Optimize.main optApp|>.run default
+         if (← IO.getEnv "BLASTER_PREP_METRICS") == some "1" then
+           let ms := (← IO.monoMsNow) - prepStarted

--- a/Benchmarks/cardano/prepare_local.py
+++ b/Benchmarks/cardano/prepare_local.py
@@ -9,6 +9,7 @@ import argparse
 import json
 from pathlib import Path
 import subprocess
+import shutil
 
 HERE = Path(__file__).resolve().parent
 NAMES = ['blaster', 'cardano', 'wsc', 'plutuscore', 'plutuscore-wsc']
@@ -18,8 +19,11 @@ for name in NAMES:
     p.add_argument('--' + name, type=Path, required=True, help='Existing local source repository')
 p.add_argument('--blaster-rev', default=None, help='Override the pinned baseline with a candidate commit')
 p.add_argument('--staged-cek', action='store_true', help='Apply the verified fused CEK prototype to both interpreter pins; requires a specialization-enabled Blaster revision')
+p.add_argument('--lifted-search', action='store_true', help='Install certified SellNFT search workers in the named CEK; requires --staged-cek')
 p.add_argument('--no-build', action='store_true', help='Create checkouts only; build dependencies before timing')
 a = p.parse_args()
+if a.lifted_search and not a.staged_cek:
+    p.error('--lifted-search requires --staged-cek')
 if a.staged_cek and not a.blaster_rev:
     p.error('--staged-cek requires --blaster-rev with the specialization-enabled candidate')
 pins = json.loads((HERE / 'pins.json').read_text())
@@ -51,10 +55,24 @@ if a.staged_cek:
         target.mkdir(parents=True, exist_ok=True)
         (target/'OptimizeTestUtils.lean').write_text((root/'blaster/Tests/Utils.lean').read_text())
         (target/(fixture + '.lean')).write_text((HERE/'fixtures'/(fixture + '.lean')).read_text())
+if a.lifted_search:
+    target = root/'plutuscore'
+    overlay = HERE/'overlays'/'lifted-search'
+    for source in sorted(overlay.rglob('*.lean')):
+        relative = source.relative_to(overlay)
+        (target/relative).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target/relative)
+        subprocess.run(['git', 'add', '--intent-to-add', str(relative)], cwd=target, check=True)
+    subprocess.run(['git', 'apply', str(HERE/'patches'/'plutuscore-lifted-search.patch')], cwd=target, check=True)
+    for fixture in ['LoopCekControl', 'LiftedTemplateSource']:
+        shutil.copyfile(HERE/'fixtures'/(fixture+'.lean'), root/'cardano'/'Tests/Benchmarks'/(fixture+'.lean'))
 if not a.no_build:
     subprocess.run(['lake', 'build', 'CardanoLedgerApi.V3', 'PlutusCore.UPLC'], cwd=root/'cardano', check=True)
     subprocess.run(['lake', 'build', 'WSC.Prep.GlobalImport'], cwd=root/'wsc', check=True)
     if a.staged_cek:
         subprocess.run(['lake', 'build', 'Tests.Benchmarks.StagedControl'], cwd=root/'cardano', check=True)
         subprocess.run(['lake', 'build', 'Tests.Benchmarks.StagedControlIndexed'], cwd=root/'wsc', check=True)
+    if a.lifted_search:
+        subprocess.run(['lake', 'build', 'CardanoLedgerApi.V2', 'Tests.Benchmarks.LoopCekControl',
+                        'Tests.Benchmarks.LiftedTemplateSource'], cwd=root/'cardano', check=True)
 print(root)

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/README.md
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/README.md
@@ -1,0 +1,114 @@
+# Certified recursive searches: SellNFT measurements
+
+The opt-in legacy adapter reduces SellNFT preparation from a median **22.874 s
+to 18.348 s** (19.8%) across three serial, alternating pairs. It replaces two
+recognized recursive searches with kernel-verified Lean workers. This does not
+reach the sub-10-second target. Governance has no supported template yet.
+
+## Clean packaged comparison
+
+These measurements use the actual installed adapter, with fully symbolic
+SellNFT inputs and the original fuel 1800. Each pair ran reference preparation,
+reference proofs, candidate preparation, candidate proofs. Dependencies were
+built before timing; no other owned build or benchmark ran concurrently.
+CPU sampling and normalization profiling were disabled. The reference uses
+the fused CEK and static-control annotations; the candidate enables
+`--lifted-search` and its worker annotations in the same workspace.
+
+| Pair | Reference optimize (s) | Candidate optimize (s) | Reference prep + proofs wall (s) | Candidate prep + proofs wall (s) |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 22.534 | 18.245 | 63.604 | 57.483 |
+| 2 | 22.958 | 18.348 | 64.216 | 57.502 |
+| 3 | 22.874 | 18.473 | 64.294 | 57.593 |
+| Median | **22.874** | **18.348** | **64.216** | **57.502** |
+
+The total wall-time reduction is 10.5%. The proof phase includes one existing
+30-second solver timeout in both arms; these totals are time to the observed
+verdicts, **not time to complete all proofs successfully**. The verdict sequence
+in every arm was:
+
+1. `Valid` for the first two positive properties.
+2. The existing timeout for `success_imp_no_multi_spent`.
+3. `Expected Falsified` for both remaining negative controls, including the
+   accepting/non-vacuity control.
+
+The proof-only command deliberately exits with status `error` because of that
+timeout. It is retained in the result JSON and not reclassified as a pass.
+
+| Median or invariant metric | Reference | Candidate |
+| --- | ---: | ---: |
+| Preparation module wall time (s) | 25.438 | 20.450 |
+| Proof module wall time (s) | 38.777 | 37.052 |
+| Final hash-cons entries | 8,271,491 | 5,510,804 |
+| Allocated context IDs | 29,063 | 29,234 |
+| Beta-cache entries | 35,479 | 23,802 |
+| Preparation sampled peak process-tree RSS (GiB) | 2.203 | 2.033 |
+| Prepared module size (bytes) | 826,280 | 818,288 |
+
+Final hash-cons entries fall by 33.4%; sampled preparation RSS falls by 7.7%.
+These are final cache counts and sampled process-tree memory, not a count of
+CEK transitions or an operating-system memory high-water mark.
+
+The machine is an Apple M2 Max, 12 logical CPUs, 64 GiB RAM, macOS 25.5.0.
+Lean is 4.24.0 (`797c613eb9b6d4ec95db23e3e00af9ac6657f24b`). Z3 is 4.15.2,
+with a wrapper passing `-T:30`. Native `lake build` is used for every measured
+module. Setup, dependency compilation, and proof of the optimization itself
+are excluded from preparation timing.
+
+The measured Blaster commit is
+`71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2`, based on the dependent-matcher fix
+in [PR #246](https://github.com/input-output-hk/Lean-blaster/pull/246).
+Every `release-pair*.json` records all five repository pins, tracked-patch
+hashes, generated-source hash, runner hash, flags, raw times, and verdicts.
+Log paths are reduced to basenames; corresponding `*.excerpt.txt` files are
+explicitly selected telemetry/verdict excerpts. Full logs remain in the local
+benchmark workspace. Later documentation commits do not change tested code.
+
+## Correctness and installation
+
+The [adapter guide](../../overlays/lifted-search/README.md) explains installation,
+the exact fuel costs, and the scope of recognition. The packaged installer was
+run against fresh checkouts of the pins. Its 13 added Lean modules, preparation
+patch, and fixtures were built successfully using native Lake (371 jobs),
+including 37 `#testOptimize` controls and two certificates that the literal
+templates occur in the decoded production SellNFT script.
+
+[`validation.log`](validation.log) contains the build and axiom output.
+`LoopCek.run_eq_runSteps` and `LoopCek.execute_eq` use only the standard Lean
+axioms `propext`, `Classical.choice`, and `Quot.sound`; neither depends on
+`sorryAx`, `native_decide`, or `blasterProven`. Both production-template
+certificates have no axioms. The pinned reference CEK contains an unrelated
+pre-existing `sorry` warning; it is absent from these theorems' dependencies.
+Blaster's property verdicts retain its existing solver trust boundary.
+
+The core Blaster fix is separate: issue #245 was filed before PR #246, with
+five passing `Issue245.lean` regression checks. The final serial native Blaster
+suite on that base passed all 729 jobs. No core optimizer change is added by
+this adapter.
+
+## Governance and rejected prototypes
+
+A prior, separate scouting comparison at the original Governance fuel 9000
+measured 23.079 s without the worker dispatch and 24.543 s with it. Both had
+all four existing proof checks `Valid` (proof wall time 4.445 s and 4.411 s).
+Its full metadata is archived in `lifted-*-governance-9000*.json`. This is
+**one scout per arm in the experimental workspace**, not part of the three
+clean SellNFT pairs and not evidence of a Governance speedup. Keep the flag
+disabled for Governance until a matching worker is implemented and measured.
+
+Earlier integration variants were rejected: an indexed certificate on the
+runtime path took 26.259 s on SellNFT and caused an additional negative-control
+timeout; the unindexed single-search version took 22.590 s but retained that
+extra timeout. The two-search version measured here restores the reference
+outcomes. Earlier timing sets are not pooled into the clean comparison.
+
+The current recognizers support two exact named-variable templates (integer
+and map payload searches for an empty byte-string key). They check complete
+bodies and captured bindings, not just binder names. This is not a general
+Y/Z-combinator compiler and does not target the indexed CEK in PlutusCore
+PR #44. The remaining SellNFT predicate search and Governance's Z/mutual
+recursion are the next candidates for the same certificate interface.
+
+Open Lean-blaster and PlutusCoreBlaster PRs were checked before publication.
+PlutusCore PR #42 has related CEK composition lemmas and PR #44 has the indexed
+fused interpreter; neither supplies these certified legacy recursive workers.

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000-governance-9000-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000-governance-9000-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true step_fusion=false lifted_search=false
+PREP_METRICS optimize_ms=23079 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=4 command_ms=23802
+Build completed successfully (365 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000-proof-governance-9000-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000-proof-governance-9000-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true step_fusion=false lifted_search=false
+PREP_METRICS optimize_ms=23079 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=4 command_ms=23802
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (366 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000-proof.json
@@ -1,0 +1,87 @@
+{
+  "label": "lifted-search-control1-governance-9000-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "c4691fb3e680088c51affbfd6c3c547cd15543f6",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "55c1883ed66a04aac1dc8d02e0aa1c000de84a70",
+      "tracked_patch_sha256": "bcd41493783b3ca49e5dcaf55dcf98d1b316c518f0d685aead0120accfcc70b9"
+    },
+    "plutuscore-wsc": {
+      "commit": "09ca8995273988375e1c57bf3724cd1d323ae44e",
+      "tracked_patch_sha256": "1c4278ec0364e336d1ed1f75dbce5bfad3f008605d11eee95bd324d33b731d13"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "7eb09f280fe4191b5ef270807e64b1b8400e7c147aa98859c710ee52a6fd6f1e",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "step_fusion": false,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "profile_bindings": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1773895680,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.4450181249994785,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "step_fusion": [
+        "false"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792,
+      "archived_log_excerpt": "lifted-search-control1-governance-9000-proof-governance-9000-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-search-control1-governance-9000.json
@@ -1,0 +1,94 @@
+{
+  "label": "lifted-search-control1-governance-9000",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "c4691fb3e680088c51affbfd6c3c547cd15543f6",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "55c1883ed66a04aac1dc8d02e0aa1c000de84a70",
+      "tracked_patch_sha256": "bcd41493783b3ca49e5dcaf55dcf98d1b316c518f0d685aead0120accfcc70b9"
+    },
+    "plutuscore-wsc": {
+      "commit": "09ca8995273988375e1c57bf3724cd1d323ae44e",
+      "tracked_patch_sha256": "1c4278ec0364e336d1ed1f75dbce5bfad3f008605d11eee95bd324d33b731d13"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "7eb09f280fe4191b5ef270807e64b1b8400e7c147aa98859c710ee52a6fd6f1e",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "step_fusion": false,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "profile_bindings": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2038480896,
+      "prep": {
+        "optimize_ms": 23079,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 25.477232958888635,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "step_fusion": [
+        "false"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 4,
+          "command_ms": 23802
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312,
+      "archived_log_excerpt": "lifted-search-control1-governance-9000-governance-9000-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000-governance-9000-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000-governance-9000-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:34:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true step_fusion=false lifted_search=true
+PREP_METRICS optimize_ms=24543 hashcons=5299353 contexts=17761 beta_cache=17991
+PREP_PHASE declaration_ms=4 command_ms=25286
+Build completed successfully (371 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000-proof-governance-9000-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000-proof-governance-9000-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:34:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true step_fusion=false lifted_search=true
+PREP_METRICS optimize_ms=24543 hashcons=5299353 contexts=17761 beta_cache=17991
+PREP_PHASE declaration_ms=4 command_ms=25286
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (372 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000-proof.json
@@ -1,0 +1,103 @@
+{
+  "label": "lifted-two-loops1-governance-9000-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "7e4a9213e203f0a57017d35e8ee78207eb11812a",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "71556f99318bf6bb2f2cd0f74afceaae14698e51",
+      "tracked_patch_sha256": "bcd41493783b3ca49e5dcaf55dcf98d1b316c518f0d685aead0120accfcc70b9"
+    },
+    "plutuscore-wsc": {
+      "commit": "09ca8995273988375e1c57bf3724cd1d323ae44e",
+      "tracked_patch_sha256": "1c4278ec0364e336d1ed1f75dbce5bfad3f008605d11eee95bd324d33b731d13"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "e0a41c754aef86c3298d37d1f1de920e707805490b6c704cb7885d9e119322ac",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "step_fusion": false,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "profile_bindings": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1778843648,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.411162332864478,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "step_fusion": [
+        "false"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792,
+      "archived_log_excerpt": "lifted-two-loops1-governance-9000-proof-governance-9000-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/lifted-two-loops1-governance-9000.json
@@ -1,0 +1,110 @@
+{
+  "label": "lifted-two-loops1-governance-9000",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "7e4a9213e203f0a57017d35e8ee78207eb11812a",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "71556f99318bf6bb2f2cd0f74afceaae14698e51",
+      "tracked_patch_sha256": "bcd41493783b3ca49e5dcaf55dcf98d1b316c518f0d685aead0120accfcc70b9"
+    },
+    "plutuscore-wsc": {
+      "commit": "09ca8995273988375e1c57bf3724cd1d323ae44e",
+      "tracked_patch_sha256": "1c4278ec0364e336d1ed1f75dbce5bfad3f008605d11eee95bd324d33b731d13"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "e0a41c754aef86c3298d37d1f1de920e707805490b6c704cb7885d9e119322ac",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "step_fusion": false,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "profile_bindings": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2035548160,
+      "prep": {
+        "optimize_ms": 24543,
+        "hashcons": 5299353,
+        "contexts": 17761,
+        "beta_cache": 17991
+      },
+      "source_sha256": "a1f49490d5cb0b0758d10de0da3087af820ab9b362565a01dd4ccce0c97164ee",
+      "elapsed_seconds": 26.57621124992147,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "step_fusion": [
+        "false"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 4,
+          "command_ms": 25286
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312,
+      "archived_log_excerpt": "lifted-two-loops1-governance-9000-governance-9000-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate-proof-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate-proof-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18245 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18995
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate-proof.json
@@ -1,0 +1,98 @@
+{
+  "label": "release-pair1-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2257600512,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.04177662497386,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ],
+      "archived_log_excerpt": "release-pair1-candidate-proof-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18245 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18995
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-candidate.json
@@ -1,0 +1,105 @@
+{
+  "label": "release-pair1-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2182332416,
+      "prep": {
+        "optimize_ms": 18245,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 20.441342833917588,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 18995
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288,
+      "archived_log_excerpt": "release-pair1-candidate-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference-proof-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference-proof-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:14:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=22534 hashcons=8271491 contexts=29063 beta_cache=35479
+PREP_PHASE declaration_ms=5 command_ms=23642
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference-proof.json
@@ -1,0 +1,82 @@
+{
+  "label": "release-pair1-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2357624832,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 38.73847679211758,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ],
+      "archived_log_excerpt": "release-pair1-reference-proof-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:14:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=22534 hashcons=8271491 contexts=29063 beta_cache=35479
+PREP_PHASE declaration_ms=5 command_ms=23642
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair1-reference.json
@@ -1,0 +1,89 @@
+{
+  "label": "release-pair1-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2365341696,
+      "prep": {
+        "optimize_ms": 22534,
+        "hashcons": 8271491,
+        "contexts": 29063,
+        "beta_cache": 35479
+      },
+      "source_sha256": "349981cb9931efdb6e4becb48cb164329390e3b5a3568ab2365e177ade6e52fd",
+      "elapsed_seconds": 24.865098249865696,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 23642
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 826280,
+      "archived_log_excerpt": "release-pair1-reference-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate-proof-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate-proof-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18348 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=19098
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate-proof.json
@@ -1,0 +1,98 @@
+{
+  "label": "release-pair2-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2253488128,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.05175658385269,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ],
+      "archived_log_excerpt": "release-pair2-candidate-proof-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18348 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=19098
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-candidate.json
@@ -1,0 +1,105 @@
+{
+  "label": "release-pair2-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2182987776,
+      "prep": {
+        "optimize_ms": 18348,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 20.450327415950596,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 19098
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288,
+      "archived_log_excerpt": "release-pair2-candidate-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference-proof-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference-proof-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:14:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=22958 hashcons=8271491 contexts=29063 beta_cache=35479
+PREP_PHASE declaration_ms=5 command_ms=24089
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference-proof.json
@@ -1,0 +1,82 @@
+{
+  "label": "release-pair2-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2349989888,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 38.77744408301078,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ],
+      "archived_log_excerpt": "release-pair2-reference-proof-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:14:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=22958 hashcons=8271491 contexts=29063 beta_cache=35479
+PREP_PHASE declaration_ms=5 command_ms=24089
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair2-reference.json
@@ -1,0 +1,89 @@
+{
+  "label": "release-pair2-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2364358656,
+      "prep": {
+        "optimize_ms": 22958,
+        "hashcons": 8271491,
+        "contexts": 29063,
+        "beta_cache": 35479
+      },
+      "source_sha256": "349981cb9931efdb6e4becb48cb164329390e3b5a3568ab2365e177ade6e52fd",
+      "elapsed_seconds": 25.438416166929528,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 24089
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 826280,
+      "archived_log_excerpt": "release-pair2-reference-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate-proof-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate-proof-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18473 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=19239
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate-proof.json
@@ -1,0 +1,98 @@
+{
+  "label": "release-pair3-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2266808320,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.09276416595094,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ],
+      "archived_log_excerpt": "release-pair3-candidate-proof-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18473 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=19239
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-candidate.json
@@ -1,0 +1,105 @@
+{
+  "label": "release-pair3-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2183069696,
+      "prep": {
+        "optimize_ms": 18473,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 20.499915666878223,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 19239
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288,
+      "archived_log_excerpt": "release-pair3-candidate-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference-proof-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference-proof-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,11 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:14:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=22874 hashcons=8271491 contexts=29063 beta_cache=35479
+PREP_PHASE declaration_ms=6 command_ms=24022
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference-proof.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference-proof.json
@@ -1,0 +1,82 @@
+{
+  "label": "release-pair3-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2358951936,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 38.80917866691016,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ],
+      "archived_log_excerpt": "release-pair3-reference-proof-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference-sellnft-1800-1.excerpt.txt
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference-sellnft-1800-1.excerpt.txt
@@ -1,0 +1,7 @@
+Selected telemetry and verdict lines; this is not the full build log.
+
+info: Tests/Benchmarks/CardanoPerfCase.lean:14:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=22874 hashcons=8271491 contexts=29063 beta_cache=35479
+PREP_PHASE declaration_ms=6 command_ms=24022
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference.json
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/release-pair3-reference.json
@@ -1,0 +1,89 @@
+{
+  "label": "release-pair3-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2365997056,
+      "prep": {
+        "optimize_ms": 22874,
+        "hashcons": 8271491,
+        "contexts": 29063,
+        "beta_cache": 35479
+      },
+      "source_sha256": "349981cb9931efdb6e4becb48cb164329390e3b5a3568ab2365e177ade6e52fd",
+      "elapsed_seconds": 25.48491037497297,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 6,
+          "command_ms": 24022
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 826280,
+      "archived_log_excerpt": "release-pair3-reference-sellnft-1800-1.excerpt.txt"
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/recursive-search-2026-09-09/validation.log
+++ b/Benchmarks/cardano/results/recursive-search-2026-09-09/validation.log
@@ -1,0 +1,121 @@
+⚠ [294/371] Replayed PlutusCore.UPLC.CekMachine
+warning: PlutusCore/UPLC/CekMachine.lean:312:4: declaration uses 'sorry'
+ℹ [331/371] Replayed PlutusCore.UPLC.StagedCekProofs
+info: PlutusCore/UPLC/StagedCekProofs.lean:100:0: 'PlutusCore.UPLC.StagedCek.run_eq_runSteps' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/StagedCekProofs.lean:101:0: 'PlutusCore.UPLC.StagedCek.execute_eq' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [332/371] Replayed PlutusCore.UPLC.CekBlocks
+info: PlutusCore/UPLC/CekBlocks.lean:63:0: 'PlutusCore.UPLC.CekBlocks.compose' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/CekBlocks.lean:64:0: 'PlutusCore.UPLC.CekBlocks.shorter_error' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [334/371] Replayed PlutusCore.UPLC.LiftedMapSearchProofs
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:122:0: 'PlutusCore.UPLC.LiftedMapSearch.scan_correct' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:124:0: 'PlutusCore.UPLC.LiftedMapSearch.empty_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:125:0: 'PlutusCore.UPLC.LiftedMapSearch.hit_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:126:0: 'PlutusCore.UPLC.LiftedMapSearch.miss_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [336/371] Replayed PlutusCore.UPLC.LiftedMapSearchRecognize
+info: PlutusCore/UPLC/LiftedMapSearchRecognize.lean:117:0: 'PlutusCore.UPLC.LiftedMapSearch.recognizeCall' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchRecognize.lean:119:0: 'PlutusCore.UPLC.LiftedMapSearch.bodyWitness' does not depend on any axioms
+info: PlutusCore/UPLC/LiftedMapSearchRecognize.lean:120:0: 'PlutusCore.UPLC.LiftedMapSearch.readyWitness' depends on axioms: [propext, Quot.sound]
+ℹ [338/371] Replayed PlutusCore.UPLC.LiftedSearchProofs
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:122:0: 'PlutusCore.UPLC.LiftedSearch.scan_correct' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:124:0: 'PlutusCore.UPLC.LiftedSearch.empty_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:125:0: 'PlutusCore.UPLC.LiftedSearch.hit_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:126:0: 'PlutusCore.UPLC.LiftedSearch.miss_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [339/371] Replayed PlutusCore.UPLC.LiftedSearchRecognize
+info: PlutusCore/UPLC/LiftedSearchRecognize.lean:117:0: 'PlutusCore.UPLC.LiftedSearch.recognizeCall' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchRecognize.lean:119:0: 'PlutusCore.UPLC.LiftedSearch.bodyWitness' does not depend on any axioms
+info: PlutusCore/UPLC/LiftedSearchRecognize.lean:120:0: 'PlutusCore.UPLC.LiftedSearch.readyWitness' depends on axioms: [propext, Quot.sound]
+ℹ [340/371] Replayed PlutusCore.UPLC.LiftedSearchFastRecognize
+info: PlutusCore/UPLC/LiftedSearchFastRecognize.lean:91:0: 'PlutusCore.UPLC.LiftedSearch.recognizeFast_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [341/371] Replayed PlutusCore.UPLC.LiftedMapSearchFastRecognize
+info: PlutusCore/UPLC/LiftedMapSearchFastRecognize.lean:91:0: 'PlutusCore.UPLC.LiftedMapSearch.recognizeFast_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [342/371] Replayed PlutusCore.UPLC.RecursiveCalls
+info: PlutusCore/UPLC/RecursiveCalls.lean:24:0: 'PlutusCore.UPLC.RecursiveCalls.recognize_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+⚠ [343/371] Replayed PlutusCore.UPLC.LoopCek
+warning: PlutusCore/UPLC/LoopCek.lean:60:21: unused variable `h`
+
+Note: This linter can be disabled with `set_option linter.unusedVariables false`
+⚠ [347/371] Built PlutusCore.UPLC.LoopCekProofs (3.0s)
+warning: PlutusCore/UPLC/LoopCekProofs.lean:55:26: try 'simp' instead of 'simpa'
+
+Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
+warning: PlutusCore/UPLC/LoopCekProofs.lean:57:29: This simp argument is unused:
+  hp
+
+Hint: Omit it from the simp argument list.
+  simp only ̵[̵h̵p̵]̵
+
+Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
+warning: PlutusCore/UPLC/LoopCekProofs.lean:66:31: This simp argument is unused:
+  hw
+
+Hint: Omit it from the simp argument list.
+  simp only [h̵w̵,̵ ̵lt]
+
+Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
+info: PlutusCore/UPLC/LoopCekProofs.lean:120:0: 'PlutusCore.UPLC.LoopCek.run_eq_runSteps' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LoopCekProofs.lean:121:0: 'PlutusCore.UPLC.LoopCek.execute_eq' depends on axioms: [propext, Classical.choice, Quot.sound]
+✔ [348/371] Built PlutusCore.UPLC.PreProcess (976ms)
+✔ [349/371] Built PlutusCore.UPLC (574ms)
+✔ [350/371] Built PlutusCore.Basic (746ms)
+ℹ [351/371] Built Tests.Benchmarks.LiftedTemplateSource (854ms)
+info: Tests/Benchmarks/LiftedTemplateSource.lean:7:0: Successfully decoded single CBOR hex 'Tests/Scripts/SellNFT/sell_nft.flat'
+info: Tests/Benchmarks/LiftedTemplateSource.lean:26:0: 'LiftedTemplateSource.LiftedSearch_in_script' does not depend on any axioms
+info: Tests/Benchmarks/LiftedTemplateSource.lean:31:0: 'LiftedTemplateSource.LiftedMapSearch_in_script' does not depend on any axioms
+✔ [352/371] Built PlutusCore (590ms)
+ℹ [353/371] Built Tests.Benchmarks.LoopCekControl (1.6s)
+info: Tests/Benchmarks/LoopCekControl.lean:52:0: LoopCekShadowing ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:59:0: LoopCekMissingName ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:64:0: LoopCekLookupFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:69:0: LoopCekCapturedEnvironment ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:76:0: LoopCekHaltAtZeroFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:80:0: LoopCekErrorAtZeroFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:83:0: LoopCekApplyNonFunction ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:88:0: LoopCekWrongForceTag ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:93:0: LoopCekConstructor ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:98:0: LoopCekApplication ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:103:0: LoopCekApplicationExhaustion ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:108:0: LoopCekConstructorFieldOrder ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:113:0: LoopCekCaseApplicationOrder ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:119:0: LoopCekCaseOutOfBounds ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:123:0: LoopCekPrimitiveCase ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:128:0: LoopCekPrimitiveCaseArity ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:132:0: LoopCekNegativeCaseIndex ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:152:0: LoopCekRecognizesUnusedCapture ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:157:0: LoopCekRejectsShadowedBuiltin ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:160:0: LoopCekLiftedHit ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:164:0: LoopCekLiftedHitFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:168:0: LoopCekLiftedRecursion ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:173:0: LoopCekLiftedRecursiveFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:178:0: LoopCekLiftedMalformedUnmatchedPayload ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:182:0: LoopCekFallbackPreservesUnusedBadBinding ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:190:0: LoopCekRejectsDifferentKeyTemplate ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:193:0: LoopCekFallbackUsesChangedKey ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:204:0: LoopCekMapRecognizesUnusedCapture ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:209:0: LoopCekMapRejectsShadowedBuiltin ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:212:0: LoopCekMapHit ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:217:0: LoopCekMapHitFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:222:0: LoopCekMapRecursion ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:227:0: LoopCekMapRecursiveFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:232:0: LoopCekMapMalformedUnmatchedPayload ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:236:0: LoopCekMapMalformedKey ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:239:0: LoopCekMapEmpty ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:243:0: LoopCekMapEmptyFuel ✅ Success!
+✔ [354/371] Built CardanoLedgerApi.IsData.Class (736ms)
+✔ [355/371] Built CardanoLedgerApi.V1.Scripts (889ms)
+✔ [356/371] Built CardanoLedgerApi.V3.Tx (966ms)
+✔ [357/371] Built CardanoLedgerApi.V1.Time (1.3s)
+✔ [358/371] Built CardanoLedgerApi.V1.Value (1.6s)
+✔ [359/371] Built CardanoLedgerApi.V1.Credential (1.1s)
+✔ [360/371] Built CardanoLedgerApi.V1.Address (770ms)
+✔ [361/371] Built CardanoLedgerApi.V1.DCert (1.3s)
+✔ [362/371] Built CardanoLedgerApi.V1.Tx (771ms)
+✔ [363/371] Built CardanoLedgerApi.V2.Tx (977ms)
+✔ [364/371] Built CardanoLedgerApi.V1.Contexts (1.9s)
+✔ [365/371] Built CardanoLedgerApi.V1 (735ms)
+✔ [366/371] Built CardanoLedgerApi.V2.Contexts (1.7s)
+✔ [367/371] Built CardanoLedgerApi.V2 (576ms)
+✔ [368/371] Built CardanoLedgerApi.V3.TxCert (3.9s)
+✔ [369/371] Built CardanoLedgerApi.V3.Governance (1.5s)
+✔ [370/371] Built CardanoLedgerApi.V3.Contexts (2.0s)
+✔ [371/371] Built CardanoLedgerApi.V3 (605ms)
+Build completed successfully (371 jobs).

--- a/Benchmarks/cardano_bench.py
+++ b/Benchmarks/cardano_bench.py
@@ -27,6 +27,7 @@ parser.add_argument('--reduce-before-arguments', action='store_true', help='Redu
 parser.add_argument('--retain-constructor-choices', action='store_true', help='Keep conditionals and matches inside constructor fields during preparation')
 parser.add_argument('--retain-choice-types', nargs='*', default=[], help='Label selected inductive types or constructors to retain field choices')
 parser.add_argument('--staged-cek', action='store_true', help='Use the verified fused CEK prototype (requires staged preparation patches)')
+parser.add_argument('--lifted-search', action='store_true', help='Use certified recursive search workers; requires staged-cek and the named CEK overlay')
 parser.add_argument('--specialize-functions', nargs='*', default=[], help='Specialize NAME:INDEX when its one-based argument has a known constructor')
 parser.add_argument('--profile-normalize', action='store_true', help='Opt-in normalization-head timings; diagnostic runs only')
 parser.add_argument('--acceptance-only', action='store_true', help='Validate existing global goldens through the exact interpreter and input conversion')
@@ -47,8 +48,17 @@ if any(not re.fullmatch(r'[A-Za-z_][A-Za-z0-9_.]*', n) for n in a.retain_choice_
     parser.error('retain-choice-types must be fully qualified Lean declaration names')
 if any(not re.fullmatch(r'[A-Za-z_][A-Za-z0-9_.]*:[1-9][0-9]*', n) for n in a.specialize_functions):
     parser.error('specialize-functions requires qualified NAME:INDEX entries')
+if a.lifted_search and (not a.staged_cek or any(c.split(':')[0]=='global' for c in a.cases)):
+    parser.error('--lifted-search requires --staged-cek and named CEK cases')
 if a.staged_cek:
     defaults = ['PlutusCore.UPLC.StagedCek.eval:2', 'PlutusCore.UPLC.StagedCek.ret:2', 'PlutusCore.UPLC.StagedCek.lookupValue:1']
+    if a.lifted_search:
+        defaults = [n.replace('.StagedCek.', '.LoopCek.') for n in defaults]
+        defaults += ['PlutusCore.UPLC.StagedCek.lookupValue:1', 'PlutusCore.UPLC.RecursiveCalls.recognize:2']
+        for worker in ['LiftedMapSearch', 'LiftedSearch']:
+            defaults += [f'PlutusCore.UPLC.{worker}.{name}:{index}' for name, index in
+                         [('recognizeFast', 2), ('bodyWitness', 1), ('bodyMatches', 1),
+                          ('readyMatch', 1), ('bindingsMatch', 1), ('worker', 3), ('scan', 1)]]
     for entry in defaults:
         if not any(n.split(':')[0] == entry.split(':')[0] for n in a.specialize_functions):
             a.specialize_functions.append(entry)
@@ -85,7 +95,7 @@ result={'label':a.label,'repeat':a.repeat,'timeout_seconds':a.timeout,'rss_limit
         'machine':{'system':platform.system(),'release':platform.release(),'architecture':platform.machine(),'logical_cpus':os.cpu_count()},
         'runner_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
         'acceptance_fixture_sha256':hashlib.sha256((Path(__file__).parent/'cardano/fixtures/GlobalAcceptance.lean').read_bytes()).hexdigest(),
-        'staged_cek':a.staged_cek,'specialize_functions':a.specialize_functions,'retain_choice_types':a.retain_choice_types,'retain_constructor_choices':a.retain_constructor_choices,'reduce_before_arguments':a.reduce_before_arguments,
+        'staged_cek':a.staged_cek,'lifted_search':a.lifted_search,'specialize_functions':a.specialize_functions,'retain_choice_types':a.retain_choice_types,'retain_constructor_choices':a.retain_constructor_choices,'reduce_before_arguments':a.reduce_before_arguments,
         'cpu_sample':a.sample,'profile_normalize':a.profile_normalize,'phase':('proof' if a.proofs_only else 'acceptance' if a.acceptance_only else 'conversion' if a.conversion_only else 'prep'),
         'allocator_env':{k:v for k,v in os.environ.items() if k.startswith('MIMALLOC_')},'runs':[]}
 
@@ -122,6 +132,8 @@ end WSC.Benchmark
         text = text.replace(prep_line, replacement)
     if a.staged_cek:
         text=text.replace('set_option maxHeartbeats 0', 'set_option plutuscore.stagedCek true\nset_option maxHeartbeats 0')
+    if a.lifted_search:
+        text=text.replace('set_option maxHeartbeats 0', 'set_option plutuscore.liftedSearch true\nset_option maxHeartbeats 0')
     if a.specialize_functions:
         for entry in a.specialize_functions:
             fn,index=entry.split(':')
@@ -233,11 +245,16 @@ end WSC.Benchmark
             if row['status']=='running': row['status']='completed' if proc.returncode==0 else 'error'
             if sampler is not None: sampler.wait(timeout=15)
         content=log.read_text()
-        row['interpreter'] = re.findall(r'^PREP_INTERPRETER staged=(true|false)$', content, re.M)
+        row['interpreter'] = re.findall(r'^PREP_INTERPRETER staged=(true|false)(?: lifted_search=(?:true|false))?$', content, re.M)
         if a.staged_cek and not (a.proofs_only or a.acceptance_only or a.conversion_only) and row['status'] == 'completed':
             if row['interpreter'] != ['true']:
                 row['status'] = 'error'
                 row['reason'] = 'staged interpreter activation was not confirmed'
+        row['lifted_search'] = re.findall(r'^PREP_INTERPRETER staged=true lifted_search=(true|false)$', content, re.M)
+        if a.lifted_search and not (a.proofs_only or a.acceptance_only or a.conversion_only) and row['status'] == 'completed':
+            if row['lifted_search'] != ['true']:
+                row['status'] = 'error'
+                row['reason'] = 'recursive search activation was not confirmed'
         row['profiles'] = [json.loads(m[1]) for m in re.finditer(r'BLASTER_PROFILE (.+)$',content,re.M)]
         if a.profile_normalize and profile_log.exists():
             for line in profile_log.read_text().splitlines():


### PR DESCRIPTION
SellNFT preparation repeatedly interprets two recursive association-list searches through the CEK machine. This adds an opt-in adapter that recognizes their complete bodies and captured bindings, then calls direct Lean workers. On three serial, alternating pairs with fully symbolic SellNFT inputs at the original fuel 1800, median optimizer time falls from **22.874 s to 18.348 s** (19.8%). Preparation plus proof-checking wall time falls from **64.216 s to 57.502 s** (10.5%).

The workers preserve exact remaining CEK fuel, malformed-data behavior, lexical shadowing, and arbitrary continuations. Kernel-checked theorems establish equivalence for every state, input, fuel, and semantics variant. Runtime dispatch uses an unindexed worker record; a separate theorem connects it to the proof-carrying certificate. Unsupported bodies and environments use the ordinary evaluator. The executable `.exec` definition is unchanged.

This is an adapter for the pinned **named-variable** PlutusCore used by the Cardano examples, installed by `prepare_local.py --staged-cek --lifted-search`. It remains off by default. PlutusCore [PR #44](https://github.com/input-output-hk/PlutusCoreBlaster/pull/44) targets the indexed interpreter, so these legacy modules are packaged alongside the existing benchmark adapters. Open PRs were checked: #44 and [PlutusCore #42](https://github.com/input-output-hk/PlutusCoreBlaster/pull/42) are related but do not provide these workers.

Stacked on #246, which fixes the dependent-matcher failure discovered during integration and includes `Issue245.lean` for #245. This PR adds no further core Blaster optimizer changes.

Validation:

- Fresh pinned installation; all tracked sources in the four workload/interpreter checkouts and the generated fixtures match the tested workspace byte for byte.
- Native Lake build passed (371 jobs), including **37 `#testOptimize` controls** and two axiom-free certificates identifying the templates in the decoded production script.
- `LoopCek.run_eq_runSteps` and `execute_eq` depend only on `propext`, `Classical.choice`, and `Quot.sound`; no `sorryAx`, `native_decide`, or `blasterProven` in the equivalence proofs.
- Three unprofiled alternating SellNFT pairs preserve the same verdict sequence: two `Valid`, the existing 30-second timeout on `success_imp_no_multi_spent`, and two `Expected Falsified`. The timeout remains an error and is included in reported wall time; these are not all-successful proof runs.
- Final hash-cons entries: 8,271,491 → 5,510,804 (33.4% fewer); median sampled preparation RSS: 2.203 → 2.033 GiB.
- The base core Blaster suite passed all 729 jobs serially. Python compilation and `git diff --check` passed for this adapter.

The sub-10-second goal is still open. Governance has no supported template and incurs overhead if the switch is forced, so keep it disabled there. The report also records rejected single-search variants that introduced an additional negative-control timeout; the published two-search candidate restores the reference outcomes.

Reproduction instructions, raw result metadata, validation output, and explicitly labeled log excerpts are in [`Benchmarks/cardano/results/recursive-search-2026-09-09`](Benchmarks/cardano/results/recursive-search-2026-09-09/README.md). The [adapter guide](Benchmarks/cardano/overlays/lifted-search/README.md) describes recognition and exact fuel costs.
