### PR TITLE
Reduce optimizer stack allocation

### DIFF
--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/README.md
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/README.md
@@ -1,0 +1,43 @@
+# Fused optimizer stack: paired Cardano measurements
+
+Storing each continuation frame and its tail in one constructor reduces median optimizer time by **3.3% for SellNFT** and **4.2% for Governance** in three serial pairs. This is a modest generic allocation improvement; neither script reaches the sub-10-second preparation target.
+
+The measured candidate is `da7a50e1`, based on PR #247 (`40786b22`, whose code matches reference `71dfe27f`). The only runtime change is the optimizer stack representation. Every rewrite action, continuation payload, and evaluation order is preserved. Known frame construction inlines to one stack constructor, and the generated C return path reads the payload and tail directly instead of reading a separate list cell and frame. Rewrites that return a standalone `OptimizeFrame` retain that intermediate value until it is pushed.
+
+## Measurements
+
+All inputs are symbolic. Fuel is 1800 for SellNFT and 9000 for Governance. Both arms use the fused CEK and static-control annotations. SellNFT enables the two certified search workers in both arms; Governance leaves them disabled. Dependencies were built before measurement. Profiling was off, and no other owned build or benchmark ran concurrently.
+
+Each arm runs preparation followed immediately by its proof module. Pair 1 is labeled `scout`; pairs 2 and 3 confirm the same unchanged candidate. Arm order is reference/candidate, candidate/reference, reference/candidate. The results come from the existing M2 Max machine with Lean 4.24.0 and Z3 4.15.2 (`-T:30`). Raw metadata records all repository pins, tracked patch hashes, generated-source and runner hashes, memory samples, verdicts, and timings.
+
+| Contract | Pair | Reference optimizer (s) | Candidate optimizer (s) | Reference prep + proofs wall (s) | Candidate prep + proofs wall (s) |
+| --- | --- | ---: | ---: | ---: | ---: |
+| sellnft | 1 | 17.924 | 17.637 | 56.852 | 57.231 |
+| sellnft | 2 | 18.236 | 16.928 | 57.506 | 55.804 |
+| sellnft | 3 | 18.356 | 17.906 | 57.539 | 57.037 |
+| sellnft | **Median** | **18.236** | **17.637** | **57.506** | **57.037** |
+| governance | 1 | 20.947 | 20.066 | 27.694 | 26.566 |
+| governance | 2 | 20.835 | 20.130 | 27.158 | 26.538 |
+| governance | 3 | 21.066 | 20.067 | 27.719 | 26.612 |
+| governance | **Median** | **20.947** | **20.067** | **27.694** | **26.566** |
+
+| Median wall metric | SellNFT reference | SellNFT candidate | Governance reference | Governance candidate |
+| --- | ---: | ---: | ---: | ---: |
+| Preparation module (s) | 20.458 | 19.941 | 23.267 | 22.136 |
+| Proof module (s) | 37.016 | 37.082 | 4.429 | 4.429 |
+
+Whole preparation improves by 2.5% for SellNFT and 4.9% for Governance. Median paired preparation-plus-proof wall time improves by 0.8% and 4.1%. SellNFT pair 1 has a small total-wall regression; this is not a claim that every run or proof phase is faster.
+
+Every SellNFT arm preserves two `Valid` properties, the existing timeout in `success_imp_no_multi_spent`, and two `Expected Falsified` controls, including acceptance/non-vacuity. The proof module therefore exits with an error in both arms. Its approximately 37-second wall time includes the 30-second timeout and is not time to successful completion of all proofs. Every Governance arm preserves its four `Valid` checks.
+
+Final hash-cons entries, context IDs, beta-cache entries, and prepared module sizes are identical within each contract. SellNFT has 5,510,804 entries, 29,234 contexts, 23,802 beta entries, and an 818,288-byte prepared module; Governance has 5,070,520 entries, 17,761 contexts, 17,985 beta entries, and a 2,216,312-byte module. The representation change reduces transient stack work, not the number of normalized expressions. No memory reduction is claimed.
+
+## Validation and scope
+
+The native full Blaster suite passed all 732 jobs. The new `StackRepresentation.lean` theorems prove round-trip conversion for every frame payload and arbitrary stack depth, using only `propext`. These are representation proofs, not a new formal proof of the whole optimizer. Existing tests exercise the actual optimizer, including Issue245 and scoped cache regressions. The Cardano dependency/control build passed 371 jobs, including all 37 recursive-search controls and production-template certificates.
+
+The packaged installer recreated a source-only workspace from the measured commit. All tracked files in all five repositories and six generated control/source-certificate fixtures were byte-identical to the built benchmark workspace. This source-only check did not itself rebuild dependencies; the measured workspace's native build is the execution evidence. Selected validation output is in `validation.log`. Log excerpts are explicitly labeled; full logs remain local.
+
+PR #160 was inspected for overlap: its ancestor-cache/context changes retain `List OptimizeStack` and do not provide this representation. This PR is an optimization, not a newly discovered bug fix. Existing issue regressions remain intact.
+
+Reproduce with `prepare_local.py --staged-cek --lifted-search --blaster-rev da7a50e1` using the local source repositories described in the benchmark guide. Run preparation and proof phases serially with matching flags. Enable `--lifted-search` for SellNFT only. No stack-specific runtime flag is needed.

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20130 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=3 command_ms=20768
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (370 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate-proof.json
@@ -1,0 +1,81 @@
+{
+  "label": "fused-stack-pair2-governance-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1724973056,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.428991833003238,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20130 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=3 command_ms=20768
+Build completed successfully (369 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-candidate.json
@@ -1,0 +1,88 @@
+{
+  "label": "fused-stack-pair2-governance-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2021900288,
+      "prep": {
+        "optimize_ms": 20130,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 22.108880082843825,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 3,
+          "command_ms": 20768
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20835 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=4 command_ms=21493
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (370 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference-proof.json
@@ -1,0 +1,81 @@
+{
+  "label": "fused-stack-pair2-governance-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1736638464,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.434482790995389,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20835 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=4 command_ms=21493
+Build completed successfully (369 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-governance-reference.json
@@ -1,0 +1,88 @@
+{
+  "label": "fused-stack-pair2-governance-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2024275968,
+      "prep": {
+        "optimize_ms": 20835,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 22.723036208888516,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 4,
+          "command_ms": 21493
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=16928 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=17635
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate-proof.json
@@ -1,0 +1,97 @@
+{
+  "label": "fused-stack-pair2-sellnft-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2259746816,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.026055875001475,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=16928 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=17635
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-candidate.json
@@ -1,0 +1,104 @@
+{
+  "label": "fused-stack-pair2-sellnft-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2184839168,
+      "prep": {
+        "optimize_ms": 16928,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 18.778363874880597,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 17635
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18236 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18969
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference-proof.json
@@ -1,0 +1,97 @@
+{
+  "label": "fused-stack-pair2-sellnft-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2266562560,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.04830341693014,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18236 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18969
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair2-sellnft-reference.json
@@ -1,0 +1,104 @@
+{
+  "label": "fused-stack-pair2-sellnft-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2183593984,
+      "prep": {
+        "optimize_ms": 18236,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 20.45779858296737,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 18969
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20067 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=4 command_ms=20674
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (370 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate-proof.json
@@ -1,0 +1,81 @@
+{
+  "label": "fused-stack-pair3-governance-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1750794240,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.435407999902964,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20067 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=4 command_ms=20674
+Build completed successfully (369 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-candidate.json
@@ -1,0 +1,88 @@
+{
+  "label": "fused-stack-pair3-governance-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2021998592,
+      "prep": {
+        "optimize_ms": 20067,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 22.176147792022675,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 4,
+          "command_ms": 20674
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=21066 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=3 command_ms=21747
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (370 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference-proof.json
@@ -1,0 +1,81 @@
+{
+  "label": "fused-stack-pair3-governance-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1768718336,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.428919875063002,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=21066 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=3 command_ms=21747
+Build completed successfully (369 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-governance-reference.json
@@ -1,0 +1,88 @@
+{
+  "label": "fused-stack-pair3-governance-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2024833024,
+      "prep": {
+        "optimize_ms": 21066,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 23.290096125099808,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 3,
+          "command_ms": 21747
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=17906 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18604
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate-proof.json
@@ -1,0 +1,97 @@
+{
+  "label": "fused-stack-pair3-sellnft-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2270461952,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.08208283316344,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=17906 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18604
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-candidate.json
@@ -1,0 +1,104 @@
+{
+  "label": "fused-stack-pair3-sellnft-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2183413760,
+      "prep": {
+        "optimize_ms": 17906,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 19.95513837481849,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 18604
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18356 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=19119
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference-proof.json
@@ -1,0 +1,97 @@
+{
+  "label": "fused-stack-pair3-sellnft-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2269954048,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.01648908294737,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=18356 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=19119
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-pair3-sellnft-reference.json
@@ -1,0 +1,104 @@
+{
+  "label": "fused-stack-pair3-sellnft-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2182922240,
+      "prep": {
+        "optimize_ms": 18356,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 20.522392458980903,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 19119
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20066 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=7 command_ms=20742
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (370 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate-proof.json
@@ -1,0 +1,81 @@
+{
+  "label": "fused-stack-scout-governance-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1731526656,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.429466875037178,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20066 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=7 command_ms=20742
+Build completed successfully (369 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-candidate.json
@@ -1,0 +1,88 @@
+{
+  "label": "fused-stack-scout-governance-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2026356736,
+      "prep": {
+        "optimize_ms": 20066,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 22.13608504110016,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 7,
+          "command_ms": 20742
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20947 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=6 command_ms=21589
+info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: ✅ Valid
+Build completed successfully (370 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference-proof.json
@@ -1,0 +1,81 @@
+{
+  "label": "fused-stack-scout-governance-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 1720778752,
+      "prep": {},
+      "source_sha256": "a48166a408953e0ad20d407c49b6490a712ecdd92abbda4734caee0dca20a733",
+      "elapsed_seconds": 4.427255125017837,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:51:52: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:59:54: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:67:37: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:75:54: \u2705 Valid"
+      ],
+      "olean_bytes": 1302792
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:17:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=false
+PREP_METRICS optimize_ms=20947 hashcons=5070520 contexts=17761 beta_cache=17985
+PREP_PHASE declaration_ms=6 command_ms=21589
+Build completed successfully (369 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-governance-reference.json
@@ -1,0 +1,88 @@
+{
+  "label": "fused-stack-scout-governance-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": false,
+  "specialize_functions": [
+    "PlutusCore.UPLC.StagedCek.eval:2",
+    "PlutusCore.UPLC.StagedCek.ret:2",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "governance",
+      "budget": 9000,
+      "repeat": 1,
+      "status": "completed",
+      "log": "governance-9000-1.log",
+      "sampled_peak_rss_bytes": 2023309312,
+      "prep": {
+        "optimize_ms": 20947,
+        "hashcons": 5070520,
+        "contexts": 17761,
+        "beta_cache": 17985
+      },
+      "source_sha256": "b856527165c1b3e6c92220556965091daf6641fdad3a9fb8b816b9b260d36196",
+      "elapsed_seconds": 23.26657741703093,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "false"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 6,
+          "command_ms": 21589
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 2216312
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=17637 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=6 command_ms=18395
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate-proof.json
@@ -1,0 +1,97 @@
+{
+  "label": "fused-stack-scout-sellnft-candidate-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2266382336,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 37.289808084024116,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=0
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=17637 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=6 command_ms=18395
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-candidate.json
@@ -1,0 +1,104 @@
+{
+  "label": "fused-stack-scout-sellnft-candidate",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "da7a50e144deb89583b4d0474c2af63a3871a781",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2186117120,
+      "prep": {
+        "optimize_ms": 17637,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 19.941070708911866,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 0
+        },
+        {
+          "declaration_ms": 6,
+          "command_ms": 18395
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference-proof.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference-proof.excerpt.txt
@@ -1,0 +1,10 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=17924 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18624
+info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: ✅ Valid
+info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: ✅ Valid
+error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout
+info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: ✅ Expected Falsified
+info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: ✅ Expected Falsified

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference-proof.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference-proof.json
@@ -1,0 +1,97 @@
+{
+  "label": "fused-stack-scout-sellnft-reference-proof",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "proof",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "error",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2249277440,
+      "prep": {},
+      "source_sha256": "2c7d97533811d09f667337f41375bc9c40b091b873fab8ccccde885250d933ca",
+      "elapsed_seconds": 36.944117582868785,
+      "exit_code": 1,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [],
+      "acceptance": [],
+      "verdicts": [
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:69:30: \u2705 Valid",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:76:54: \u2705 Valid",
+        "error: Tests/Benchmarks/CardanoPerfProofs.lean:86:0: checkSat: Unexpected check-sat result: timeout",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:95:72: \u2705 Expected Falsified",
+        "info: Tests/Benchmarks/CardanoPerfProofs.lean:103:55: \u2705 Expected Falsified"
+      ]
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference.excerpt.txt
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference.excerpt.txt
@@ -1,0 +1,6 @@
+Selected telemetry/verdict lines from the complete local build log.
+info: Tests/Benchmarks/CardanoPerfCase.lean:31:0: PREP_PHASE input_construct_ms=1
+PREP_INTERPRETER staged=true lifted_search=true
+PREP_METRICS optimize_ms=17924 hashcons=5510804 contexts=29234 beta_cache=23802
+PREP_PHASE declaration_ms=5 command_ms=18624
+Build completed successfully (362 jobs).

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference.json
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/fused-stack-scout-sellnft-reference.json
@@ -1,0 +1,104 @@
+{
+  "label": "fused-stack-scout-sellnft-reference",
+  "repeat": 1,
+  "timeout_seconds": 120.0,
+  "rss_limit_bytes": 12884901888,
+  "lean": "Lean (version 4.24.0, arm64-apple-darwin23.6.0, commit 797c613eb9b6d4ec95db23e3e00af9ac6657f24b, Release)",
+  "pins": {
+    "cardano": {
+      "commit": "7245eb8d6faf6764ed6d3551ddcae3fc08cd301b",
+      "tracked_patch_sha256": "04235b965a210f5d6604c1ec19cf52ded43b81ff94a672290509e3f3d227161d"
+    },
+    "wsc": {
+      "commit": "58b8b670cd9ae218c56d21ae2ecbfc5da6e77a12",
+      "tracked_patch_sha256": "f9b54b8a3b5bbc6471e784bf48b4f9a34127c0c59df931cc91d6d4eb102a9805"
+    },
+    "blaster": {
+      "commit": "71dfe27f3b0b05fa0a7d095a46f1ba0b9a67dcc2",
+      "tracked_patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "plutuscore": {
+      "commit": "073950e49a11ea58ca432d6a0da39294e4d2ce50",
+      "tracked_patch_sha256": "b4306cdffebf6a25f6129a9db3ce1d948b0116e58ff678ef7978b85aa6043f35"
+    },
+    "plutuscore-wsc": {
+      "commit": "5f2baa2a965388dbf0bf9ef36b82bb05ea8074c8",
+      "tracked_patch_sha256": "1b80d27e6bc928c340ae3d5081ed85014b0455f2b4808ed75595c865f19194c8"
+    }
+  },
+  "machine": {
+    "system": "Darwin",
+    "release": "25.5.0",
+    "architecture": "arm64",
+    "logical_cpus": 12
+  },
+  "runner_sha256": "feb3a27f49d2e245c4eebafe5c46ccb677f218b8d911fbf29ac61467373c5d61",
+  "acceptance_fixture_sha256": "f863fe07484be59eeb8fc550f4dafa3427908c9fcd0fdad4d2f6036f6893f4f2",
+  "staged_cek": true,
+  "lifted_search": true,
+  "specialize_functions": [
+    "PlutusCore.UPLC.LoopCek.eval:2",
+    "PlutusCore.UPLC.LoopCek.ret:2",
+    "PlutusCore.UPLC.LoopCek.lookupValue:1",
+    "PlutusCore.UPLC.StagedCek.lookupValue:1",
+    "PlutusCore.UPLC.RecursiveCalls.recognize:2",
+    "PlutusCore.UPLC.LiftedMapSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedMapSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedMapSearch.worker:3",
+    "PlutusCore.UPLC.LiftedMapSearch.scan:1",
+    "PlutusCore.UPLC.LiftedSearch.recognizeFast:2",
+    "PlutusCore.UPLC.LiftedSearch.bodyWitness:1",
+    "PlutusCore.UPLC.LiftedSearch.bodyMatches:1",
+    "PlutusCore.UPLC.LiftedSearch.readyMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.bindingsMatch:1",
+    "PlutusCore.UPLC.LiftedSearch.worker:3",
+    "PlutusCore.UPLC.LiftedSearch.scan:1"
+  ],
+  "retain_choice_types": [],
+  "retain_constructor_choices": false,
+  "reduce_before_arguments": false,
+  "cpu_sample": false,
+  "profile_normalize": false,
+  "phase": "prep",
+  "allocator_env": {},
+  "runs": [
+    {
+      "case": "sellnft",
+      "budget": 1800,
+      "repeat": 1,
+      "status": "completed",
+      "log": "sellnft-1800-1.log",
+      "sampled_peak_rss_bytes": 2183299072,
+      "prep": {
+        "optimize_ms": 17924,
+        "hashcons": 5510804,
+        "contexts": 29234,
+        "beta_cache": 23802
+      },
+      "source_sha256": "56fc27ee26722ada1e00cd403f1041bc604cf885cad1e92a726540f29c032fe2",
+      "elapsed_seconds": 19.908321958966553,
+      "exit_code": 0,
+      "interpreter": [
+        "true"
+      ],
+      "lifted_search": [
+        "true"
+      ],
+      "profiles": [],
+      "phases": [
+        {
+          "input_construct_ms": 1
+        },
+        {
+          "declaration_ms": 5,
+          "command_ms": 18624
+        }
+      ],
+      "acceptance": [],
+      "olean_bytes": 818288
+    }
+  ]
+}

--- a/Benchmarks/cardano/results/fused-stack-2026-09-09/validation.log
+++ b/Benchmarks/cardano/results/fused-stack-2026-09-09/validation.log
@@ -1,0 +1,88 @@
+Selected validation lines from fused-stack-tests.log
+ℹ [260/732] Built Tests.Optimize.StackRepresentation (4.8s)
+info: Tests/Optimize/StackRepresentation.lean:55:0: 'Tests.StackRepresentation.toList_ofList' depends on axioms: [propext]
+info: Tests/Optimize/StackRepresentation.lean:56:0: 'Tests.StackRepresentation.ofList_toList' depends on axioms: [propext]
+✔ [417/732] Built Tests.Optimize.StackRepresentation:c.o (1.9s)
+ℹ [426/732] Built Tests.FixedIssues.Issue245 (1.6s)
+info: Tests/FixedIssues/Issue245.lean:24:0: IndexedPlanFallback ✅ Success!
+info: Tests/FixedIssues/Issue245.lean:26:0: IndexedPlanSelected ✅ Success!
+info: Tests/FixedIssues/Issue245.lean:29:0: IndexedPlanSymbolicFallback ✅ Success!
+info: Tests/FixedIssues/Issue245.lean:39:0: IndexedProofSelected ✅ Success!
+info: Tests/FixedIssues/Issue245.lean:40:0: IndexedProofFallback ✅ Success!
+✔ [571/732] Built Tests.Optimize.StackRepresentation:dynlib (65ms)
+✔ [582/732] Built Tests.FixedIssues.Issue245:dynlib (72ms)
+Build completed successfully (732 jobs).
+Selected validation lines from fused-stack-warm.log
+info: PlutusCore/UPLC/StagedCekProofs.lean:100:0: 'PlutusCore.UPLC.StagedCek.run_eq_runSteps' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/StagedCekProofs.lean:101:0: 'PlutusCore.UPLC.StagedCek.execute_eq' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/CekBlocks.lean:63:0: 'PlutusCore.UPLC.CekBlocks.compose' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/CekBlocks.lean:64:0: 'PlutusCore.UPLC.CekBlocks.shorter_error' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:122:0: 'PlutusCore.UPLC.LiftedMapSearch.scan_correct' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:124:0: 'PlutusCore.UPLC.LiftedMapSearch.empty_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:125:0: 'PlutusCore.UPLC.LiftedMapSearch.hit_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchProofs.lean:126:0: 'PlutusCore.UPLC.LiftedMapSearch.miss_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchRecognize.lean:117:0: 'PlutusCore.UPLC.LiftedMapSearch.recognizeCall' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchRecognize.lean:119:0: 'PlutusCore.UPLC.LiftedMapSearch.bodyWitness' does not depend on any axioms
+info: PlutusCore/UPLC/LiftedMapSearchRecognize.lean:120:0: 'PlutusCore.UPLC.LiftedMapSearch.readyWitness' depends on axioms: [propext, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:122:0: 'PlutusCore.UPLC.LiftedSearch.scan_correct' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:124:0: 'PlutusCore.UPLC.LiftedSearch.empty_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:125:0: 'PlutusCore.UPLC.LiftedSearch.hit_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchProofs.lean:126:0: 'PlutusCore.UPLC.LiftedSearch.miss_block' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchRecognize.lean:117:0: 'PlutusCore.UPLC.LiftedSearch.recognizeCall' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchRecognize.lean:119:0: 'PlutusCore.UPLC.LiftedSearch.bodyWitness' does not depend on any axioms
+info: PlutusCore/UPLC/LiftedSearchRecognize.lean:120:0: 'PlutusCore.UPLC.LiftedSearch.readyWitness' depends on axioms: [propext, Quot.sound]
+info: PlutusCore/UPLC/LiftedSearchFastRecognize.lean:91:0: 'PlutusCore.UPLC.LiftedSearch.recognizeFast_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LiftedMapSearchFastRecognize.lean:91:0: 'PlutusCore.UPLC.LiftedMapSearch.recognizeFast_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/RecursiveCalls.lean:24:0: 'PlutusCore.UPLC.RecursiveCalls.recognize_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LoopCekProofs.lean:120:0: 'PlutusCore.UPLC.LoopCek.run_eq_runSteps' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: PlutusCore/UPLC/LoopCekProofs.lean:121:0: 'PlutusCore.UPLC.LoopCek.execute_eq' depends on axioms: [propext, Classical.choice, Quot.sound]
+ℹ [351/371] Built Tests.Benchmarks.LiftedTemplateSource (827ms)
+info: Tests/Benchmarks/LiftedTemplateSource.lean:7:0: Successfully decoded single CBOR hex 'Tests/Scripts/SellNFT/sell_nft.flat'
+info: Tests/Benchmarks/LiftedTemplateSource.lean:26:0: 'LiftedTemplateSource.LiftedSearch_in_script' does not depend on any axioms
+info: Tests/Benchmarks/LiftedTemplateSource.lean:31:0: 'LiftedTemplateSource.LiftedMapSearch_in_script' does not depend on any axioms
+ℹ [353/371] Built Tests.Benchmarks.LoopCekControl (1.6s)
+info: Tests/Benchmarks/LoopCekControl.lean:52:0: LoopCekShadowing ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:59:0: LoopCekMissingName ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:64:0: LoopCekLookupFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:69:0: LoopCekCapturedEnvironment ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:76:0: LoopCekHaltAtZeroFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:80:0: LoopCekErrorAtZeroFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:83:0: LoopCekApplyNonFunction ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:88:0: LoopCekWrongForceTag ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:93:0: LoopCekConstructor ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:98:0: LoopCekApplication ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:103:0: LoopCekApplicationExhaustion ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:108:0: LoopCekConstructorFieldOrder ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:113:0: LoopCekCaseApplicationOrder ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:119:0: LoopCekCaseOutOfBounds ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:123:0: LoopCekPrimitiveCase ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:128:0: LoopCekPrimitiveCaseArity ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:132:0: LoopCekNegativeCaseIndex ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:152:0: LoopCekRecognizesUnusedCapture ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:157:0: LoopCekRejectsShadowedBuiltin ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:160:0: LoopCekLiftedHit ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:164:0: LoopCekLiftedHitFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:168:0: LoopCekLiftedRecursion ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:173:0: LoopCekLiftedRecursiveFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:178:0: LoopCekLiftedMalformedUnmatchedPayload ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:182:0: LoopCekFallbackPreservesUnusedBadBinding ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:190:0: LoopCekRejectsDifferentKeyTemplate ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:193:0: LoopCekFallbackUsesChangedKey ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:204:0: LoopCekMapRecognizesUnusedCapture ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:209:0: LoopCekMapRejectsShadowedBuiltin ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:212:0: LoopCekMapHit ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:217:0: LoopCekMapHitFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:222:0: LoopCekMapRecursion ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:227:0: LoopCekMapRecursiveFuel ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:232:0: LoopCekMapMalformedUnmatchedPayload ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:236:0: LoopCekMapMalformedKey ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:239:0: LoopCekMapEmpty ✅ Success!
+info: Tests/Benchmarks/LoopCekControl.lean:243:0: LoopCekMapEmptyFuel ✅ Success!
+Build completed successfully (371 jobs).
+Source-only installer verification:
+blaster: 444 tracked files byte-identical
+cardano: 60 tracked files byte-identical
+wsc: 380 tracked files byte-identical
+plutuscore: 1231 tracked files byte-identical
+plutuscore-wsc: 1195 tracked files byte-identical
+All six generated control/source-certificate fixtures byte-identical.

--- a/Blaster/Optimize/Basic.lean
+++ b/Blaster/Optimize/Basic.lean
@@ -12,9 +12,9 @@ open Lean Elab Command Term Meta Blaster.Options
 namespace Blaster.Optimize
 
 -- TODO: update formalization with inference rule style notation.
-partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr := do
+partial def optimizeExprAux (stack : OptimizeStack) : TranslateEnvT Expr := do
   match stack with
-  | .InitOptimizeExpr e mvarDecls :: xs =>
+  | .InitOptimizeExpr e mvarDecls ::: xs =>
       match (← isInOptimizeEnvCache e xs mvarDecls) with
       | Sum.inl i_stack =>
           -- trace[Optimize.expr] "optimizing {← ppExpr e}"
@@ -25,7 +25,7 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
               | Sum.inl stack' => optimizeExprAux stack'
 
           | Expr.mvar _ =>
-              optimizeExprAux (.InitOptimizeExpr (← getMVarValue e) :: i_stack)
+              optimizeExprAux (.InitOptimizeExpr (← getMVarValue e) ::: i_stack)
 
           | Expr.sort l =>
               -- sort is used for Type u, Prop, etc
@@ -50,9 +50,9 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
                    let x := reuse.fvars[0]!
                    setAndCommitCtx reuse.scope
                    let body ← instantiateShared1 b x
-                   optimizeExprAux (.InitOptimizeExpr body :: .ForallWaitForBody x t (some reuse.scope) true :: i_stack)
+                   optimizeExprAux (.InitOptimizeExpr body ::: .ForallWaitForBody x t (some reuse.scope) true ::: i_stack)
 
-              | none => optimizeExprAux (.InitOptimizeExpr t :: .ForallWaitForType n bi b :: i_stack)
+              | none => optimizeExprAux (.InitOptimizeExpr t ::: .ForallWaitForType n bi b ::: i_stack)
 
           | Expr.app f a =>
              let f ← if f.isMVar then getMVarValue f else pure f
@@ -61,39 +61,39 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
              if f.isLambda then
                -- perform beta reduction and apply optimization
                let betaRes ← betaLambdaEnv f ras
-               optimizeExprAux (.InitOptimizeExpr betaRes.betaReduced betaRes.prevMVarIdDecls :: i_stack)
+               optimizeExprAux (.InitOptimizeExpr betaRes.betaReduced betaRes.prevMVarIdDecls ::: i_stack)
              else
                -- set inFunApp flag before optimizing `f`
                setInFunApp true
-               let i_stack' := .AppWaitForConst ras :: i_stack
-               optimizeExprAux (.InitOptimizeExpr f :: i_stack')
+               let i_stack' := .AppWaitForConst ras ::: i_stack
+               optimizeExprAux (.InitOptimizeExpr f ::: i_stack')
 
           | Expr.lam n t b bi =>
                if ← isPropEnv t then
                  -- skip proof term
-                 match (← stackContinuity (.LambdaWaitForType n bi b :: i_stack) t) with
+                 match (← stackContinuity (.LambdaWaitForType n bi b ::: i_stack) t) with
                  | Sum.inl stack' => optimizeExprAux stack'
                  | _ => throwEnvError "optimizeExprAux: continuity expected for LambdaWaitForType !!!"
-               else optimizeExprAux (.InitOptimizeExpr t :: .LambdaWaitForType n bi b :: i_stack)
+               else optimizeExprAux (.InitOptimizeExpr t ::: .LambdaWaitForType n bi b ::: i_stack)
 
           | Expr.letE _n _t v b _ => optimizeExprAux (inlineLet v b i_stack) -- inline let expression
 
           | Expr.mdata d me =>
               if (isTaggedRecursiveCall e) then
                 setNormalizeFunCall false
-                optimizeExprAux (.InitOptimizeExpr me :: .MDataRecCallWaitForExpr d :: i_stack)
-              else optimizeExprAux (.InitOptimizeExpr me :: i_stack)
+                optimizeExprAux (.InitOptimizeExpr me ::: .MDataRecCallWaitForExpr d ::: i_stack)
+              else optimizeExprAux (.InitOptimizeExpr me ::: i_stack)
 
           | Expr.proj n idx s =>
-              let i_stack' := .ProjWaitForExpr n idx :: i_stack
-              optimizeExprAux (.InitOptimizeExpr s :: i_stack')
+              let i_stack' := .ProjWaitForExpr n idx ::: i_stack
+              optimizeExprAux (.InitOptimizeExpr s ::: i_stack')
 
           | Expr.bvar .. => throwEnvError "optimizeExpr: unexpected bound variable {e}"
 
       | Sum.inr (Sum.inr e') => return e'
       | Sum.inr (Sum.inl stack') => optimizeExprAux stack'
 
-  | .RecFunDefStorage uargs instApp subsInst params optDef startCtxId :: xs =>
+  | .RecFunDefStorage uargs instApp subsInst params optDef startCtxId ::: xs =>
         uncacheFunName instApp
         -- clean-up rewrite cache
         freeRewriteCacheRange startCtxId (← get).optEnv.options.nextCtxId
@@ -104,74 +104,74 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
         | Sum.inr e => return e
         | Sum.inl stack' => optimizeExprAux stack'
 
-  | .InitNonFunOptimizeArgs f args idx stopIdx :: xs =>
+  | .InitNonFunOptimizeArgs f args idx stopIdx ::: xs =>
          -- try to apply funPropagation to avoid optimizing ite/match multiple times
          if let some r ← funPropagation? f args (resolveArgs := true) (← isAppArg) then
-           optimizeExprAux (r :: xs)
+           optimizeExprAux (r ::: xs)
          else
            let prevInCtor ← isCtorArg
            setIsCtorArg (← isCtorExpr f)
-           optimizeExprAux (.NonFunOptimizeArgs f args idx stopIdx prevInCtor :: xs)
+           optimizeExprAux (.NonFunOptimizeArgs f args idx stopIdx prevInCtor ::: xs)
 
-  | .NonFunOptimizeArgs f args idx stopIdx prevInCtor :: xs =>
+  | .NonFunOptimizeArgs f args idx stopIdx prevInCtor ::: xs =>
         if idx ≥ stopIdx then
           -- restore previous isCtorArg flag
           setIsCtorArg prevInCtor
           match (← finalizeNonFunApp f args xs) with
           | Sum.inr e' => return e'
           | Sum.inl stack' => optimizeExprAux stack'
-        else optimizeExprAux (.InitOptimizeExpr args[idx]! :: stack)
+        else optimizeExprAux (.InitOptimizeExpr args[idx]! ::: stack)
 
-  | .AppOptimizeImplicitArgs f args idx startIdx stopIdx pInfo prevInApp :: xs =>
+  | .AppOptimizeImplicitArgs f args idx startIdx stopIdx pInfo prevInApp ::: xs =>
        if idx ≥ stopIdx then
          -- normalizing ite/match function application first to
          -- avoid handling extra args in optimizeDITEChoice, matchReduction and funPropagation
          if let some re ← normChoiceApplication? f args prevInApp then
            -- trace[Optimize.normChoiceApp] "normalizing choice application {reprStr f} {reprStr args} => {reprStr re}"
-           optimizeExprAux (re :: xs)
+           optimizeExprAux (re ::: xs)
          else if isBlasterDiteConst f && args.size ≥ 2 then
            -- applying choice reduction to avoid optimizing unreachable arguments in Blaster.dite'
            setIsAppArg true
            let condOpt := .InitOptimizeExpr args[1]!
-           optimizeExprAux (condOpt :: .DiteChoiceWaitForCond f args pInfo prevInApp :: xs)
+           optimizeExprAux (condOpt ::: .DiteChoiceWaitForCond f args pInfo prevInApp ::: xs)
          else if let some mInfo ← isMatcher? f then
             -- try match reduction rule first to avoid unnecessary optimization on discriminators
             if let some r ← matchReduction? f args mInfo (resolveArgs := true) prevInApp then
-              optimizeExprAux (r :: xs)
+              optimizeExprAux (r ::: xs)
             else
               -- applying choice reduction and match constant propagation to
               -- avoid optimizing unreachable rhs in match
               -- only optimizing match return type and discriminators first
               setIsAppArg true
-              optimizeExprAux (.MatchChoiceOptimizeDiscrs f args pInfo (mInfo.getFirstDiscrPos - 1) mInfo prevInApp :: xs)
+              optimizeExprAux (.MatchChoiceOptimizeDiscrs f args pInfo (mInfo.getFirstDiscrPos - 1) mInfo prevInApp ::: xs)
          else if let some r ← specializeApp? f args then
            setIsAppArg prevInApp
-           optimizeExprAux (.InitOptimizeExpr r.betaReduced r.prevMVarIdDecls :: xs)
+           optimizeExprAux (.InitOptimizeExpr r.betaReduced r.prevMVarIdDecls ::: xs)
          else if let some argIdx ← specializationArg? f args then
            setIsAppArg true
-           optimizeExprAux (.InitOptimizeExpr args[argIdx]! ::
-             .SpecializeWaitForArg f args argIdx startIdx pInfo prevInApp :: xs)
+           optimizeExprAux (.InitOptimizeExpr args[argIdx]! :::
+             .SpecializeWaitForArg f args argIdx startIdx pInfo prevInApp ::: xs)
          -- try to apply funPropagation to avoid optimizing ite/match multiple times
          else if let some r ← funPropagation? f args (reorderArgs := true) (resolveArgs := true) prevInApp then
-           optimizeExprAux (r :: xs)
+           optimizeExprAux (r ::: xs)
          -- apply optimization on remaining explicit parameters before reduction
-         else optimizeExprAux (.AppOptimizeExplicitArgs f args startIdx args.size pInfo none prevInApp :: xs)
+         else optimizeExprAux (.AppOptimizeExplicitArgs f args startIdx args.size pInfo none prevInApp ::: xs)
 
        else if idx < pInfo.paramsInfo.size -- handle case when HOF is the returned type
             then if !pInfo.paramsInfo[idx]!.isExplicit
-                 then optimizeExprAux (.InitOptimizeExpr args[idx]! :: stack)
-                 else optimizeExprAux (.AppOptimizeImplicitArgs f args (idx + 1) startIdx stopIdx pInfo prevInApp :: xs)
-            else optimizeExprAux (.AppOptimizeImplicitArgs f args (idx + 1) startIdx stopIdx pInfo prevInApp :: xs)
+                 then optimizeExprAux (.InitOptimizeExpr args[idx]! ::: stack)
+                 else optimizeExprAux (.AppOptimizeImplicitArgs f args (idx + 1) startIdx stopIdx pInfo prevInApp ::: xs)
+            else optimizeExprAux (.AppOptimizeImplicitArgs f args (idx + 1) startIdx stopIdx pInfo prevInApp ::: xs)
 
-  | .SpecializeReady f args startIdx pInfo prevInApp :: xs =>
+  | .SpecializeReady f args startIdx pInfo prevInApp ::: xs =>
        if let some r ← specializeApp? f args then
          setIsAppArg prevInApp
-         optimizeExprAux (.InitOptimizeExpr r.betaReduced r.prevMVarIdDecls :: xs)
+         optimizeExprAux (.InitOptimizeExpr r.betaReduced r.prevMVarIdDecls ::: xs)
        else if let some r ← funPropagation? f args (reorderArgs := true) (resolveArgs := true) prevInApp then
-         optimizeExprAux (r :: xs)
-       else optimizeExprAux (.AppOptimizeExplicitArgs f args startIdx args.size pInfo none prevInApp :: xs)
+         optimizeExprAux (r ::: xs)
+       else optimizeExprAux (.AppOptimizeExplicitArgs f args startIdx args.size pInfo none prevInApp ::: xs)
 
-  | .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp :: xs =>
+  | .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp ::: xs =>
        if idx ≥ stopIdx then
          -- restore previous isAppArg flag
          setIsAppArg prevInApp
@@ -190,11 +190,11 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
          -- NOTE: we can only unfold once all parameters have been optimized.
          else if let some fdef ← getUnfoldFunDef? f args then
            -- trace[Optimize.unfoldDef] "unfolding function definition {reprStr f} {reprStr args} => {reprStr fdef}"
-           optimizeExprAux (.InitOptimizeExpr fdef.betaReduced fdef.prevMVarIdDecls :: xs)
+           optimizeExprAux (.InitOptimizeExpr fdef.betaReduced fdef.prevMVarIdDecls ::: xs)
          -- normalizing partially apply function after unfolding non-opaque functions
          else if let some pe ← normPartialFun? f args then
            -- trace[Optimize.normPartial] "normalizing partial function {reprStr f} {reprStr args} => {reprStr pe}"
-           optimizeExprAux (.InitOptimizeExpr pe :: xs)
+           optimizeExprAux (.InitOptimizeExpr pe ::: xs)
          -- applying optimization on opaque rec function and app and proceed with fun propagation rules
          else
            match (← optimizeApp f args xs) with
@@ -203,67 +203,67 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
        else if idx < pInfo.paramsInfo.size
             then if pInfo.paramsInfo[idx]!.isExplicit
                  then optimizeExprAux (← optimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp stack xs)
-                 else optimizeExprAux (.AppOptimizeExplicitArgs f args (idx + 1) stopIdx pInfo mInfo prevInApp :: xs)
-            else optimizeExprAux (.InitOptimizeExpr args[idx]! :: stack)
+                 else optimizeExprAux (.AppOptimizeExplicitArgs f args (idx + 1) stopIdx pInfo mInfo prevInApp ::: xs)
+            else optimizeExprAux (.InitOptimizeExpr args[idx]! ::: stack)
 
-  | .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp :: xs =>
+  | .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp ::: xs =>
         if idx ≥ mInfo.getFirstAltPos then
           -- restore prevous isAppArg flag
           setIsAppArg prevInApp
           if let some r ← matchReduction? f args mInfo (matchToIte := true) prevInApp then
-            optimizeExprAux (r :: xs)
+            optimizeExprAux (r ::: xs)
           else
             -- apply optimization on remaining explicit parameters before reduction
             -- keep matchInfo to avoid unnecessary query and to avoid optimizing discriminators again
-            optimizeExprAux (.AppOptimizeExplicitArgs f args mInfo.getFirstAltPos args.size pInfo mInfo prevInApp :: xs)
-        else optimizeExprAux (.InitOptimizeExpr args[idx]! :: stack)
+            optimizeExprAux (.AppOptimizeExplicitArgs f args mInfo.getFirstAltPos args.size pInfo mInfo prevInApp ::: xs)
+        else optimizeExprAux (.InitOptimizeExpr args[idx]! ::: stack)
 
-  | .MatchRhsLambdaNext next :: xs =>
+  | .MatchRhsLambdaNext next ::: xs =>
       match next with
       | Expr.lam n t b bi =>
-          optimizeExprAux (.MatchLhsSkipForallType t :: .MatchRhsLambdaWaitForType n bi b :: xs)
+          optimizeExprAux (.MatchLhsSkipForallType t ::: .MatchRhsLambdaWaitForType n bi b ::: xs)
       | _ =>
          -- header on xs is expected to be .MatchRhsLambdaWaitForBody
          match (← stackContinuity xs next) with
          | Sum.inl stack' => optimizeExprAux stack'
          | _ => throwEnvError "optimizeExprAux: continuity expected for MatchRhsLambdaNext !!!"
 
-  | .MatchLhsSkipForallType e :: xs =>
+  | .MatchLhsSkipForallType e ::: xs =>
       match e with
       | Expr.forallE n t b bi =>
           let stack' ←
             withLocalDecl' n bi t fun x => do
-              pure $ .MatchLhsSkipForallType (← instantiateShared1 b x) :: .MatchLhsForallWaitForBody x :: xs
+              pure $ .MatchLhsSkipForallType (← instantiateShared1 b x) ::: .MatchLhsForallWaitForBody x ::: xs
           optimizeExprAux stack'
-      | _ => optimizeExprAux (.InitOptimizeExpr e :: xs) -- optimize lhs body
+      | _ => optimizeExprAux (.InitOptimizeExpr e ::: xs) -- optimize lhs body
 
   | _ => throwEnvError "optimizeExprAux: unexpected optimize stack continuity {reprStr stack} !!!"
 
   where
     @[always_inline, inline]
-    finalizeNonFunApp (f : Expr) (args : Array Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+    finalizeNonFunApp (f : Expr) (args : Array Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
       if ← isCtorExpr f
       then optimizeConstApp f args stack
       else stackContinuity stack (← mkAppNExpr f args)
 
     /-- Given `e := Expr.fVar fv` perform the following:
          - When `some v := fv.getValue?`
-             - return `Sum.inl (.InitOptimizeExpr v :: stack)`
+             - return `Sum.inl (.InitOptimizeExpr v ::: stack)`
          - Otherwise:
              - return `stackContinuity stack (← mkExpr e)`
     -/
     @[always_inline, inline]
-    normFVar (e : Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+    normFVar (e : Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
       match ← e.fvarId!.getEnvValue? with
       | none => stackContinuity stack e
-      | some v => return Sum.inl (.InitOptimizeExpr (← hashcons v) :: stack)
+      | some v => return Sum.inl (.InitOptimizeExpr (← hashcons v) ::: stack)
 
     @[always_inline, inline]
-    inlineLet (v : Expr) (body : Expr) (stack : List OptimizeStack) : List OptimizeStack :=
-      (.InitOptimizeExpr v :: .LetWaitForValue body :: stack)
+    inlineLet (v : Expr) (body : Expr) (stack : OptimizeStack) : OptimizeStack :=
+      (.InitOptimizeExpr v ::: .LetWaitForValue body ::: stack)
 
     @[always_inline, inline]
-    optimizeDiteArg (e : Expr) (cond : Expr) (isThen : Bool) (stack : List OptimizeStack) : TranslateEnvT (List OptimizeStack) := do
+    optimizeDiteArg (e : Expr) (cond : Expr) (isThen : Bool) (stack : OptimizeStack) : TranslateEnvT (OptimizeStack) := do
       match e with
       | Expr.lam n _t b bi =>
            let mkCond (c : Expr) : TranslateEnvT Expr := do
@@ -274,39 +274,39 @@ partial def optimizeExprAux (stack : List OptimizeStack) : TranslateEnvT Expr :=
                let x := reuse.fvars[0]!
                setAndCommitCtx reuse.scope
                let body ← instantiateShared1 b x
-               return .InitOptimizeExpr body :: .LambdaWaitForBody x (some reuse.scope) true 0 :: stack
+               return .InitOptimizeExpr body ::: .LambdaWaitForBody x (some reuse.scope) true 0 ::: stack
            | none =>
                let t' ← mkCond cond
                withLocalDecl' n bi t' fun x => do
                  let bodyOpt := .InitOptimizeExpr (← instantiateShared1 b x)
                  let mscope ← addHypotheses t' x
-                 return bodyOpt :: .LambdaWaitForBody x mscope true 0 :: stack
+                 return bodyOpt ::: .LambdaWaitForBody x mscope true 0 ::: stack
       | Expr.mvar _ => optimizeDiteArg (← getMVarValue e) cond isThen stack
-      | _ => return .InitOptimizeExpr e :: stack
+      | _ => return .InitOptimizeExpr e ::: stack
 
     @[always_inline, inline]
     optimizeExplicitArgs
      (f : Expr) (args : Array Expr) (idx : Nat) (_stopIdx : Nat)
      (_pInfo : FunEnvInfo) (mInfo : Option MatchInfo) (_prevInApp : Bool)
-     (stack : List OptimizeStack) (_nxtStack : List OptimizeStack) : TranslateEnvT (List OptimizeStack) := do
+     (stack : OptimizeStack) (_nxtStack : OptimizeStack) : TranslateEnvT (OptimizeStack) := do
       let currArg := args[idx]!
       if isBlasterDiteConst f then
          -- NOTE: optimization on Blaster.dite' cond already performed at this stage
          -- and idx starts as from 2 (see continuation for DiteChoiceWaitForCond)
         if idx == 2 || idx == 3 then
           optimizeDiteArg currArg args[1]! (idx == 2) stack
-        else return (.InitOptimizeExpr currArg :: stack)
+        else return (.InitOptimizeExpr currArg ::: stack)
       else if let some argInfo := mInfo then
          -- NOTE: optimization on discriminators already performed at this stage
          -- and idx starts as from getFirstDiscrPos (see continuation for MatchChoiceOptimizeDiscrs).
          if idx >= argInfo.getFirstAltPos && idx < argInfo.arity then
            optimizeMatchAlt args argInfo idx currArg stack
-         else return (.InitOptimizeExpr currArg :: stack)
-      else return (.InitOptimizeExpr currArg :: stack)
+         else return (.InitOptimizeExpr currArg ::: stack)
+      else return (.InitOptimizeExpr currArg ::: stack)
 
 @[always_inline, inline]
 def optimizeExpr (e : Expr) : TranslateEnvT Expr :=
-  optimizeExprAux [.InitOptimizeExpr e]
+  optimizeExprAux (.InitOptimizeExpr e ::: .nil)
 
 /-- Populate the `recFunInstCache` with opaque recursive function definition.
     This function need to be call before performing optimization on a lean expression.
@@ -324,7 +324,7 @@ def cacheOpaqueRecFun : TranslateEnvT Unit := do
 
  where
    callOptimize (e : Expr) (params := #[]) : TranslateEnvT Unit := do
-     match ← normRecFun e params e [] with
+     match ← normRecFun e params e .nil with
      | Sum.inr _ => return ()
      | Sum.inl stack' => discard $ optimizeExprAux stack'
 

--- a/Blaster/Optimize/OptimizeStack.lean
+++ b/Blaster/Optimize/OptimizeStack.lean
@@ -13,7 +13,7 @@ abbrev HypsStackContext := Option CtxScope -- context scope to close on exit
 instance : Repr (Option MVarIdDecls) where
   reprPrec _ _ := "<MVarIdDecls>"
 
-inductive OptimizeStack where
+inductive OptimizeFrame where
  | InitOptimizeExpr (e : Expr) (mvarDecls : Option MVarIdDecls := none)
  | InitOptimizeReturn (e : Expr) (isGlobal : Bool) (mvarDecls : Option MVarIdDecls)
  | RecFunDefWaitForStorage (args : Array Expr) (instApp : Expr)
@@ -54,7 +54,86 @@ inductive OptimizeStack where
  | ProjWaitForExpr (n : Name) (idx : Nat)
  deriving Repr
 
-abbrev OptimizeContinuity := Sum (List OptimizeStack) Expr
+
+/-- The continuation stack stores a frame and its tail in one heap object.
+    OptimizeFrame remains the return type of rewrites producing one next step. -/
+inductive OptimizeStack where
+ | nil
+ | InitOptimizeExpr (e : Expr) (mvarDecls : Option MVarIdDecls := none) (tail : OptimizeStack)
+ | InitOptimizeReturn (e : Expr) (isGlobal : Bool) (mvarDecls : Option MVarIdDecls) (tail : OptimizeStack)
+ | RecFunDefWaitForStorage (args : Array Expr) (instApp : Expr)
+                           (subsInts : Expr) (params : ImplicitParameters) (startCtxId : CtxId) (tail : OptimizeStack)
+ | RecFunDefStorage (args : Array Expr) (instApp : Expr)
+                    (subsInts : Expr) (params : ImplicitParameters) (optBody : Expr)
+                    (startCtxId : CtxId) (tail : OptimizeStack)
+ | ForallWaitForType (n : Name) (bi : BinderInfo) (body : Expr) (tail : OptimizeStack)
+ | ForallWaitForBody (x : Expr) (t : Expr) (hctx : HypsStackContext) (isProp : Bool) (tail : OptimizeStack)
+ | AppWaitForConst (args : Array Expr) (tail : OptimizeStack)
+ | OptimizeMatchInfoWaitForInst (f : Expr) (args : Array Expr)
+                                (startArgIdx : Nat) (pInfo : FunEnvInfo) (mInfo : MatcherRecInfo) (tail : OptimizeStack)
+ | AppOptimizeImplicitArgs (f : Expr) (args : Array Expr) (idx : Nat)
+                           (startArgIdx : Nat) (stopIdx : Nat)
+                           (pInfo : FunEnvInfo) (prevInApp : Bool) (tail : OptimizeStack)
+ | SpecializeWaitForArg (f : Expr) (args : Array Expr) (argIdx startIdx : Nat)
+                        (pInfo : FunEnvInfo) (prevInApp : Bool) (tail : OptimizeStack)
+ | SpecializeReady (f : Expr) (args : Array Expr) (startIdx : Nat)
+                   (pInfo : FunEnvInfo) (prevInApp : Bool) (tail : OptimizeStack)
+ | AppOptimizeExplicitArgs (f : Expr) (args : Array Expr) (idx : Nat)
+                           (stopIdx : Nat) (pInfo : FunEnvInfo)
+                           (mInfo : Option MatchInfo) (prevInApp : Bool) (tail : OptimizeStack)
+ | InitNonFunOptimizeArgs (f : Expr) (args : Array Expr) (idx : Nat) (stopIdx : Nat) (tail : OptimizeStack)
+ | NonFunOptimizeArgs (f : Expr) (args : Array Expr) (idx : Nat) (stopIdx : Nat) (prevInCtor : Bool) (tail : OptimizeStack)
+ | DiteChoiceWaitForCond (f : Expr) (args : Array Expr) (pInfo : FunEnvInfo) (prevInApp : Bool) (tail : OptimizeStack)
+ | MatchChoiceOptimizeDiscrs (f : Expr) (args : Array Expr) (pInfo : FunEnvInfo)
+                             (idx : Nat) (mInfo : MatchInfo) (prevInApp : Bool) (tail : OptimizeStack)
+ | LambdaWaitForType (n : Name) (bi : BinderInfo) (body : Expr) (tail : OptimizeStack)
+ | LambdaWaitForBody (x : Expr) (hctx : HypsStackContext) (inDite : Bool) (startCtxId : CtxId) (tail : OptimizeStack)
+ | MatchRhsLambdaWaitForType (n : Name) (bi : BinderInfo) (body : Expr) (tail : OptimizeStack)
+ | MatchRhsLambdaNext (e : Expr) (tail : OptimizeStack)
+ | MatchRhsLambdaWaitForBody (x : Expr) (tail : OptimizeStack)
+ | MatchLhsSkipForallType (e : Expr) (tail : OptimizeStack)
+ | MatchLhsForallWaitForBody (e : Expr) (tail : OptimizeStack)
+ | MatchAltWaitForExpr (params : Array Expr) (hctx : HypsStackContext) (idx : USize) (matchInst : Expr) (tail : OptimizeStack)
+ | LetWaitForValue (body : Expr) (tail : OptimizeStack)
+ | MDataRecCallWaitForExpr (data : MData) (tail : OptimizeStack)
+ | ProjWaitForExpr (n : Name) (idx : Nat) (tail : OptimizeStack)
+ deriving Repr, Inhabited
+
+/-- Inline construction fuses a known frame with its tail. The match-pattern
+    attribute also lets the evaluator keep its frame-oriented case notation. -/
+@[always_inline, inline, match_pattern]
+def OptimizeStack.push : OptimizeFrame → OptimizeStack → OptimizeStack
+ | .InitOptimizeExpr e mvarDecls, tail => .InitOptimizeExpr e mvarDecls tail
+ | .InitOptimizeReturn e isGlobal mvarDecls, tail => .InitOptimizeReturn e isGlobal mvarDecls tail
+ | .RecFunDefWaitForStorage args instApp subsInts params startCtxId, tail => .RecFunDefWaitForStorage args instApp subsInts params startCtxId tail
+ | .RecFunDefStorage args instApp subsInts params optBody startCtxId, tail => .RecFunDefStorage args instApp subsInts params optBody startCtxId tail
+ | .ForallWaitForType n bi body, tail => .ForallWaitForType n bi body tail
+ | .ForallWaitForBody x t hctx isProp, tail => .ForallWaitForBody x t hctx isProp tail
+ | .AppWaitForConst args, tail => .AppWaitForConst args tail
+ | .OptimizeMatchInfoWaitForInst f args startArgIdx pInfo mInfo, tail => .OptimizeMatchInfoWaitForInst f args startArgIdx pInfo mInfo tail
+ | .AppOptimizeImplicitArgs f args idx startArgIdx stopIdx pInfo prevInApp, tail => .AppOptimizeImplicitArgs f args idx startArgIdx stopIdx pInfo prevInApp tail
+ | .SpecializeWaitForArg f args argIdx startIdx pInfo prevInApp, tail => .SpecializeWaitForArg f args argIdx startIdx pInfo prevInApp tail
+ | .SpecializeReady f args startIdx pInfo prevInApp, tail => .SpecializeReady f args startIdx pInfo prevInApp tail
+ | .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp, tail => .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp tail
+ | .InitNonFunOptimizeArgs f args idx stopIdx, tail => .InitNonFunOptimizeArgs f args idx stopIdx tail
+ | .NonFunOptimizeArgs f args idx stopIdx prevInCtor, tail => .NonFunOptimizeArgs f args idx stopIdx prevInCtor tail
+ | .DiteChoiceWaitForCond f args pInfo prevInApp, tail => .DiteChoiceWaitForCond f args pInfo prevInApp tail
+ | .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp, tail => .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp tail
+ | .LambdaWaitForType n bi body, tail => .LambdaWaitForType n bi body tail
+ | .LambdaWaitForBody x hctx inDite startCtxId, tail => .LambdaWaitForBody x hctx inDite startCtxId tail
+ | .MatchRhsLambdaWaitForType n bi body, tail => .MatchRhsLambdaWaitForType n bi body tail
+ | .MatchRhsLambdaNext e, tail => .MatchRhsLambdaNext e tail
+ | .MatchRhsLambdaWaitForBody x, tail => .MatchRhsLambdaWaitForBody x tail
+ | .MatchLhsSkipForallType e, tail => .MatchLhsSkipForallType e tail
+ | .MatchLhsForallWaitForBody e, tail => .MatchLhsForallWaitForBody e tail
+ | .MatchAltWaitForExpr params hctx idx matchInst, tail => .MatchAltWaitForExpr params hctx idx matchInst tail
+ | .LetWaitForValue body, tail => .LetWaitForValue body tail
+ | .MDataRecCallWaitForExpr data, tail => .MDataRecCallWaitForExpr data tail
+ | .ProjWaitForExpr n idx, tail => .ProjWaitForExpr n idx tail
+
+infixr:67 " ::: " => OptimizeStack.push
+
+abbrev OptimizeContinuity := Sum (OptimizeStack) Expr
 
 
 @[always_inline, inline]
@@ -98,11 +177,11 @@ def isInEqualityMap (e : Expr) (isGlobal : Bool) : TranslateEnvT Expr := do
     | none => return e
     | some b => return b
 
-def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := false) : TranslateEnvT OptimizeContinuity := do
+def stackContinuity (stack : OptimizeStack) (optExpr : Expr) (skipCache := false) : TranslateEnvT OptimizeContinuity := do
   match stack with
-  | [] => return Sum.inr optExpr
+  | .nil => return Sum.inr optExpr
 
-  | .InitOptimizeReturn e isGlobal mvarDecls :: xs =>
+  | .InitOptimizeReturn e isGlobal mvarDecls ::: xs =>
        let optExpr ← isInEqualityMap optExpr isGlobal
        if !skipCache then
          updateOptimizeEnvCache optExpr optExpr isGlobal
@@ -110,41 +189,41 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
        restoreMVarDecls mvarDecls
        profileLeave
        match xs with
-       | [] => return Sum.inr optExpr
+       | .nil => return Sum.inr optExpr
        | _ => stackContinuity xs optExpr
 
-  | .RecFunDefWaitForStorage args instApp subsInst params startCtxId :: xs =>
+  | .RecFunDefWaitForStorage args instApp subsInst params startCtxId ::: xs =>
        -- optExpr corresponds to optimized rec fun body
        -- continuity with normOpaqueAndRecFun
-       return Sum.inl (.RecFunDefStorage args instApp subsInst params optExpr startCtxId :: xs)
+       return Sum.inl (.RecFunDefStorage args instApp subsInst params optExpr startCtxId ::: xs)
 
-  | .ForallWaitForType n bi body :: xs =>
+  | .ForallWaitForType n bi body ::: xs =>
        -- optExpr corresponds to optimized forall binder type
        -- check forall reduction to avoid optimizing body
        let isProp ← isPropEnv (← mkForallExpr n bi optExpr body)
        if let some r ← forallReduction? optExpr body isProp then
          match r with
          | Expr.const ``True _ => stackContinuity xs r
-         | _ => return Sum.inl ( .InitOptimizeExpr r :: xs)
+         | _ => return Sum.inl ( .InitOptimizeExpr r ::: xs)
        else
          -- continuity with optimizing forall body
           withLocalDecl' n bi optExpr fun x => do
             let body' ← instantiateShared1 body x
             let mscope ← addHypotheses optExpr x (isPropBody := isProp)
-            return Sum.inl ( .InitOptimizeExpr body' :: .ForallWaitForBody x optExpr mscope isProp :: xs)
+            return Sum.inl ( .InitOptimizeExpr body' ::: .ForallWaitForBody x optExpr mscope isProp ::: xs)
 
-  | .ForallWaitForBody x t hctx isProp :: xs =>
+  | .ForallWaitForBody x t hctx isProp ::: xs =>
        -- optExpr corresponds to optimized forall body
        -- continuity with applying forall normalization rules.
        let e ← optimizeForall x t optExpr hctx isProp
        resetContext hctx
        if ← isRestart then
          resetRestart
-         return Sum.inl (.InitOptimizeExpr e :: xs)
+         return Sum.inl (.InitOptimizeExpr e ::: xs)
        else -- continuity with optimizing next expression
          stackContinuity xs e
 
-  | .AppWaitForConst args :: xs =>
+  | .AppWaitForConst args ::: xs =>
        -- optExpr corresponds to optimized fun app
        -- reset inFunApp flag
        setInFunApp false
@@ -152,13 +231,13 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
        if optExpr.isLambda then
          -- perform beta reduction and apply optimization
          let betaRes ← betaLambdaEnv optExpr (← resolveMVarsArgs #[] args)
-         return Sum.inl (.InitOptimizeExpr betaRes.betaReduced betaRes.prevMVarIdDecls :: xs)
+         return Sum.inl (.InitOptimizeExpr betaRes.betaReduced betaRes.prevMVarIdDecls ::: xs)
        else
          let (rf, extraArgs) := getAppFnWithArgs optExpr
          let args ← resolveMVarsArgs extraArgs args
          let is_match ← isMatchExpr rf
          if (← isNotFun rf <&&> pure !is_match) then
-            return Sum.inl (.InitNonFunOptimizeArgs rf args extraArgs.size args.size :: xs)
+            return Sum.inl (.InitNonFunOptimizeArgs rf args extraArgs.size args.size ::: xs)
          else
            let pInfo ← getFunEnvInfo rf
            -- apply optimization on match generic instance (if necessary)
@@ -167,7 +246,7 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
               -- continuity with optimization on implicit arguments
               let prevInApp ← isAppArg
               if !(isBlasterDiteConst rf) then setIsAppArg true
-              return Sum.inl (.AppOptimizeImplicitArgs rf args extraArgs.size extraArgs.size args.size pInfo prevInApp :: xs)
+              return Sum.inl (.AppOptimizeImplicitArgs rf args extraArgs.size extraArgs.size args.size pInfo prevInApp ::: xs)
            | some (mInfo, instApp) =>
               -- continuity with optimizing match generic instance
               -- NOTE: instApp is expected to be a lambda term
@@ -175,13 +254,13 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
               -- correspond to the match lhs.
               match instApp with
               | Expr.lam n t b bi =>
-                    let mWait := .OptimizeMatchInfoWaitForInst rf args extraArgs.size pInfo mInfo :: xs
+                    let mWait := .OptimizeMatchInfoWaitForInst rf args extraArgs.size pInfo mInfo ::: xs
                     -- NOTE: we only optimize the lhs forall body and not the types.
-                    return Sum.inl (.MatchLhsSkipForallType t :: .MatchRhsLambdaWaitForType n bi b :: mWait)
+                    return Sum.inl (.MatchLhsSkipForallType t ::: .MatchRhsLambdaWaitForType n bi b ::: mWait)
               | _ => throwEnvError "stackContinuity: lambda expected for match instance but got {reprStr instApp}"
 
 
-  | .OptimizeMatchInfoWaitForInst f args startArgIdx pInfo mInfo :: xs =>
+  | .OptimizeMatchInfoWaitForInst f args startArgIdx pInfo mInfo ::: xs =>
        -- optExpr corresponds to optimized match generic instance
        -- update cache isMatcherCache
        if let Expr.const n _ := f then
@@ -191,32 +270,32 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
          -- we don't consider explicit parameters at this stage to avoid performing
          -- optimization on unreachable arguments
          let prevInApp ← isAppArg
-         return Sum.inl (.AppOptimizeImplicitArgs f args startArgIdx startArgIdx args.size pInfo prevInApp :: xs)
+         return Sum.inl (.AppOptimizeImplicitArgs f args startArgIdx startArgIdx args.size pInfo prevInApp ::: xs)
        else throwEnvError "stackContinuity: name expression for match application but got {reprStr f} !!!"
 
-  | .NonFunOptimizeArgs f args idx stopIdx prevInCtor :: xs =>
+  | .NonFunOptimizeArgs f args idx stopIdx prevInCtor ::: xs =>
        -- optExpr corresponds to the optimized non-fun argument referenced by idx.
        -- continuity with optimizing the next implicit argument.
        -- Perform backward proof reconstruction in ctor/applied theorem (if necessary)
        let optExpr ← normNonFunProof idx f args optExpr
-       return Sum.inl (.NonFunOptimizeArgs f (args.set! idx optExpr) (idx + 1) stopIdx prevInCtor :: xs)
+       return Sum.inl (.NonFunOptimizeArgs f (args.set! idx optExpr) (idx + 1) stopIdx prevInCtor ::: xs)
 
-  | .AppOptimizeImplicitArgs f args idx startArgIdx stopIdx pInfo prevInApp :: xs =>
+  | .AppOptimizeImplicitArgs f args idx startArgIdx stopIdx pInfo prevInApp ::: xs =>
        -- optExpr corresponds to the optimized implicit argument referenced by idx.
        -- continuity with optimizing the next implicit argument.
-       return Sum.inl (.AppOptimizeImplicitArgs f (args.set! idx optExpr) (idx + 1) startArgIdx stopIdx pInfo prevInApp :: xs)
+       return Sum.inl (.AppOptimizeImplicitArgs f (args.set! idx optExpr) (idx + 1) startArgIdx stopIdx pInfo prevInApp ::: xs)
 
-  | .SpecializeWaitForArg f args index startIdx pInfo prevInApp :: xs =>
-       return Sum.inl (.SpecializeReady f (args.set! index optExpr) startIdx pInfo prevInApp :: xs)
+  | .SpecializeWaitForArg f args index startIdx pInfo prevInApp ::: xs =>
+       return Sum.inl (.SpecializeReady f (args.set! index optExpr) startIdx pInfo prevInApp ::: xs)
 
-  | .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp :: xs =>
+  | .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp ::: xs =>
        -- optExpr corresponds to the optimized explicit argument referenced by idx.
        -- continuity with optimizing the next explicit argument.
        -- Perform backward proof reconstruction (if necessary)
        let optExpr ← normProof idx args optExpr pInfo
-       return Sum.inl (.AppOptimizeExplicitArgs f (args.set! idx optExpr) (idx + 1) stopIdx pInfo mInfo prevInApp :: xs)
+       return Sum.inl (.AppOptimizeExplicitArgs f (args.set! idx optExpr) (idx + 1) stopIdx pInfo mInfo prevInApp ::: xs)
 
-  | .DiteChoiceWaitForCond f args pInfo prevInApp :: xs =>
+  | .DiteChoiceWaitForCond f args pInfo prevInApp ::: xs =>
        -- optExpr corresponds to the optimized Blaster.dite' conditional, i.e., referenced by index 1.
        -- When some r ← optimizeDiteChoice f (args.set! 1 optExpr)
        --  - continuity with optimizing `r`
@@ -225,24 +304,24 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
        -- set isAppArg to keep context for eventual constant match.
        setIsAppArg true
        if let some r ← optimizeDITEChoice f (args.set! 1 optExpr) then
-           return Sum.inl (.InitOptimizeExpr r :: xs)
+           return Sum.inl (.InitOptimizeExpr r ::: xs)
        else
-          return Sum.inl (.AppOptimizeExplicitArgs f (args.set! 1 optExpr) 2 args.size pInfo none prevInApp :: xs)
+          return Sum.inl (.AppOptimizeExplicitArgs f (args.set! 1 optExpr) 2 args.size pInfo none prevInApp ::: xs)
 
-  | .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp :: xs =>
+  | .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp ::: xs =>
        -- optExpr corresponds to the optimized match discriminator referenced by idx.
        -- continuity with optimizing the next discriminator
-       return Sum.inl (.MatchChoiceOptimizeDiscrs f (args.set! idx optExpr) pInfo (idx + 1) mInfo prevInApp :: xs)
+       return Sum.inl (.MatchChoiceOptimizeDiscrs f (args.set! idx optExpr) pInfo (idx + 1) mInfo prevInApp ::: xs)
 
-  | .LambdaWaitForType n bi body :: xs =>
+  | .LambdaWaitForType n bi body ::: xs =>
        -- optExpr corresponds to optimized lambda type
        withLocalDecl' n bi optExpr fun x => do
          let bodyOpt := .InitOptimizeExpr (← instantiateShared1 body x)
          -- NOTE: keeping track of next ctxId to clean-up rewrite cache
          let nextCtxId := (← get).optEnv.options.nextCtxId
-         return Sum.inl (bodyOpt :: .LambdaWaitForBody x none false nextCtxId :: xs)
+         return Sum.inl (bodyOpt ::: .LambdaWaitForBody x none false nextCtxId ::: xs)
 
-  | .LambdaWaitForBody x hctx inDite startCtxId :: xs =>
+  | .LambdaWaitForBody x hctx inDite startCtxId ::: xs =>
        -- optExpr corresponds to optimized lambda body
        -- continuity with optimizing next expression
        let e ← mkLambdaFVarExpr x optExpr
@@ -255,20 +334,20 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
          freeRewriteCacheRange startCtxId (← get).optEnv.options.nextCtxId
          stackContinuity xs e
 
-  | .MatchRhsLambdaWaitForType n bi body :: xs =>
+  | .MatchRhsLambdaWaitForType n bi body ::: xs =>
         -- optExpr corresponds to optimized lambda type
         -- continuity with optimizing body
         withLocalDecl' n bi optExpr fun x => do
           let bodyOpt := .MatchRhsLambdaNext (← instantiateShared1 body x)
-          return Sum.inl (bodyOpt :: .MatchRhsLambdaWaitForBody x :: xs)
+          return Sum.inl (bodyOpt ::: .MatchRhsLambdaWaitForBody x ::: xs)
 
-  | .MatchRhsLambdaWaitForBody x :: xs =>
+  | .MatchRhsLambdaWaitForBody x ::: xs =>
         -- optExpr corresponds to optimized lambda body
         -- continuity with optimizing next expression
         let e ← mkLambdaFVarExpr x optExpr
         stackContinuity xs e
 
-  | .MatchAltWaitForExpr params hctx idx matchInst :: xs =>
+  | .MatchAltWaitForExpr params hctx idx matchInst ::: xs =>
        -- optExpr corresponds to the optimized match rhs
        -- continuity with optimizing next expression
        let e ← mkLambdaFVarsExpr params optExpr
@@ -276,27 +355,27 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
        resetChoiceContext hctx params matchInst idx
        stackContinuity xs e
 
-  | .MatchLhsForallWaitForBody x :: xs =>
+  | .MatchLhsForallWaitForBody x ::: xs =>
        -- optExpr corresponds to the optimized lhs forall body
        -- continuity with optimizing next expression
        let e ← mkForallFVarExpr x optExpr
        stackContinuity xs e
 
-  | .LetWaitForValue body :: xs =>
+  | .LetWaitForValue body ::: xs =>
        -- optExpr corresponds to the optimized let value
        -- continuity with optimizing body
-       return Sum.inl (.InitOptimizeExpr (← instantiateShared1 body optExpr) :: xs)
+       return Sum.inl (.InitOptimizeExpr (← instantiateShared1 body optExpr) ::: xs)
 
-  | .MDataRecCallWaitForExpr d :: xs =>
+  | .MDataRecCallWaitForExpr d ::: xs =>
        -- optExpr corresponds to the annotated rec call that is optimized when `normalizeFunCall` is set to false
        -- continuity with optimizing next expression
        setNormalizeFunCall true
        stackContinuity xs (← mkMDataExpr d optExpr)
 
-  | .ProjWaitForExpr n idx :: xs =>
+  | .ProjWaitForExpr n idx ::: xs =>
       -- optExpr corresponds to optimized projection structure
       if let some re ← optimizeProjection? n idx optExpr then
-         return Sum.inl (.InitOptimizeExpr re :: xs)
+         return Sum.inl (.InitOptimizeExpr re ::: xs)
       else
         -- continuity with optimizing next expression
         stackContinuity xs (← mkProjExpr n idx optExpr)
@@ -371,21 +450,21 @@ def stackContinuity (stack : List OptimizeStack) (optExpr : Expr) (skipCache := 
       normProof idx args optArg pInfo
 
 @[always_inline, inline]
-def mkOptimizeContinuity (e : Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+def mkOptimizeContinuity (e : Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
   if ← isRestart then
     resetRestart
-    return Sum.inl (.InitOptimizeExpr e :: stack)
+    return Sum.inl (.InitOptimizeExpr e ::: stack)
   else stackContinuity stack e
 
 /-- Apply simplification/normalization rules on Blaster.dite' expressions.
     Assume that f = Expr.const ``Blaster.dite'.
 -/
 @[always_inline, inline]
-def optimizeIfThenElse? (f : Expr) (args : Array Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+def optimizeIfThenElse? (f : Expr) (args : Array Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
    mkOptimizeContinuity (← optimizeDITE f args) stack
 
 @[always_inline, inline]
-def isInOptimizeEnvCache (a : Expr) (stack : List OptimizeStack) (mvarDecls : Option MVarIdDecls) : TranslateEnvT (Sum (List OptimizeStack) OptimizeContinuity) := do
+def isInOptimizeEnvCache (a : Expr) (stack : OptimizeStack) (mvarDecls : Option MVarIdDecls) : TranslateEnvT (Sum (OptimizeStack) OptimizeContinuity) := do
   let env ← get
   -- NOTE: Always consider global context when `a` does not contain any FVar/MVar
   let isGlobal := !(hasVar a) || isGlobalContext env
@@ -397,10 +476,10 @@ def isInOptimizeEnvCache (a : Expr) (stack : List OptimizeStack) (mvarDecls : Op
       Sum.inr <$> stackContinuity stack cached
     else
       profileEnter a false
-      return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
+      return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls ::: stack)
   else
     profileEnter a true
-    return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls :: stack)
+    return Sum.inl (.InitOptimizeReturn a isGlobal mvarDecls ::: stack)
 
   where
     hasVar (e : Expr) : Bool := e.hasFVar || e.hasMVar

--- a/Blaster/Optimize/Rewriting/FunPropagation.lean
+++ b/Blaster/Optimize/Rewriting/FunPropagation.lean
@@ -21,7 +21,7 @@ namespace Blaster.Optimize
          | p₍ₘ₎₍₁₎, ..., p₍ₘ₎₍ₙ₎ => tₘ x₁ ... xₙ
 -/
 def normChoiceApplication?
-  (f : Expr) (args : Array Expr) (prevInApp : Bool) : TranslateEnvT (Option OptimizeStack) := do
+  (f : Expr) (args : Array Expr) (prevInApp : Bool) : TranslateEnvT (Option OptimizeFrame) := do
     if let some r ← normDIteApp? f args then return r
     normMatchApp? f args
 
@@ -38,7 +38,7 @@ def normChoiceApplication?
          let auxApp ← mkAppRangeExpr (← mkAppExpr ite_e (← mkBVarExpr 0)) 4 args.size args
          mkLambdaExpr (← Term.mkFreshBinderName) BinderInfo.default ite_cond auxApp
 
-    normDIteApp? (f : Expr) (args : Array Expr) : TranslateEnvT (Option OptimizeStack) := do
+    normDIteApp? (f : Expr) (args : Array Expr) : TranslateEnvT (Option OptimizeFrame) := do
       let Expr.const ``Blaster.dite' _ := f | return none
       if args.size ≤ 4 then return none
       let e1 ← mkAppInDIteExpr args args[1]! args[2]!
@@ -55,7 +55,7 @@ def normChoiceApplication?
     mkAppInRhs (args : Array Expr) (beginIdx endIdx : Nat) (nbParams : Nat) (rhs : Expr) : TranslateEnvT Expr := do
       applyOnLambdaBoundedBody rhs nbParams (fun body => mkAppRangeExpr body beginIdx endIdx args)
 
-    normMatchApp? (f : Expr) (args : Array Expr) : TranslateEnvT (Option OptimizeStack) := do
+    normMatchApp? (f : Expr) (args : Array Expr) : TranslateEnvT (Option OptimizeFrame) := do
       let some argInfo ← isMatcher? f | return none
       if args.size ≤ argInfo.arity then return none
       let idxType := argInfo.getFirstDiscrPos - 1
@@ -111,7 +111,7 @@ def normChoiceApplication?
 -/
 def funPropagation?
   (cf : Expr) (cargs : Array Expr) (prevInApp : Bool)
-  (reorderArgs := false) (resolveArgs := false) : TranslateEnvT (Option OptimizeStack) := do
+  (reorderArgs := false) (resolveArgs := false) : TranslateEnvT (Option OptimizeFrame) := do
   match cf with
   | Expr.const n _ =>
       if n == ``Blaster.dite' then return none
@@ -136,7 +136,7 @@ def funPropagation?
              | _ => go (idx + 1) stop
       return go 0 args.size
 
-    loop (idx : Nat) (stop : Nat) (args : Array Expr) : TranslateEnvT (Option OptimizeStack) := do
+    loop (idx : Nat) (stop : Nat) (args : Array Expr) : TranslateEnvT (Option OptimizeFrame) := do
       if idx ≥ stop then return none
       else if let some re ← diteCstProp? cf args idx then
         profileEvent (Name.str cf.constName! "choice_ite")
@@ -176,7 +176,7 @@ def funPropagation?
 
     /-- Implements dite over ctor rule -/
     @[always_inline, inline]
-    diteCstProp? (f : Expr) (args : Array Expr) (idxArg : Nat) : TranslateEnvT (Option OptimizeStack) := do
+    diteCstProp? (f : Expr) (args : Array Expr) (idxArg : Nat) : TranslateEnvT (Option OptimizeFrame) := do
       -- NOTE: can't be an applied dite' function (e.g., applied to more than 4 arguments)
       if let some (_psort, pcond, e1, e2) := dite'? args[idxArg]! then
         let pInfo ← getFunEnvInfo f
@@ -206,7 +206,7 @@ def funPropagation?
 
     /-- Implements match over ctor rule -/
     @[always_inline, inline]
-    matchCstProp? (f : Expr) (args : Array Expr) (idxArg : Nat) : TranslateEnvT (Option OptimizeStack) := do
+    matchCstProp? (f : Expr) (args : Array Expr) (idxArg : Nat) : TranslateEnvT (Option OptimizeFrame) := do
       if let some argInfo ← isMatcher? args[idxArg]!.getAppFn then
         -- NOTE: can't be an applied match (e.g., applied to more argInfo.mInfo.arity arguments)
         let pargs := args[idxArg]!.getAppArgs

--- a/Blaster/Optimize/Rewriting/OptimizeApp.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeApp.lean
@@ -142,7 +142,7 @@ def optimizeAppAux (f : Expr) (args : Array Expr) : TranslateEnvT Expr := do
 -/
 def finalizeRecApp
      (uf rf : Expr) (uargs : Array Expr)
-     (params : ImplicitParameters) (xs : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+     (params : ImplicitParameters) (xs : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
      if params.isEmpty then
        return ← stackContinuity xs rf
      if exprEq uf rf then
@@ -170,7 +170,7 @@ def finalizeRecApp
          -- trace[Optimize.recFun.app] "polymorphic equivalent case {reprStr auxApp.getAppFn'} {reprStr auxApp.getAppArgs}"
          isEquivOpaqueFun auxApp.getAppFn auxApp xs
  where
-   isEquivOpaqueFun (f : Expr) (e : Expr) (xs : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+   isEquivOpaqueFun (f : Expr) (e : Expr) (xs : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
      let isOpaqueRecFun (f : Expr) : Bool :=
        if exprEq uf f then false
        else
@@ -178,7 +178,7 @@ def finalizeRecApp
          | Expr.const n _ => opaqueFuns.contains n || optRecFuns.contains n
          | _ => false
      if isOpaqueRecFun f then
-       return Sum.inl (.InitOptimizeExpr e :: xs)
+       return Sum.inl (.InitOptimizeExpr e ::: xs)
      else stackContinuity xs e
 
 /-- Given application `f x₁ ... xₙ` perform the following:
@@ -197,7 +197,7 @@ def finalizeRecApp
     Assumes that an entry exists for each opaque recursive function in `recFunMap` before
     optimization is performed (see function `cacheOpaqueRecFun`).
 -/
-def normRecFun (uf : Expr) (uargs : Array Expr) (appExpr : Expr) (xs : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+def normRecFun (uf : Expr) (uargs : Array Expr) (appExpr : Expr) (xs : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
  let Expr.const n _ := uf | return (← stackContinuity xs appExpr)
  let isOpaqueRec ← isOpaqueRecFun uf uargs
  if (← isRecursiveFun n) || isOpaqueRec
@@ -227,7 +227,7 @@ def normRecFun (uf : Expr) (uargs : Array Expr) (appExpr : Expr) (xs : List Opti
      -- optimize recursive fun definition and store
      -- NOTE: keeping track of next ctxId to generate for clean-up
      let nextCtxId := (← get).optEnv.options.nextCtxId
-     return Sum.inl (.InitOptimizeExpr fdef :: .RecFunDefWaitForStorage uargs instApp subsInst params nextCtxId :: xs)
+     return Sum.inl (.InitOptimizeExpr fdef ::: .RecFunDefWaitForStorage uargs instApp subsInst params nextCtxId ::: xs)
  else stackContinuity xs appExpr -- proceed with continuity
 
  where
@@ -282,23 +282,23 @@ def normRecFun (uf : Expr) (uargs : Array Expr) (appExpr : Expr) (xs : List Opti
     returns `true`.
 -/
 def optimizeApp
-  (f : Expr) (args: Array Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+  (f : Expr) (args: Array Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
   let e ← optimizeAppAux f args
   if ← isRestart then
     resetRestart
-    return Sum.inl (.InitOptimizeExpr e :: stack)
+    return Sum.inl (.InitOptimizeExpr e ::: stack)
   else
     if e.isApp then
        let (f', args') := getAppFnWithArgs e
-       if let some r ← funPropagation? f' args' (← isAppArg) then return Sum.inl (r :: stack)
+       if let some r ← funPropagation? f' args' (← isAppArg) then return Sum.inl (r ::: stack)
        -- try to reduce app if all params are constructors
-       if let some be ← reduceApp? f' args' then return Sum.inl (.InitOptimizeExpr be.betaReduced be.prevMVarIdDecls :: stack)
+       if let some be ← reduceApp? f' args' then return Sum.inl (.InitOptimizeExpr be.betaReduced be.prevMVarIdDecls ::: stack)
        normRecFun f' args' e stack
     else stackContinuity stack e -- proceed with continuity
 
   where
     @[always_inline, inline]
-    isFunPropagation? (e : Expr) : TranslateEnvT (Option OptimizeStack) := do
+    isFunPropagation? (e : Expr) : TranslateEnvT (Option OptimizeFrame) := do
       if e.isApp then
         let (f', args') := getAppFnWithArgs e
         funPropagation? f' args' (← isAppArg)

--- a/Blaster/Optimize/Rewriting/OptimizeConst.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeConst.lean
@@ -104,7 +104,7 @@ partial def normLevels (xs : List Level) : TranslateEnvT (List Level) := do
          - Otherwise
              - return `mkExpr e`
 -/
-def normConst (e : Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+def normConst (e : Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
   match e with
   | Expr.const n l =>
       match n with
@@ -238,7 +238,7 @@ def normConst (e : Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeCo
         if (← isNotFoldable e #[]) then return none
         -- non recursive function case
         if let some fbody ← getFunBody e then
-          return (some $ Sum.inl $ .InitOptimizeExpr fbody :: stack)
+          return (some $ Sum.inl $ .InitOptimizeExpr fbody ::: stack)
         else return none
 
 /-- Given a ctor application `C x₁ ... xₙ`,
@@ -266,13 +266,13 @@ def normPartialCtorApp? (f : Expr) (args : Array Expr) : TranslateEnvT (Option E
          - Otherwise:
              - proceed with stack continuity
 -/
-def optimizeConstApp (f : Expr) (args : Array Expr) (stack : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
-  if let some r ← normPartialCtorApp? f args then return Sum.inl (.InitOptimizeExpr r :: stack)
-  if let some r ← funPropagation? f args (← isAppArg) then return Sum.inl (r :: stack)
+def optimizeConstApp (f : Expr) (args : Array Expr) (stack : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+  if let some r ← normPartialCtorApp? f args then return Sum.inl (.InitOptimizeExpr r ::: stack)
+  if let some r ← funPropagation? f args (← isAppArg) then return Sum.inl (r ::: stack)
   let e ← applyConstAppRules f args
   if ← isRestart then
     resetRestart
-    return Sum.inl (.InitOptimizeExpr e :: stack)
+    return Sum.inl (.InitOptimizeExpr e ::: stack)
   else stackContinuity stack e
 
   where

--- a/Blaster/Optimize/Rewriting/OptimizeMatch.lean
+++ b/Blaster/Optimize/Rewriting/OptimizeMatch.lean
@@ -357,13 +357,13 @@ def reduceMatch? (args : Array Expr) (mInfo : MatchInfo) (resolveArgs := false) 
 -/
 def constMatchPropagation?
   (cm : Expr) (cargs : Array Expr) (mInfo : MatchInfo)
-  (prevInApp : Bool) (resolveArgs := false) : TranslateEnvT (Option OptimizeStack) := do
+  (prevInApp : Bool) (resolveArgs := false) : TranslateEnvT (Option OptimizeFrame) := do
   if !(← allDiscrsAreCstMatch mInfo.getFirstDiscrPos mInfo.getFirstAltPos)
   then return none
   else loop mInfo.getFirstDiscrPos mInfo.getFirstAltPos
 
   where
-    loop (idx : Nat) (stop : Nat) : TranslateEnvT (Option OptimizeStack) := do
+    loop (idx : Nat) (stop : Nat) : TranslateEnvT (Option OptimizeFrame) := do
       if idx ≥ stop then return none
       else if let some r ← isDiteArg idx then return r
       else if let some r ← isMatchArg idx then return r
@@ -393,7 +393,7 @@ def constMatchPropagation?
       | _ => throwEnvError "pushMatchInDIteExpr: lambda term expected !!!"
 
     @[always_inline, inline]
-    isDiteArg (idx : Nat) : TranslateEnvT (Option OptimizeStack) := do
+    isDiteArg (idx : Nat) : TranslateEnvT (Option OptimizeFrame) := do
       if let some (_psort, pcond, e1, e2) := dite'? cargs[idx]! then
         -- erase context
         eraseMatchRhsRewriteCache mInfo
@@ -418,7 +418,7 @@ def constMatchPropagation?
       else return none
 
     @[always_inline, inline]
-    isMatchArg (idx : Nat) : TranslateEnvT (Option OptimizeStack) := do
+    isMatchArg (idx : Nat) : TranslateEnvT (Option OptimizeFrame) := do
       if let some argInfo ← isMatcher? cargs[idx]!.getAppFn then
         -- erase context
         eraseMatchRhsRewriteCache mInfo
@@ -451,7 +451,7 @@ def constMatchPropagation?
 @[always_inline, inline]
 def matchReduction?
   (f : Expr) (args : Array Expr) (mInfo : MatchInfo) (prevInApp : Bool)
-  (matchToIte := false) (resolveArgs := false) : TranslateEnvT (Option OptimizeStack) := do
+  (matchToIte := false) (resolveArgs := false) : TranslateEnvT (Option OptimizeFrame) := do
     -- try match reduction first
     if let some r ← reduceMatch? args mInfo resolveArgs then
       return some (.InitOptimizeExpr r.betaReduced r.prevMVarIdDecls)
@@ -711,7 +711,7 @@ def updateEqMap
 @[always_inline, inline]
 partial def optimizeMatchAlt
   (args : Array Expr) (mInfo : MatchInfo) (altIdx : Nat) (rhs : Expr)
-  (stack : List OptimizeStack) : TranslateEnvT (List OptimizeStack) := do
+  (stack : OptimizeStack) : TranslateEnvT (OptimizeStack) := do
   let currIdx := (altIdx - mInfo.getFirstAltPos).toUSize
   -- NOTE: We need to consider the generic type for context reuse.
   -- Otherwise, we might instantiate the rhs
@@ -720,7 +720,7 @@ partial def optimizeMatchAlt
   | some reuse =>
        setAndCommitCtx reuse.scope
        let body ← betaLambdaShared rhs reuse.fvars
-       return .InitOptimizeExpr body :: .MatchAltWaitForExpr reuse.fvars (some reuse.scope) currIdx matchInst :: stack
+       return .InitOptimizeExpr body ::: .MatchAltWaitForExpr reuse.fvars (some reuse.scope) currIdx matchInst ::: stack
   | none =>
        let alts ← getMatchAlts args mInfo
        let ⟨_, ⟨_, _, _, _, _, _, _, _, _,_, ⟨_, _, _, _, _, nextCtxId, _, _, _⟩, _, _, _⟩⟩ ← get
@@ -730,7 +730,7 @@ partial def optimizeMatchAlt
          let body ← betaLambdaShared rhs xs
          let updatedEqCtx ← updateEqMap mInfo lhs args nextCtxId false
          let mscope ← if updatedMCtx || updatedEqCtx then some <$> newCtx else pure none
-         return .InitOptimizeExpr body :: .MatchAltWaitForExpr xs mscope currIdx matchInst :: stack
+         return .InitOptimizeExpr body ::: .MatchAltWaitForExpr xs mscope currIdx matchInst ::: stack
 
   where
    onlyOnePattern (lhs : Array Expr) (idx : Nat) (onlyOne : Bool) : TranslateEnvT Bool := do
@@ -910,12 +910,12 @@ def structEqMatch
 @[always_inline, inline]
 partial def optimizeMatch
   (f : Expr) (args : Array Expr) (mInfo : MatchInfo)
-  (xs : List OptimizeStack) : TranslateEnvT OptimizeContinuity := do
+  (xs : OptimizeStack) : TranslateEnvT OptimizeContinuity := do
  -- check for match elimination rules first
  if let some r ← elimMatch? mInfo args then
    match r with
    | Sum.inl e => return (← stackContinuity xs e)
-   | Sum.inr b => return Sum.inl (.InitOptimizeExpr b :: xs)
+   | Sum.inr b => return Sum.inl (.InitOptimizeExpr b ::: xs)
  -- check for match equivalence afterwards
  let (f', args') ← structEqMatch f args mInfo
  let e ← mkAppNExpr f' args'

--- a/Tests/Optimize.lean
+++ b/Tests/Optimize.lean
@@ -18,3 +18,5 @@ import Tests.Optimize.OptimizeUnfold
 
 import Tests.Optimize.Profile
 import Tests.Optimize.Specialize
+
+import Tests.Optimize.StackRepresentation

--- a/Tests/Optimize/StackRepresentation.lean
+++ b/Tests/Optimize/StackRepresentation.lean
@@ -1,0 +1,58 @@
+import Blaster.Optimize.OptimizeStack
+
+open Blaster.Optimize
+
+namespace Tests.StackRepresentation
+
+-- These conversions are only used to check that the fused representation
+-- preserves every frame payload and the complete continuation order.
+def toList : OptimizeStack → List OptimizeFrame
+ | .nil => []
+ | .InitOptimizeExpr e mvarDecls tail => .InitOptimizeExpr e mvarDecls :: toList tail
+ | .InitOptimizeReturn e isGlobal mvarDecls tail => .InitOptimizeReturn e isGlobal mvarDecls :: toList tail
+ | .RecFunDefWaitForStorage args instApp subsInts params startCtxId tail => .RecFunDefWaitForStorage args instApp subsInts params startCtxId :: toList tail
+ | .RecFunDefStorage args instApp subsInts params optBody startCtxId tail => .RecFunDefStorage args instApp subsInts params optBody startCtxId :: toList tail
+ | .ForallWaitForType n bi body tail => .ForallWaitForType n bi body :: toList tail
+ | .ForallWaitForBody x t hctx isProp tail => .ForallWaitForBody x t hctx isProp :: toList tail
+ | .AppWaitForConst args tail => .AppWaitForConst args :: toList tail
+ | .OptimizeMatchInfoWaitForInst f args startArgIdx pInfo mInfo tail => .OptimizeMatchInfoWaitForInst f args startArgIdx pInfo mInfo :: toList tail
+ | .AppOptimizeImplicitArgs f args idx startArgIdx stopIdx pInfo prevInApp tail => .AppOptimizeImplicitArgs f args idx startArgIdx stopIdx pInfo prevInApp :: toList tail
+ | .SpecializeWaitForArg f args argIdx startIdx pInfo prevInApp tail => .SpecializeWaitForArg f args argIdx startIdx pInfo prevInApp :: toList tail
+ | .SpecializeReady f args startIdx pInfo prevInApp tail => .SpecializeReady f args startIdx pInfo prevInApp :: toList tail
+ | .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp tail => .AppOptimizeExplicitArgs f args idx stopIdx pInfo mInfo prevInApp :: toList tail
+ | .InitNonFunOptimizeArgs f args idx stopIdx tail => .InitNonFunOptimizeArgs f args idx stopIdx :: toList tail
+ | .NonFunOptimizeArgs f args idx stopIdx prevInCtor tail => .NonFunOptimizeArgs f args idx stopIdx prevInCtor :: toList tail
+ | .DiteChoiceWaitForCond f args pInfo prevInApp tail => .DiteChoiceWaitForCond f args pInfo prevInApp :: toList tail
+ | .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp tail => .MatchChoiceOptimizeDiscrs f args pInfo idx mInfo prevInApp :: toList tail
+ | .LambdaWaitForType n bi body tail => .LambdaWaitForType n bi body :: toList tail
+ | .LambdaWaitForBody x hctx inDite startCtxId tail => .LambdaWaitForBody x hctx inDite startCtxId :: toList tail
+ | .MatchRhsLambdaWaitForType n bi body tail => .MatchRhsLambdaWaitForType n bi body :: toList tail
+ | .MatchRhsLambdaNext e tail => .MatchRhsLambdaNext e :: toList tail
+ | .MatchRhsLambdaWaitForBody x tail => .MatchRhsLambdaWaitForBody x :: toList tail
+ | .MatchLhsSkipForallType e tail => .MatchLhsSkipForallType e :: toList tail
+ | .MatchLhsForallWaitForBody e tail => .MatchLhsForallWaitForBody e :: toList tail
+ | .MatchAltWaitForExpr params hctx idx matchInst tail => .MatchAltWaitForExpr params hctx idx matchInst :: toList tail
+ | .LetWaitForValue body tail => .LetWaitForValue body :: toList tail
+ | .MDataRecCallWaitForExpr data tail => .MDataRecCallWaitForExpr data :: toList tail
+ | .ProjWaitForExpr n idx tail => .ProjWaitForExpr n idx :: toList tail
+
+def ofList : List OptimizeFrame → OptimizeStack
+ | [] => .nil
+ | frame :: tail => frame ::: ofList tail
+
+theorem toList_push (frame : OptimizeFrame) (tail : OptimizeStack) :
+    toList (frame ::: tail) = frame :: toList tail := by
+  cases frame <;> rfl
+
+theorem toList_ofList (frames : List OptimizeFrame) : toList (ofList frames) = frames := by
+  induction frames with
+  | nil => rfl
+  | cons frame tail ih => simp only [ofList, toList_push, ih]
+
+theorem ofList_toList (stack : OptimizeStack) : ofList (toList stack) = stack := by
+  induction stack <;> simp_all only [toList, ofList, OptimizeStack.push]
+
+#print axioms toList_ofList
+#print axioms ofList_toList
+
+end Tests.StackRepresentation


### PR DESCRIPTION
Repeated symbolic normalization allocates a separate frame and list cell for each optimizer stack entry. Store the frame payload and continuation tail in one constructor, so hot pushes and pops handle one object. This preserves the rewrite actions, evaluation order, and all frame payloads. Rewrites producing a single next action still return an `OptimizeFrame`; inline `push` constructs the fused stack.

Stacked on #247. The stack change applies to the core optimizer and needs no contract-specific flag.

Three serial, unprofiled pairs on fully symbolic Cardano inputs, at the original fuel 1800/9000:

| Median | SellNFT reference → candidate | Governance reference → candidate |
| --- | ---: | ---: |
| Optimizer | 18.236 → 17.637 s (**3.3%**) | 20.947 → 20.067 s (**4.2%**) |
| Whole preparation module | 20.458 → 19.941 s | 23.267 → 22.136 s |
| Paired preparation + proofs | 57.506 → 57.037 s | 27.694 → 26.566 s |

Both SellNFT arms enable the two certified search workers from #247; both Governance arms leave those workers disabled. Expression counts and prepared module sizes are unchanged. SellNFT retains its existing solver timeout, two Valid checks, and two Expected Falsified controls, including acceptance; Governance retains all four Valid checks. SellNFT totals include the 30-second timeout and are not time to successful completion of all proofs. Pair 1 has a small SellNFT total-wall regression. Neither contract reaches sub-10-second preparation yet.

Validation: native full Blaster suite passed **732 jobs**; Cardano dependencies and **37 search controls** passed **371 jobs**. New kernel-checked round-trip theorems cover all 27 frame shapes and arbitrary stack depth using only `propext`; these establish representation preservation, not a formal correctness proof of the entire optimizer. A source-only installer recreation matched the built workspace byte for byte in all five repositories and six generated control/source-certificate fixtures. PR #160 was checked and retains the original list-of-frames representation.

Raw timings, pins, hashes, selected log excerpts, and reproduction details: `Benchmarks/cardano/results/fused-stack-2026-09-09/README.md`. Tested code is `da7a50e1`; later commits add measurement documentation only.
